### PR TITLE
G03-G04: scaffold the Xcode project and establish CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: build and test (${{ matrix.architecture }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: arm64
+            runner: macos-26
+          - architecture: x86_64
+            runner: macos-26-intel
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Build and test
+        env:
+          COPYLASSO_CI_ARCH: ${{ matrix.architecture }}
+          COPYLASSO_CI_FAILURE_PROBE: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-failure-probe') }}
+        run: ./scripts/ci.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,5 @@ All notable changes to CopyLasso will be documented in this file.
 
 - Initial v0.1 product contract and verified development-environment documentation.
 - Public project overview, contribution guidance, security-reporting policy, privacy policy, and repository hygiene rules.
+- Native SwiftUI Xcode scaffold with shared app, unit-test, and UI-test scheme.
+- Reproducible dual-architecture CI for Debug, XCTest bundles, unit tests, and Universal 2 Release builds.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,14 @@ Thank you for helping build CopyLasso. The project is still in early pre-release
 - Treat new compiler and analyzer warnings as failures.
 - Update public documentation whenever user-visible behavior, requirements, privacy, or limitations change.
 
+Before submitting, run the canonical clean pipeline:
+
+```sh
+./scripts/ci.sh
+```
+
+It lints Swift, resolves dependencies, builds Debug and Universal 2 Release, builds both XCTest bundles, runs unit tests, asserts required build settings, and verifies the Release architectures. Run UI tests separately through Xcode with runnable local signing when the change affects launch or interface behavior.
+
 Some macOS behavior, including real privacy dialogs, global shortcut delivery, visual overlays, display capture, signing, notarization, and Gatekeeper checks, requires manual verification. Separate and automate the testable logic first, then describe the manual procedure and result in the pull request.
 
 ## Original Work and Privacy
@@ -37,5 +45,7 @@ A pull request should explain:
 - any remaining limitation or follow-up work.
 
 Submit only green commits. Reviewers may ask for a change to be split if unrelated work makes the behavior or verification difficult to assess.
+
+Maintainers may temporarily apply the `ci-failure-probe` pull-request label to verify that both CI architectures report a controlled failing unit test. The label must be removed after the red result; removal reruns the same commit without the probe. Do not add a deliberately failing commit for this purpose.
 
 By contributing, you agree that your contribution is licensed under the repository's [MIT License](LICENSE).

--- a/Configuration/Shared.xcconfig
+++ b/Configuration/Shared.xcconfig
@@ -1,0 +1,4 @@
+// Shared, non-secret build configuration.
+// Local.xcconfig is optional and ignored by Git.
+CODE_SIGN_STYLE = Automatic
+#include? "../Local.xcconfig"

--- a/CopyLasso.xcodeproj/project.pbxproj
+++ b/CopyLasso.xcodeproj/project.pbxproj
@@ -1,0 +1,592 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		AACED2F930004BEC001F9909 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AACED2E330004BEB001F9909 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AACED2EA30004BEB001F9909;
+			remoteInfo = CopyLasso;
+		};
+		AACED30330004BEC001F9909 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AACED2E330004BEB001F9909 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AACED2EA30004BEB001F9909;
+			remoteInfo = CopyLasso;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		AACED2EB30004BEB001F9909 /* CopyLasso.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CopyLasso.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AACED2F830004BEC001F9909 /* CopyLassoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CopyLassoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AACED30230004BEC001F9909 /* CopyLassoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CopyLassoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0A1A0013001000000000001 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		AACED2ED30004BEB001F9909 /* CopyLasso */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = CopyLasso;
+			sourceTree = "<group>";
+		};
+		AACED2FB30004BEC001F9909 /* CopyLassoTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = CopyLassoTests;
+			sourceTree = "<group>";
+		};
+		AACED30530004BEC001F9909 /* CopyLassoUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = CopyLassoUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AACED2E830004BEB001F9909 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AACED2F530004BEC001F9909 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AACED2FF30004BEC001F9909 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		AACED2E230004BEB001F9909 = {
+			isa = PBXGroup;
+			children = (
+				C0A1A0023001000000000002 /* Configuration */,
+				AACED2ED30004BEB001F9909 /* CopyLasso */,
+				AACED2FB30004BEC001F9909 /* CopyLassoTests */,
+				AACED30530004BEC001F9909 /* CopyLassoUITests */,
+				AACED2EC30004BEB001F9909 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		AACED2EC30004BEB001F9909 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AACED2EB30004BEB001F9909 /* CopyLasso.app */,
+				AACED2F830004BEC001F9909 /* CopyLassoTests.xctest */,
+				AACED30230004BEC001F9909 /* CopyLassoUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C0A1A0023001000000000002 /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				C0A1A0013001000000000001 /* Shared.xcconfig */,
+			);
+			path = Configuration;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AACED2EA30004BEB001F9909 /* CopyLasso */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AACED30C30004BEC001F9909 /* Build configuration list for PBXNativeTarget "CopyLasso" */;
+			buildPhases = (
+				AACED2E730004BEB001F9909 /* Sources */,
+				AACED2E830004BEB001F9909 /* Frameworks */,
+				AACED2E930004BEB001F9909 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				AACED2ED30004BEB001F9909 /* CopyLasso */,
+			);
+			name = CopyLasso;
+			packageProductDependencies = (
+			);
+			productName = CopyLasso;
+			productReference = AACED2EB30004BEB001F9909 /* CopyLasso.app */;
+			productType = "com.apple.product-type.application";
+		};
+		AACED2F730004BEC001F9909 /* CopyLassoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AACED30F30004BEC001F9909 /* Build configuration list for PBXNativeTarget "CopyLassoTests" */;
+			buildPhases = (
+				AACED2F430004BEC001F9909 /* Sources */,
+				AACED2F530004BEC001F9909 /* Frameworks */,
+				AACED2F630004BEC001F9909 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AACED2FA30004BEC001F9909 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				AACED2FB30004BEC001F9909 /* CopyLassoTests */,
+			);
+			name = CopyLassoTests;
+			packageProductDependencies = (
+			);
+			productName = CopyLassoTests;
+			productReference = AACED2F830004BEC001F9909 /* CopyLassoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		AACED30130004BEC001F9909 /* CopyLassoUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AACED31230004BEC001F9909 /* Build configuration list for PBXNativeTarget "CopyLassoUITests" */;
+			buildPhases = (
+				AACED2FE30004BEC001F9909 /* Sources */,
+				AACED2FF30004BEC001F9909 /* Frameworks */,
+				AACED30030004BEC001F9909 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AACED30430004BEC001F9909 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				AACED30530004BEC001F9909 /* CopyLassoUITests */,
+			);
+			name = CopyLassoUITests;
+			packageProductDependencies = (
+			);
+			productName = CopyLassoUITests;
+			productReference = AACED30230004BEC001F9909 /* CopyLassoUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AACED2E330004BEB001F9909 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2660;
+				LastUpgradeCheck = 2660;
+				TargetAttributes = {
+					AACED2EA30004BEB001F9909 = {
+						CreatedOnToolsVersion = 26.6;
+					};
+					AACED2F730004BEC001F9909 = {
+						CreatedOnToolsVersion = 26.6;
+						TestTargetID = AACED2EA30004BEB001F9909;
+					};
+					AACED30130004BEC001F9909 = {
+						CreatedOnToolsVersion = 26.6;
+						TestTargetID = AACED2EA30004BEB001F9909;
+					};
+				};
+			};
+			buildConfigurationList = AACED2E630004BEB001F9909 /* Build configuration list for PBXProject "CopyLasso" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = AACED2E230004BEB001F9909;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = AACED2EC30004BEB001F9909 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AACED2EA30004BEB001F9909 /* CopyLasso */,
+				AACED2F730004BEC001F9909 /* CopyLassoTests */,
+				AACED30130004BEC001F9909 /* CopyLassoUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AACED2E930004BEB001F9909 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AACED2F630004BEC001F9909 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AACED30030004BEC001F9909 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AACED2E730004BEB001F9909 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AACED2F430004BEC001F9909 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AACED2FE30004BEC001F9909 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		AACED2FA30004BEC001F9909 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AACED2EA30004BEB001F9909 /* CopyLasso */;
+			targetProxy = AACED2F930004BEC001F9909 /* PBXContainerItemProxy */;
+		};
+		AACED30430004BEC001F9909 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AACED2EA30004BEB001F9909 /* CopyLasso */;
+			targetProxy = AACED30330004BEC001F9909 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		AACED30A30004BEC001F9909 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C0A1A0013001000000000001 /* Shared.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+			};
+			name = Debug;
+		};
+		AACED30B30004BEC001F9909 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C0A1A0013001000000000001 /* Shared.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					arm64,
+					x86_64,
+				);
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = NO;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+			};
+			name = Release;
+		};
+		AACED30D30004BEC001F9909 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = 28F59BA3HG;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Bennett Hilberg. All rights reserved.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.bennetthilberg.copylasso.debug;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = NO;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		AACED30E30004BEC001F9909 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Bennett Hilberg. All rights reserved.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.bennetthilberg.copylasso;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = NO;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		AACED31030004BEC001F9909 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.bennetthilberg.copylasso.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CopyLasso.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/CopyLasso";
+			};
+			name = Debug;
+		};
+		AACED31130004BEC001F9909 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.bennetthilberg.copylasso.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CopyLasso.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/CopyLasso";
+			};
+			name = Release;
+		};
+		AACED31330004BEC001F9909 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.bennetthilberg.copylasso.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TEST_TARGET_NAME = CopyLasso;
+			};
+			name = Debug;
+		};
+		AACED31430004BEC001F9909 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.bennetthilberg.copylasso.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TEST_TARGET_NAME = CopyLasso;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		AACED2E630004BEB001F9909 /* Build configuration list for PBXProject "CopyLasso" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AACED30A30004BEC001F9909 /* Debug */,
+				AACED30B30004BEC001F9909 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AACED30C30004BEC001F9909 /* Build configuration list for PBXNativeTarget "CopyLasso" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AACED30D30004BEC001F9909 /* Debug */,
+				AACED30E30004BEC001F9909 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AACED30F30004BEC001F9909 /* Build configuration list for PBXNativeTarget "CopyLassoTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AACED31030004BEC001F9909 /* Debug */,
+				AACED31130004BEC001F9909 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AACED31230004BEC001F9909 /* Build configuration list for PBXNativeTarget "CopyLassoUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AACED31330004BEC001F9909 /* Debug */,
+				AACED31430004BEC001F9909 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = AACED2E330004BEB001F9909 /* Project object */;
+}

--- a/CopyLasso.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/CopyLasso.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CopyLasso.xcodeproj/xcshareddata/xcschemes/CopyLasso.xcscheme
+++ b/CopyLasso.xcodeproj/xcshareddata/xcschemes/CopyLasso.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2660"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AACED2EA30004BEB001F9909"
+               BuildableName = "CopyLasso.app"
+               BlueprintName = "CopyLasso"
+               ReferencedContainer = "container:CopyLasso.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AACED2F730004BEC001F9909"
+               BuildableName = "CopyLassoTests.xctest"
+               BlueprintName = "CopyLassoTests"
+               ReferencedContainer = "container:CopyLasso.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AACED30130004BEC001F9909"
+               BuildableName = "CopyLassoUITests.xctest"
+               BlueprintName = "CopyLassoUITests"
+               ReferencedContainer = "container:CopyLasso.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AACED2EA30004BEB001F9909"
+            BuildableName = "CopyLasso.app"
+            BlueprintName = "CopyLasso"
+            ReferencedContainer = "container:CopyLasso.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AACED2EA30004BEB001F9909"
+            BuildableName = "CopyLasso.app"
+            BlueprintName = "CopyLasso"
+            ReferencedContainer = "container:CopyLasso.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CopyLasso/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/CopyLasso/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CopyLasso/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/CopyLasso/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CopyLasso/Assets.xcassets/Contents.json
+++ b/CopyLasso/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CopyLasso/ContentView.swift
+++ b/CopyLasso/ContentView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct ContentView: View {
+  var body: some View {
+    VStack(spacing: 8) {
+      Text("CopyLasso")
+        .font(.title)
+        .accessibilityLabel("CopyLasso")
+        .accessibilityIdentifier("copylasso.placeholder.title")
+
+      Text("Screen text capture is coming soon.")
+        .foregroundStyle(.secondary)
+    }
+    .padding()
+    .frame(minWidth: 320, minHeight: 180)
+  }
+}
+
+#Preview {
+  ContentView()
+}

--- a/CopyLasso/CopyLassoApp.swift
+++ b/CopyLasso/CopyLassoApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct CopyLassoApp: App {
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+  }
+}

--- a/CopyLassoTests/CopyLassoTests.swift
+++ b/CopyLassoTests/CopyLassoTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+
+@testable import CopyLasso
+
+final class CopyLassoTests: XCTestCase {
+  func testTargetExecutes() {
+    XCTAssertTrue(true)
+  }
+
+  func testCIFailureProbeIsDisabled() {
+    #if COPYLASSO_CI_FAILURE_PROBE
+      XCTFail("Controlled CI failure probe is enabled")
+    #else
+      XCTAssertTrue(true)
+    #endif
+  }
+}

--- a/CopyLassoUITests/CopyLassoUITests.swift
+++ b/CopyLassoUITests/CopyLassoUITests.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+final class CopyLassoUITests: XCTestCase {
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+  }
+
+  @MainActor
+  func testPlaceholderLaunches() {
+    let app = XCUIApplication()
+    app.launch()
+
+    let title = app.staticTexts["copylasso.placeholder.title"]
+    XCTAssertTrue(title.waitForExistence(timeout: 5))
+  }
+}

--- a/Local.xcconfig.example
+++ b/Local.xcconfig.example
@@ -1,0 +1,6 @@
+// Copy this file to Local.xcconfig and set your Apple Developer team.
+DEVELOPMENT_TEAM =
+
+// For scaffold-only ad hoc signing when no unlocked identity is available:
+// CODE_SIGN_STYLE = Manual
+// CODE_SIGN_IDENTITY = -

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # CopyLasso
 
+[![CI](https://github.com/bennetthilberg/copylasso/actions/workflows/ci.yml/badge.svg)](https://github.com/bennetthilberg/copylasso/actions/workflows/ci.yml)
+
 CopyLasso is a free, open-source macOS utility for copying visible text from anywhere on screen. Press a global shortcut, drag around text, and receive the recognized plain text on the clipboard.
 
-> **Project status:** CopyLasso is in early pre-release development. The repository does not contain a buildable application yet, and no public release is available.
+> **Project status:** CopyLasso is in early pre-release development. The repository contains a buildable placeholder application, but screen capture, OCR, and the intended menu-bar experience are not implemented, and no public release is available.
 
 ## Planned v0.1 Experience
 
@@ -27,7 +29,15 @@ See the full [privacy policy](PRIVACY.md) and [v0.1 product contract](docs/v0.1-
 - Swift 6 and the `swift-format` version bundled with that Xcode release
 - An Apple Development signing identity for signed local builds
 
-The current verified baseline is Xcode 26.6 with Swift 6.3.3. See [Development Environment](docs/development-environment.md) for the reproducible setup and exact toolchain snapshot. Build instructions will be added when the Xcode project is introduced.
+The current verified baseline is Xcode 26.6 with Swift 6.3.3. See [Development Environment](docs/development-environment.md) for setup and canonical commands, and [Build Configuration](docs/architecture/build-configuration.md) for target and signing decisions.
+
+Run the same unsigned build and unit-test pipeline used by CI:
+
+```sh
+./scripts/ci.sh
+```
+
+The shared Xcode scheme also builds and runs the placeholder locally. UI tests require runnable local signing; CI builds their bundle without launching the unsigned runner.
 
 ## Contributing
 

--- a/docs/architecture/build-configuration.md
+++ b/docs/architecture/build-configuration.md
@@ -1,0 +1,73 @@
+# Build Configuration
+
+CopyLasso uses one native Xcode project, one shared scheme, and no third-party build system. The committed project is intended to remain understandable in Xcode and reproducible from the command line.
+
+## Targets and Scheme
+
+The shared `CopyLasso` scheme contains:
+
+- `CopyLasso`, the SwiftUI macOS application;
+- `CopyLassoTests`, the XCTest unit-test bundle; and
+- `CopyLassoUITests`, the XCTest UI-test bundle.
+
+The application currently presents only a placeholder window. Menu-bar behavior, global shortcuts, screen capture, OCR, onboarding, settings, and login-at-launch behavior are intentionally outside this scaffold.
+
+## Supported Configuration
+
+| Setting | Value |
+| --- | --- |
+| Deployment target | macOS 14.0 |
+| Swift language mode | Swift 6 |
+| Concurrency checking | Complete |
+| Warnings | Treated as errors |
+| Debug bundle identifier | `io.github.bennetthilberg.copylasso.debug` |
+| Release bundle identifier | `io.github.bennetthilberg.copylasso` |
+| Marketing version | `0.1.0` |
+| Build number | `1` |
+| Release architectures | `arm64`, `x86_64` |
+| App Sandbox | Enabled |
+| Hardened Runtime | Enabled |
+
+Release builds explicitly set both macOS architectures and disable `ONLY_ACTIVE_ARCH`. The canonical pipeline inspects the built executable with `lipo`; checking the build setting alone is not sufficient.
+
+## Signing
+
+`Configuration/Shared.xcconfig` is the tracked, non-secret configuration include. It defaults to automatic signing and optionally loads the ignored root-level `Local.xcconfig`.
+
+Create local signing configuration from the empty example:
+
+```sh
+cp Local.xcconfig.example Local.xcconfig
+```
+
+Set only non-exportable identifiers or build-setting selections in that ignored file. Never commit an Apple account, team identifier, certificate fingerprint, private key, password, or token. A normal Apple Developer setup needs only:
+
+```xcconfig
+DEVELOPMENT_TEAM =
+```
+
+Enter the team identifier after the equals sign only in the ignored local copy.
+
+For scaffold development on a Mac without an available unlocked development identity, local ad hoc signing can make test runners executable without accessing Keychain:
+
+```xcconfig
+DEVELOPMENT_TEAM =
+CODE_SIGN_STYLE = Manual
+CODE_SIGN_IDENTITY = -
+```
+
+Ad hoc signing is not suitable for distribution and does not provide stable identity for privacy-permission continuity. Use a real local development identity before implementing or manually verifying permission-dependent behavior.
+
+GitHub Actions passes `CODE_SIGNING_ALLOWED=NO`. CI executes unit tests only; it builds the UI-test bundle to catch compile and linkage failures but does not launch the unsigned UI-test runner.
+
+## Canonical Commands
+
+Run the complete local equivalent of CI from the repository root:
+
+```sh
+./scripts/ci.sh
+```
+
+The script requires Xcode 26.6, starts with clean DerivedData under `.build`, lints Swift, resolves dependencies, builds Debug, builds both test bundles, runs unit tests, checks required settings, builds Universal 2 Release, and verifies the executable's two architecture slices.
+
+Execute UI tests through Xcode with runnable local signing. The unsigned CI command intentionally does not launch them.

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -18,7 +18,7 @@ Verified July 9, 2026 on the maintainer workstation:
 
 Apple's current [Xcode support matrix](https://developer.apple.com/support/xcode/) lists Xcode 26.6 as the latest stable release; Xcode 27 is still a beta and is not the project baseline.
 
-CopyLasso itself targets macOS 14 or newer and will produce a Universal 2 Release application containing `arm64` and `x86_64`. Those project build settings are established and tested in later roadmap goals; G01 verifies only the development environment.
+CopyLasso targets macOS 14 or newer and produces a Universal 2 Release application containing `arm64` and `x86_64`. The project, shared scheme, and enforced settings are documented in [Build Configuration](architecture/build-configuration.md).
 
 ## Xcode Setup
 
@@ -59,6 +59,18 @@ Before installing it, confirm that the downloaded certificate is the Apple World
 
 Do not export or commit the Apple Development identity. If the certificate or private key is replaced later, verify the new identity before relying on privacy-permission continuity between development builds.
 
+## Local Project Signing
+
+The tracked `Configuration/Shared.xcconfig` optionally includes an ignored `Local.xcconfig`. Start from the empty example:
+
+```sh
+cp Local.xcconfig.example Local.xcconfig
+```
+
+For normal automatic development signing, set `DEVELOPMENT_TEAM` in the ignored file. Do not print that value into shared logs. Contributors who only need to run the current scaffold may use local ad hoc signing as documented in [Build Configuration](architecture/build-configuration.md); permission-dependent development requires a stable Apple Development identity.
+
+An authorization dialog from `codesign` requests the password of the named keychain, which may differ from the current macOS login password if that password changed without updating the keychain. Do not repeatedly enter credentials, reset a keychain, or delete signing material merely to run the scaffold. Stop the build and use the documented ad hoc configuration until the keychain can be repaired intentionally.
+
 ## Git Identity
 
 Git must have an intentional maintainer identity before creating commits. It may be configured globally or for this repository. Check presence without printing private values into shared logs:
@@ -75,7 +87,7 @@ fi
 
 Do not replace the maintainer's Git identity with a generic automation identity unless the maintainer explicitly requests that change.
 
-## Canonical Verification
+## Canonical Toolchain Verification
 
 Run these checks from the repository root:
 
@@ -111,6 +123,30 @@ fi
 
 The verified G01 environment has one valid Apple Development identity. The certificate and paired private key remain in the login keychain and are not repository artifacts.
 
+## Project Build and Test
+
+The canonical local and GitHub Actions entrypoint is:
+
+```sh
+./scripts/ci.sh
+```
+
+It selects clean DerivedData under `.build`, verifies Xcode 26.6, lints Swift sources, resolves packages, builds Debug, builds the unit and UI test bundles, runs unit tests, asserts the required build settings, builds Universal 2 Release, and verifies both binary slices. It disables code signing and never launches the unsigned UI-test runner.
+
+For interactive verification, open `CopyLasso.xcodeproj`, select the shared `CopyLasso` scheme and **My Mac**, then use:
+
+- **Product > Build** (`Command-B`) for Debug;
+- **Product > Run** (`Command-R`) for the placeholder application; and
+- **Product > Test** (`Command-U`) for the unit and UI suites.
+
+Interactive Run and UI testing require runnable local signing. Keep any team or identity override in ignored `Local.xcconfig`.
+
+## GitHub Actions
+
+`.github/workflows/ci.yml` runs for pull requests targeting `main` and pushes to `main`. It explicitly selects Xcode 26.6 and executes `scripts/ci.sh` on the GitHub-hosted macOS 26 Apple Silicon and Intel runner images. The workflow has read-only repository contents permission, persists no checkout credential, uses no secrets or cache, and bounds concurrent runs and job duration.
+
+The required check names are `build and test (arm64)` and `build and test (x86_64)`. Maintainers can apply the temporary `ci-failure-probe` label to a pull request to compile a controlled unit-test failure into both jobs. Removing the label restores green checks at the same commit. Delete the temporary repository label after verifying both transitions.
+
 ## Tooling Policy
 
 - G01 introduces no Homebrew-only build dependency.
@@ -118,6 +154,6 @@ The verified G01 environment has one valid Apple Development identity. The certi
 - Add external build tools only when a later approved goal has a concrete need and records the version, source, purpose, and license.
 - Keep generated build output, archives, exported applications, signing material, and credentials out of Git.
 
-## G01 Boundary
+## Current Boundary
 
-This environment setup intentionally creates no Xcode project, application source, entitlement, dependency, or build artifact. The project scaffold begins in G03 after the repository foundation in G02 is complete.
+The repository now contains only the buildable application and test scaffold. Menu-bar behavior, global shortcuts, screen capture, OCR, onboarding, settings, login-at-launch behavior, packaging, and release automation remain intentionally unimplemented.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly project_path="$repository_root/CopyLasso.xcodeproj"
+readonly scheme="CopyLasso"
+readonly requested_architecture="${COPYLASSO_CI_ARCH:-$(uname -m)}"
+readonly derived_data="${COPYLASSO_DERIVED_DATA_PATH:-$repository_root/.build/ci-$requested_architecture}"
+
+case "$requested_architecture" in
+    arm64 | x86_64) ;;
+    *)
+        echo "Unsupported CI architecture: $requested_architecture" >&2
+        exit 1
+        ;;
+esac
+
+case "$derived_data" in
+    "$repository_root"/.build/*) ;;
+    *)
+        echo "Derived data must remain under $repository_root/.build." >&2
+        exit 1
+        ;;
+esac
+
+if [[ "$(xcodebuild -version | /usr/bin/head -n 1)" != "Xcode 26.6" ]]; then
+    echo "CopyLasso CI requires Xcode 26.6." >&2
+    xcodebuild -version >&2
+    exit 1
+fi
+
+cd "$repository_root"
+rm -rf "$derived_data"
+mkdir -p "$derived_data"
+
+echo "Linting Swift sources"
+xcrun swift-format lint --recursive --strict \
+    CopyLasso \
+    CopyLassoTests \
+    CopyLassoUITests
+
+echo "Resolving package dependencies"
+xcodebuild -resolvePackageDependencies \
+    -project "$project_path" \
+    -scheme "$scheme" \
+    -clonedSourcePackagesDirPath "$derived_data/SourcePackages"
+
+readonly destination="platform=macOS,arch=$requested_architecture"
+common_arguments=(
+    -project "$project_path"
+    -scheme "$scheme"
+    -destination "$destination"
+    -derivedDataPath "$derived_data"
+    -clonedSourcePackagesDirPath "$derived_data/SourcePackages"
+    CODE_SIGNING_ALLOWED=NO
+)
+
+echo "Building Debug for $requested_architecture"
+xcodebuild build \
+    "${common_arguments[@]}" \
+    -configuration Debug
+
+probe_arguments=('SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited)')
+if [[ "${COPYLASSO_CI_FAILURE_PROBE:-false}" == "true" ]]; then
+    probe_arguments=('SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) COPYLASSO_CI_FAILURE_PROBE')
+    echo "Controlled CI failure probe enabled"
+fi
+
+echo "Building unit-test and UI-test bundles"
+xcodebuild build-for-testing \
+    "${common_arguments[@]}" \
+    -configuration Debug \
+    "${probe_arguments[@]}"
+
+echo "Running unit tests"
+xcodebuild test-without-building \
+    "${common_arguments[@]}" \
+    -configuration Debug \
+    -only-testing:CopyLassoTests \
+    -resultBundlePath "$derived_data/UnitTests.xcresult" \
+    "${probe_arguments[@]}"
+
+echo "Inspecting required build settings"
+xcodebuild -showBuildSettings \
+    -project "$project_path" \
+    -scheme "$scheme" \
+    -configuration Debug \
+    CODE_SIGNING_ALLOWED=NO \
+    > "$derived_data/debug-build-settings.txt"
+xcodebuild -showBuildSettings \
+    -project "$project_path" \
+    -scheme "$scheme" \
+    -configuration Release \
+    CODE_SIGNING_ALLOWED=NO \
+    > "$derived_data/release-build-settings.txt"
+
+assert_setting() {
+    local settings_file="$1"
+    local setting_name="$2"
+    local expected_value="$3"
+
+    if ! /usr/bin/grep -Eq "^[[:space:]]+$setting_name = $expected_value$" "$settings_file"; then
+        echo "Expected $setting_name to equal $expected_value." >&2
+        exit 1
+    fi
+}
+
+assert_setting "$derived_data/debug-build-settings.txt" MACOSX_DEPLOYMENT_TARGET 14.0
+assert_setting "$derived_data/debug-build-settings.txt" SWIFT_VERSION 6.0
+assert_setting "$derived_data/debug-build-settings.txt" SWIFT_STRICT_CONCURRENCY complete
+assert_setting "$derived_data/debug-build-settings.txt" SWIFT_TREAT_WARNINGS_AS_ERRORS YES
+assert_setting "$derived_data/debug-build-settings.txt" GCC_TREAT_WARNINGS_AS_ERRORS YES
+assert_setting "$derived_data/debug-build-settings.txt" ENABLE_APP_SANDBOX YES
+assert_setting "$derived_data/debug-build-settings.txt" PRODUCT_BUNDLE_IDENTIFIER io.github.bennetthilberg.copylasso.debug
+assert_setting "$derived_data/release-build-settings.txt" PRODUCT_BUNDLE_IDENTIFIER io.github.bennetthilberg.copylasso
+assert_setting "$derived_data/release-build-settings.txt" ENABLE_HARDENED_RUNTIME YES
+assert_setting "$derived_data/release-build-settings.txt" ARCHS "arm64 x86_64"
+assert_setting "$derived_data/release-build-settings.txt" ONLY_ACTIVE_ARCH NO
+
+echo "Building Universal 2 Release"
+xcodebuild build \
+    -project "$project_path" \
+    -scheme "$scheme" \
+    -configuration Release \
+    -destination 'generic/platform=macOS' \
+    -derivedDataPath "$derived_data" \
+    -clonedSourcePackagesDirPath "$derived_data/SourcePackages" \
+    CODE_SIGNING_ALLOWED=NO
+
+readonly release_executable="$derived_data/Build/Products/Release/CopyLasso.app/Contents/MacOS/CopyLasso"
+if [[ ! -x "$release_executable" ]]; then
+    echo "Release executable was not produced." >&2
+    exit 1
+fi
+
+readonly release_architectures="$(xcrun lipo -archs "$release_executable")"
+for required_architecture in arm64 x86_64; do
+    if [[ " $release_architectures " != *" $required_architecture "* ]]; then
+        echo "Release executable is missing $required_architecture." >&2
+        exit 1
+    fi
+done
+
+echo "CopyLasso CI passed for $requested_architecture; Release architectures: $release_architectures"


### PR DESCRIPTION
## Summary

- scaffold the native SwiftUI app, unit-test target, UI-test target, and shared CopyLasso scheme
- enforce macOS 14, Swift 6 strict concurrency, warnings as errors, Sandbox, Hardened Runtime, and Universal 2 Release settings
- add the canonical clean build and test script plus Apple Silicon and Intel GitHub Actions jobs
- document local signing, build configuration, CI, and the controlled failure probe

## Verification

- canonical pipeline passed locally for arm64 and x86_64
- automatically signed full XCTest suite passed all three tests
- Xcode Command-B, Command-R, and Command-U passed
- Release executable contains arm64 and x86_64 slices
- controlled failure probe produced the expected failing unit test without a failing commit
- staged scope, formatting, workflow syntax, project discovery, and sensitive-content audits passed

## Scope

The app displays only a minimal placeholder window. This PR does not implement menu-bar behavior, shortcuts, capture, OCR, onboarding, settings, login-at-launch behavior, packaging, or release automation.
