### PR TITLE
lock v0.1 product contract

### DIFF
--- a/docs/v0.1-product-contract.md
+++ b/docs/v0.1-product-contract.md
@@ -1,0 +1,174 @@
+# CopyLasso v0.1 Product Contract
+
+- **Status:** Approved scope for the first public release
+- **Approved:** July 9, 2026
+- **Implementation status:** Pre-development
+
+This document defines CopyLasso's user-visible v0.1 promises. It is the public source of truth for product scope, supported systems, privacy guarantees, known boundaries, and release completion. It does not describe the internal development workflow.
+
+## Product Identity
+
+- Product name: **CopyLasso**
+- GitHub repository: `bennetthilberg/copylasso`
+- GitHub owner: `bennetthilberg`
+- Copyright holder: Bennett Hilberg
+- License: MIT
+- Production bundle identifier: `io.github.bennetthilberg.copylasso`
+- Debug bundle identifier: `io.github.bennetthilberg.copylasso.debug`
+- Distribution: signed and notarized DMG from GitHub Releases
+
+CopyLasso is free, open-source, private, offline-capable, and local-first. Public descriptions, documentation, release notes, and marketing must present the product on those merits without naming proprietary competitors or implying an affiliation with another product.
+
+The product, implementation, icon, interface, documentation, and copy must be original. CopyLasso must not reuse proprietary source code, private implementation details, binary resources, branding, icons, screenshots, website copy, or other protected assets.
+
+## Core User Story
+
+A user presses CopyLasso's global shortcut, drags a rectangle around visible text anywhere on a Mac screen, and receives recognized plain text in the clipboard without uploading or retaining the screenshot.
+
+CopyLasso recognizes captured screen pixels rather than relying on selectable text or application-specific data. The pixels may come from a native app, browser, PDF viewer, image, paused video, game, virtual machine, remote desktop, system interface, desktop wallpaper, or photograph displayed on screen. If the selected pixels look remotely like text, CopyLasso should attempt recognition, subject to macOS capture restrictions and the quality limits below.
+
+## Supported Environment
+
+- Native macOS application written in Swift 6.
+- Built with the latest stable full Xcode release available to the maintainer, with exact local and CI versions recorded for reproducibility.
+- macOS 14.0 or newer.
+- Universal 2 application supporting `arm64` and `x86_64`.
+- Apple Silicon is the primary manually tested platform.
+- Intel builds and automated tests are release-blocking while Intel remains supported.
+- SwiftUI is used for the app shell and Settings; AppKit may be used where selection-window behavior requires it.
+- ScreenCaptureKit provides screen pixels.
+- Apple Vision performs OCR entirely on device.
+- App Sandbox and Hardened Runtime remain enabled unless a documented, reproducible platform blocker requires a deliberate scope amendment.
+
+Supporting macOS 13 or earlier is outside v0.1.
+
+## Application Experience
+
+### Availability and invocation
+
+- CopyLasso runs as a menu-bar utility without a normal Dock icon.
+- The primary command is the configurable global shortcut.
+- The initial shortcut is `Control-Shift-Command-2` (`⌃⇧⌘2`).
+- Onboarding shows the initial shortcut explicitly and lets the user confirm, replace, or clear it.
+- The configured shortcut persists across relaunches, reboots, and reinstallations while the preference domain remains present.
+- The menu provides Capture Text, Settings, About, and Quit commands.
+- Capture Text in the menu invokes the same capture workflow as the global shortcut.
+- Clearing the shortcut leaves the menu command available.
+- Updates are downloaded and installed manually in v0.1.
+
+### Launch at Login
+
+- Onboarding presents a clearly labeled Launch at Login option enabled by default.
+- CopyLasso applies the displayed option only after the user confirms onboarding; it does not register itself silently beforehand.
+- Launch at Login remains configurable in Settings.
+- When enabled, CopyLasso starts after login so the stored shortcut is available without a manual launch.
+- When disabled, CopyLasso does not start automatically.
+- Registration failures must be reported accurately and must not leave Settings claiming that an unavailable login item is enabled.
+
+### Onboarding and settings
+
+- Onboarding and Settings use restrained, native macOS presentation.
+- The first-run experience explains that OCR is local and that Screen Recording permission is needed to capture selected pixels.
+- Onboarding does not request Screen Recording permission automatically.
+- Completed onboarding remains complete across ordinary relaunches and app reinstallations while preferences remain.
+- A future release may show a narrowly scoped setup step when a new permission or migration actually requires it.
+- A documented complete-uninstall procedure unregisters Launch at Login and removes CopyLasso's preferences, app-owned sandbox data, and Screen Recording permission entry.
+
+## Capture Contract
+
+- The user may begin a rectangular selection on any connected display.
+- A v0.1 selection remains on the display where the drag begins and cannot span displays.
+- Moving to a display edge clamps the selection rather than extending it onto another display.
+- Displays unrelated to the current selection are not dimmed.
+- The pointer and selection bounds remain visible while dragging.
+- Pressing Escape cancels selection without changing the clipboard.
+- Tiny or zero-area selections cancel safely without changing the clipboard.
+- Pixels are captured on mouse-up, after CopyLasso's selection overlay has been removed or excluded.
+- CopyLasso's overlay, border, and pointer must not appear in the captured image.
+- Capture should work over ordinary full-screen apps and across macOS Spaces where supported by public platform behavior.
+- Protected or DRM-restricted content may be unavailable or appear blank because of macOS restrictions; CopyLasso must report or document that limitation without claiming to bypass it.
+
+CopyLasso requests Screen Recording permission only when the user first attempts capture. Denial, revocation, and unavailable permission states must provide understandable recovery guidance and a path to the relevant System Settings pane.
+
+CopyLasso does not need to identify which application produced the selected pixels and must not depend on a browser DOM, PDF text layer, application plug-in, or Accessibility text extraction.
+
+## OCR Contract
+
+The firm v0.1 quality requirement is ordinary, approximately horizontal, single-column English text.
+
+- Text does not need to be selectable or digitally encoded as text.
+- Rasterized text and English text inside an on-screen photograph are valid inputs.
+- CopyLasso attempts recognition for difficult, stylized, low-contrast, photographic, or otherwise imperfect English text without guaranteeing accuracy for every input.
+- OCR quality depends on source resolution, contrast, orientation, and whether macOS permits capture.
+- Recognized observations are assembled into sensible top-to-bottom, left-to-right plain text for ordinary single-column content.
+- Multiple columns and complex layouts may produce imperfect ordering, but formatting must remain deterministic and must not crash, duplicate observations, or invent text not returned by Vision.
+- A genuine no-text result is distinct from cancellation, permission denial, or an internal failure.
+
+Non-English recognition, automatic language detection, manual recognition-language settings, and guaranteed recognition of handwriting, vertical text, curved text, or heavily stylized text are outside v0.1.
+
+## Clipboard and Feedback Contract
+
+- Successful nonempty recognition replaces the general clipboard with plain text.
+- Success produces a brief, nonactivating HUD with a short, truncated preview of the copied text and a temporary menu-bar state change.
+- The HUD never steals focus from the previously active application.
+- No sound plays by default.
+- Cancellation, no text, permission denial, capture failure, OCR failure, formatting failure, and internal errors leave the existing clipboard unchanged.
+- Feedback disappears automatically and CopyLasso returns to its idle state.
+
+## Privacy and Data Handling
+
+- Screen images and recognized text are processed locally and in memory.
+- Core functionality works with networking disabled.
+- No screenshot, OCR, or clipboard history is retained.
+- Captured images and recognized strings must be released as soon as the active operation no longer needs them.
+- Screenshots, recognized text, clipboard text, and HUD preview text must not appear in logs, crash breadcrumbs, preferences, caches, temporary files, analytics, or telemetry.
+- CopyLasso has no accounts, synchronization, cloud OCR, analytics, or telemetry in v0.1.
+- The core workflow requires Screen Recording as its only macOS privacy permission. The global shortcut must not require Accessibility or Input Monitoring permission.
+- The app stores only ordinary preferences needed for onboarding, shortcut configuration, Launch at Login presentation, and settings behavior.
+
+## Reliability and Accessibility
+
+- CopyLasso must preserve the user's frontmost application throughout shortcut capture, selection, OCR, clipboard output, and success feedback.
+- Repeated shortcut presses while capture is active must not create overlapping workflows.
+- Cancellation and failure at every pipeline stage must release overlays, images, callbacks, and transient text and return the app to a usable state.
+- The app must tolerate display changes, sleep and wake, lock and unlock, permission changes, and quitting during selection without requiring a force quit.
+- Native controls must be keyboard accessible and VoiceOver labeled when introduced.
+- Onboarding, Settings, selection, permission recovery, errors, and feedback must remain understandable in supported appearance and accessibility configurations.
+
+## Explicit v0.1 Non-Goals
+
+- Cross-display drag selections.
+- Screenshot, OCR, or clipboard history.
+- QR-code or barcode recognition.
+- Text-to-speech.
+- Translation.
+- Rich-text, Markdown, table, or layout reconstruction.
+- File import, drag-and-drop image OCR, or camera OCR.
+- Manual recognition-language settings.
+- Guaranteed recognition of non-English, handwritten, vertical, curved, or heavily stylized text.
+- Automatic updates.
+- Mac App Store distribution.
+- Homebrew Cask publication.
+- Cloud OCR, accounts, synchronization, analytics, or telemetry.
+- Browser extensions, application plug-ins, or app-specific integrations.
+- Reading text through a browser DOM, PDF text layer, or macOS Accessibility tree instead of OCRing screen pixels.
+- Supporting macOS 13 or earlier.
+
+## v0.1 Release Definition
+
+CopyLasso v0.1.0 is complete only when:
+
+- Every approved v0.1 roadmap goal is complete with reproducible evidence.
+- The same release commit passes local and CI builds and automated tests.
+- Every separable production behavior was developed test-first, with documented manual procedures for system behavior that cannot be automated faithfully.
+- Debug and Release use their fixed, distinct bundle identifiers.
+- The Release application contains both `arm64` and `x86_64` architectures.
+- Intel build and automated-test CI passes.
+- The core workflow passes on the maintainer's Apple Silicon Mac.
+- The DMG is Developer ID signed, notarized, stapled, and accepted by Gatekeeper.
+- A browser-downloaded copy passes the clean-installation checklist on the selected minimum and latest test systems.
+- Permission denial and recovery, Launch at Login, global-shortcut and menu invocation, capture, OCR, clipboard output, focus preservation, and complete uninstall all pass their release checks.
+- Known limitations are documented in the release notes.
+- No release-blocking defect remains open.
+
+Changes to these promises require an explicit product-scope amendment before implementation. Ordinary implementation details may evolve as long as they continue to satisfy this contract.


### PR DESCRIPTION
## Summary

- add the tracked CopyLasso v0.1 product contract
- lock product identity, bundle identifiers, macOS 14 and Universal 2 support
- define shortcut, Launch at Login, capture, OCR, clipboard, privacy, accessibility, non-goals, and release promises

## Why

Goal G00 requires the approved product decisions to be recorded in a public source of truth before the Xcode project is created.

## Impact

This is documentation-only. It creates no application code, Xcode project, permissions, dependencies, or runtime behavior.

## Verification

- reviewed the contract line by line against roadmap Section 2
- passed a 25-item decision crosswalk
- validated distinct reverse-DNS bundle identifiers
- confirmed the existing MIT license and copyright
- repeated exact-name checks across GitHub, Homebrew, the US Mac App Store search API, and general web search
- passed forbidden-reference, document-structure, and whitespace checks
- confirmed the commit contains only `docs/v0.1-product-contract.md`
