### PR TITLE
G02: complete the FOSS repository foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,72 @@
+# macOS metadata
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon?
+._*
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+__MACOSX/
+
+# Xcode user state
+xcuserdata/
+*.xcuserstate
+*.xccheckout
+*.xcscmblueprint
+
+# Xcode and Swift build output
+DerivedData/
+build/
+.build/
+*.hmap
+*.ipa
+*.dSYM
+*.dSYM.zip
+*.xcarchive
+*.xcresult
+*.xctestrun
+*.moved-aside
+
+# Exported and packaged applications
+*.app
+*.dmg
+*.pkg
+*.mpkg
+/Archives/
+/ExportedApps/
+/dist/
+
+# Dependency build output
+Carthage/Build/
+.swiftpm/xcode/package.xcworkspace/xcuserdata/
+
+# Local environment and secret-bearing configuration
+.env
+.env.*
+!.env.example
+!.env.sample
+Local.xcconfig
+Secrets.xcconfig
+*.secrets.xcconfig
+
+# Signing material and credentials
+*.cer
+*.crt
+*.der
+*.key
+*.keychain
+*.keychain-db
+*.mobileprovision
+*.p12
+*.p8
+*.pem
+*.pfx
+*.provisionprofile
+
+# Local logs
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to CopyLasso will be documented in this file.
+
+## Unreleased
+
+### Added
+
+- Initial v0.1 product contract and verified development-environment documentation.
+- Public project overview, contribution guidance, security-reporting policy, privacy policy, and repository hygiene rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to CopyLasso
+
+Thank you for helping build CopyLasso. The project is still in early pre-release development, so focused changes that preserve the approved v0.1 scope are the easiest to review.
+
+## Before Making a Change
+
+- Read the [v0.1 product contract](docs/v0.1-product-contract.md) for supported behavior, privacy guarantees, and non-goals.
+- Review the [development environment](docs/development-environment.md) and use the documented stable Xcode toolchain.
+- Open an issue before starting a large feature, architectural change, new dependency, or product-scope change.
+- Never include credentials, signing material, captured screen content, recognized private text, or other sensitive data in a commit, issue, test fixture, screenshot, or log.
+
+## Development Expectations
+
+- Keep each pull request small, cohesive, and limited to one clear purpose.
+- Develop production behavior test-first. Add focused failing tests, confirm the expected failure, implement the smallest passing change, and run the relevant broader suite.
+- Test success, failure, cancellation, boundary, and state-transition behavior introduced by the change.
+- Use native Apple frameworks when they meet the requirement cleanly.
+- Format Swift with the version bundled with Xcode: `xcrun swift-format`.
+- Treat new compiler and analyzer warnings as failures.
+- Update public documentation whenever user-visible behavior, requirements, privacy, or limitations change.
+
+Some macOS behavior, including real privacy dialogs, global shortcut delivery, visual overlays, display capture, signing, notarization, and Gatekeeper checks, requires manual verification. Separate and automate the testable logic first, then describe the manual procedure and result in the pull request.
+
+## Original Work and Privacy
+
+Contributions must be original or compatible with the MIT License. Do not copy proprietary source code, private implementation details, branding, icons, screenshots, interface assets, website copy, or other protected material.
+
+CopyLasso must never log, persist, or transmit screenshots, recognized text, clipboard text, or HUD preview text. Preserve the existing clipboard on every cancellation and failure path, and keep platform APIs behind testable boundaries where practical.
+
+## Pull Requests
+
+A pull request should explain:
+
+- what changed and why;
+- the tests and manual checks performed;
+- any user-visible, privacy, security, or accessibility impact; and
+- any remaining limitation or follow-up work.
+
+Submit only green commits. Reviewers may ask for a change to be split if unrelated work makes the behavior or verification difficult to assess.
+
+By contributing, you agree that your contribution is licensed under the repository's [MIT License](LICENSE).

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,36 @@
+# CopyLasso Privacy
+
+**Status:** Approved privacy contract for the pre-release v0.1 application.
+
+CopyLasso is designed as a local-first macOS utility. Its core job is to capture a user-selected screen region, recognize visible text, and place the result on the clipboard without uploading or retaining the captured content.
+
+## Local Processing
+
+- Screen capture uses Apple's ScreenCaptureKit framework.
+- OCR uses Apple's Vision framework on the Mac.
+- Captured images and recognized text remain in memory only for the active operation and are released as soon as they are no longer needed.
+- Core capture and OCR work without a network connection.
+
+## Data Not Collected or Retained
+
+CopyLasso v0.1 has no:
+
+- screenshot, OCR, or clipboard history;
+- cloud OCR or content upload;
+- accounts or synchronization;
+- analytics or telemetry; or
+- logging of screenshots, recognized text, clipboard text, or copied-text previews.
+
+The application stores only ordinary preferences needed for onboarding, shortcut configuration, Launch at Login presentation, and settings behavior. It does not use those preferences to retain captured images or recognized text.
+
+## macOS Permissions
+
+CopyLasso needs macOS Screen Recording permission to capture the selected pixels. It requests that permission only when the user first attempts a capture and provides recovery guidance if access is denied or later revoked.
+
+The v0.1 core workflow does not require Accessibility or Input Monitoring permission. macOS may prevent protected or DRM-restricted content from being captured, and CopyLasso does not attempt to bypass those protections.
+
+## Network Activity
+
+Core functionality does not require network access, and v0.1 contains no automatic updater. Users obtain releases manually from GitHub. Any network activity involved in visiting GitHub or downloading a release occurs outside the CopyLasso core OCR workflow.
+
+The detailed, release-blocking privacy requirements are part of the public [v0.1 product contract](docs/v0.1-product-contract.md).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# CopyLasso
+
+CopyLasso is a free, open-source macOS utility for copying visible text from anywhere on screen. Press a global shortcut, drag around text, and receive the recognized plain text on the clipboard.
+
+> **Project status:** CopyLasso is in early pre-release development. The repository does not contain a buildable application yet, and no public release is available.
+
+## Planned v0.1 Experience
+
+- Capture text from screen pixels in any application, including images and video.
+- Perform OCR entirely on the Mac with Apple's Vision framework.
+- Copy recognized plain text without retaining a screenshot or OCR history.
+- Start capture from a configurable global shortcut or menu-bar command.
+- Run as a native Universal 2 app on macOS 14 or newer.
+
+The initial release targets ordinary, approximately horizontal, single-column English text. Protected or DRM-restricted content may not be capturable because CopyLasso follows macOS screen-capture restrictions.
+
+## Privacy
+
+CopyLasso is designed to keep captured images and recognized text local, in memory, and only for as long as the active operation needs them. v0.1 has no accounts, cloud OCR, analytics, telemetry, or capture history. Core OCR does not require a network connection.
+
+See the full [privacy policy](PRIVACY.md) and [v0.1 product contract](docs/v0.1-product-contract.md) for the approved guarantees and limitations.
+
+## Development Requirements
+
+- A Mac running macOS 14 or newer
+- The latest stable full Xcode release selected by the project
+- Swift 6 and the `swift-format` version bundled with that Xcode release
+- An Apple Development signing identity for signed local builds
+
+The current verified baseline is Xcode 26.6 with Swift 6.3.3. See [Development Environment](docs/development-environment.md) for the reproducible setup and exact toolchain snapshot. Build instructions will be added when the Xcode project is introduced.
+
+## Contributing
+
+CopyLasso is under active development. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before proposing a change. Security issues should be reported privately according to [SECURITY.md](SECURITY.md).
+
+## License
+
+CopyLasso is available under the [MIT License](LICENSE). Copyright 2026 Bennett Hilberg.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+CopyLasso is in pre-release development and does not yet have a supported public release. Security reports about the source, planned application behavior, build process, or repository configuration are still welcome.
+
+## Report a Vulnerability Privately
+
+Use [GitHub Private Vulnerability Reporting](https://github.com/bennetthilberg/copylasso/security/advisories/new) to report a suspected vulnerability. Please do not disclose the issue in a public GitHub issue, discussion, pull request, or social post before a fix and coordinated disclosure are ready.
+
+Include enough information to reproduce and assess the report when possible:
+
+- the affected revision, version, or component;
+- reproduction steps or a minimal proof of concept;
+- the security impact and required conditions; and
+- suggested mitigations, if known.
+
+Remove passwords, tokens, signing credentials, private keys, personal screen captures, recognized private text, and unrelated personal data before submitting a report. The maintainer will use the private advisory to clarify the report and coordinate remediation and disclosure.
+
+General defects without a security impact may be reported through the repository's public issue tracker.


### PR DESCRIPTION
## Summary

- add Xcode, Swift, macOS, packaging, credential, and signing-material ignore rules
- add the public README, contribution guide, privacy policy, security policy, and changelog
- document the pre-release state and link the existing product contract and development-environment guide
- enable GitHub Private Vulnerability Reporting as the private security contact route

## Validation

- `git diff --cached --check`
- verified 21 representative generated or sensitive paths are ignored
- verified 8 representative source and reproducibility paths remain trackable
- checked local documentation links and all tracked candidates
- searched for stale names, proprietary-product references, non-MIT licenses, placeholders, secrets, credentials, and local machine paths
- verified GitHub Private Vulnerability Reporting reads back as enabled

## Scope

This is a documentation and repository-configuration goal, so test-first application behavior does not apply. No Xcode project, Swift source, dependency, or application behavior is introduced.
