### PR TITLE
G07: prove selection overlay and coordinate conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ All notable changes to CopyLasso will be documented in this file.
 - Reproducible dual-architecture CI for Debug, XCTest bundles, unit tests, and Universal 2 Release builds.
 - Project-owned OCR fixtures, a thin in-memory Vision experiment, explicit quality tests, and a recorded viability decision.
 - A Debug-only in-memory ScreenCaptureKit experiment, permission-state tests, and a recorded capture viability decision.
+- A Debug-only multi-display AppKit selection experiment, coordinate-conversion tests, and a recorded overlay viability decision.

--- a/CopyLasso.xcodeproj/project.pbxproj
+++ b/CopyLasso.xcodeproj/project.pbxproj
@@ -451,6 +451,9 @@
 				EXCLUDED_SOURCE_FILE_NAMES = (
 					ScreenCaptureSpike.swift,
 					ScreenCaptureSpikeView.swift,
+					SelectionGeometry.swift,
+					SelectionOverlayController.swift,
+					SelectionOverlaySpikeView.swift,
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Bennett Hilberg. All rights reserved.";

--- a/CopyLasso/CopyLassoApp.swift
+++ b/CopyLasso/CopyLassoApp.swift
@@ -5,7 +5,9 @@ struct CopyLassoApp: App {
   var body: some Scene {
     WindowGroup {
       #if DEBUG
-        if ProcessInfo.processInfo.arguments.contains("--g06-capture-spike") {
+        if ProcessInfo.processInfo.arguments.contains("--g07-selection-spike") {
+          SelectionOverlaySpikeView()
+        } else if ProcessInfo.processInfo.arguments.contains("--g06-capture-spike") {
           ScreenCaptureSpikeView()
         } else {
           ContentView()

--- a/CopyLasso/SelectionGeometry.swift
+++ b/CopyLasso/SelectionGeometry.swift
@@ -1,0 +1,232 @@
+#if DEBUG
+  import CoreGraphics
+  import Foundation
+
+  enum DisplayGeometryError: Error, Equatable {
+    case invalidAppKitFrame
+    case invalidCoreGraphicsBounds
+    case invalidBackingScale
+    case invalidPoint
+  }
+
+  struct DisplayGeometry: Equatable {
+    let displayID: CGDirectDisplayID
+    let appKitFrame: CGRect
+    let coreGraphicsBounds: CGRect
+    let backingScale: CGFloat
+
+    init(
+      displayID: CGDirectDisplayID,
+      appKitFrame: CGRect,
+      coreGraphicsBounds: CGRect,
+      backingScale: CGFloat
+    ) throws {
+      guard Self.isValid(frame: appKitFrame) else {
+        throw DisplayGeometryError.invalidAppKitFrame
+      }
+      guard Self.isValid(frame: coreGraphicsBounds) else {
+        throw DisplayGeometryError.invalidCoreGraphicsBounds
+      }
+      guard backingScale.isFinite, backingScale > 0 else {
+        throw DisplayGeometryError.invalidBackingScale
+      }
+
+      self.displayID = displayID
+      self.appKitFrame = appKitFrame
+      self.coreGraphicsBounds = coreGraphicsBounds
+      self.backingScale = backingScale
+    }
+
+    func selectionResult(
+      from start: CGPoint,
+      to end: CGPoint,
+      minimumSize: CGFloat = 4
+    ) throws -> SelectionResult? {
+      guard Self.isFinite(point: start), Self.isFinite(point: end) else {
+        throw DisplayGeometryError.invalidPoint
+      }
+
+      let clampedStart = clamped(point: start)
+      let clampedEnd = clamped(point: end)
+      let appKitGlobalRect = Self.normalizedRect(from: clampedStart, to: clampedEnd)
+      guard appKitGlobalRect.width >= minimumSize, appKitGlobalRect.height >= minimumSize else {
+        return nil
+      }
+
+      let displayLocalRect = appKitGlobalRect.offsetBy(
+        dx: -appKitFrame.minX,
+        dy: -appKitFrame.minY
+      )
+      let coreGraphicsDisplayLocalRect = CGRect(
+        x: displayLocalRect.minX,
+        y: appKitFrame.height - displayLocalRect.maxY,
+        width: displayLocalRect.width,
+        height: displayLocalRect.height
+      )
+      let coreGraphicsGlobalRect = coreGraphicsDisplayLocalRect.offsetBy(
+        dx: coreGraphicsBounds.minX,
+        dy: coreGraphicsBounds.minY
+      )
+      let backingPixelRect = Self.outwardRoundedPixelRect(
+        coreGraphicsDisplayLocalRect,
+        scale: backingScale
+      )
+
+      return SelectionResult(
+        displayID: displayID,
+        appKitGlobalRect: appKitGlobalRect,
+        displayLocalRect: displayLocalRect,
+        coreGraphicsGlobalRect: coreGraphicsGlobalRect,
+        coreGraphicsDisplayLocalRect: coreGraphicsDisplayLocalRect,
+        backingPixelRect: backingPixelRect
+      )
+    }
+
+    func clamped(point: CGPoint) -> CGPoint {
+      CGPoint(
+        x: min(max(point.x, appKitFrame.minX), appKitFrame.maxX),
+        y: min(max(point.y, appKitFrame.minY), appKitFrame.maxY)
+      )
+    }
+
+    func contains(point: CGPoint) -> Bool {
+      point.x >= appKitFrame.minX && point.x <= appKitFrame.maxX
+        && point.y >= appKitFrame.minY && point.y <= appKitFrame.maxY
+    }
+
+    private static func isValid(frame: CGRect) -> Bool {
+      frame.origin.x.isFinite && frame.origin.y.isFinite
+        && frame.size.width.isFinite && frame.size.height.isFinite
+        && frame.size.width > 0 && frame.size.height > 0
+    }
+
+    private static func isFinite(point: CGPoint) -> Bool {
+      point.x.isFinite && point.y.isFinite
+    }
+
+    private static func normalizedRect(from first: CGPoint, to second: CGPoint) -> CGRect {
+      CGRect(
+        x: min(first.x, second.x),
+        y: min(first.y, second.y),
+        width: abs(second.x - first.x),
+        height: abs(second.y - first.y)
+      )
+    }
+
+    private static func outwardRoundedPixelRect(_ rect: CGRect, scale: CGFloat) -> CGRect {
+      let minX = floor(rect.minX * scale)
+      let minY = floor(rect.minY * scale)
+      let maxX = ceil(rect.maxX * scale)
+      let maxY = ceil(rect.maxY * scale)
+      return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+  }
+
+  struct SelectionResult: Equatable {
+    let displayID: CGDirectDisplayID
+    let appKitGlobalRect: CGRect
+    let displayLocalRect: CGRect
+    let coreGraphicsGlobalRect: CGRect
+    let coreGraphicsDisplayLocalRect: CGRect
+    let backingPixelRect: CGRect
+  }
+
+  enum SelectionCancellationReason: String, Equatable {
+    case escape
+    case tooSmall
+    case displayChanged
+    case applicationTerminated
+  }
+
+  enum SelectionOutcome: Equatable {
+    case selected(SelectionResult)
+    case cancelled(SelectionCancellationReason)
+  }
+
+  final class SelectionSession {
+    private struct Drag {
+      let display: DisplayGeometry
+      let start: CGPoint
+      var current: CGPoint
+    }
+
+    private let displaysByID: [CGDirectDisplayID: DisplayGeometry]
+    private let completion: (SelectionOutcome) -> Void
+    private let minimumSize: CGFloat
+    private var drag: Drag?
+    private var hasCompleted = false
+
+    init(
+      displays: [DisplayGeometry],
+      minimumSize: CGFloat = 4,
+      completion: @escaping (SelectionOutcome) -> Void
+    ) {
+      displaysByID = Dictionary(uniqueKeysWithValues: displays.map { ($0.displayID, $0) })
+      self.minimumSize = minimumSize
+      self.completion = completion
+    }
+
+    var currentDisplayID: CGDirectDisplayID? {
+      drag?.display.displayID
+    }
+
+    var currentAppKitRect: CGRect? {
+      guard let drag else { return nil }
+      let start = drag.display.clamped(point: drag.start)
+      let current = drag.display.clamped(point: drag.current)
+      return CGRect(
+        x: min(start.x, current.x),
+        y: min(start.y, current.y),
+        width: abs(current.x - start.x),
+        height: abs(current.y - start.y)
+      )
+    }
+
+    func begin(on displayID: CGDirectDisplayID, at point: CGPoint) -> Bool {
+      guard !hasCompleted, drag == nil, let display = displaysByID[displayID],
+        display.contains(point: point)
+      else {
+        return false
+      }
+      drag = Drag(display: display, start: point, current: point)
+      return true
+    }
+
+    func update(to point: CGPoint) {
+      guard !hasCompleted, var drag else { return }
+      drag.current = drag.display.clamped(point: point)
+      self.drag = drag
+    }
+
+    func finish(at point: CGPoint) {
+      guard !hasCompleted, var drag else { return }
+      drag.current = drag.display.clamped(point: point)
+      self.drag = drag
+
+      do {
+        if let result = try drag.display.selectionResult(
+          from: drag.start,
+          to: drag.current,
+          minimumSize: minimumSize
+        ) {
+          complete(.selected(result))
+        } else {
+          complete(.cancelled(.tooSmall))
+        }
+      } catch {
+        complete(.cancelled(.displayChanged))
+      }
+    }
+
+    func cancel(_ reason: SelectionCancellationReason) {
+      complete(.cancelled(reason))
+    }
+
+    private func complete(_ outcome: SelectionOutcome) {
+      guard !hasCompleted else { return }
+      hasCompleted = true
+      drag = nil
+      completion(outcome)
+    }
+  }
+#endif

--- a/CopyLasso/SelectionOverlayController.swift
+++ b/CopyLasso/SelectionOverlayController.swift
@@ -1,0 +1,350 @@
+#if DEBUG
+  import AppKit
+  import CoreGraphics
+  import Foundation
+
+  enum SelectionOverlaySpikeError: Error, LocalizedError {
+    case noDisplays
+    case missingDisplayIdentifier
+    case invalidDisplayGeometry
+
+    var errorDescription: String? {
+      switch self {
+      case .noDisplays:
+        "No displays are available for selection."
+      case .missingDisplayIdentifier:
+        "A connected display did not provide a Core Graphics identifier."
+      case .invalidDisplayGeometry:
+        "A connected display reported invalid geometry."
+      }
+    }
+  }
+
+  struct LiveDisplayDescriptor: Identifiable, Equatable {
+    var id: CGDirectDisplayID { geometry.displayID }
+
+    let name: String
+    let geometry: DisplayGeometry
+    let backingConversionScale: CGFloat
+
+    var backingScaleMatchesConversion: Bool {
+      abs(geometry.backingScale - backingConversionScale) < 0.001
+    }
+
+    static func current() throws -> [LiveDisplayDescriptor] {
+      guard !NSScreen.screens.isEmpty else {
+        throw SelectionOverlaySpikeError.noDisplays
+      }
+
+      return try NSScreen.screens.map { screen in
+        let key = NSDeviceDescriptionKey("NSScreenNumber")
+        guard let number = screen.deviceDescription[key] as? NSNumber else {
+          throw SelectionOverlaySpikeError.missingDisplayIdentifier
+        }
+
+        let displayID = CGDirectDisplayID(number.uint32Value)
+        let geometry: DisplayGeometry
+        do {
+          geometry = try DisplayGeometry(
+            displayID: displayID,
+            appKitFrame: screen.frame,
+            coreGraphicsBounds: CGDisplayBounds(displayID),
+            backingScale: screen.backingScaleFactor
+          )
+        } catch {
+          throw SelectionOverlaySpikeError.invalidDisplayGeometry
+        }
+
+        let referenceRect = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let convertedRect = screen.convertRectToBacking(referenceRect)
+        return LiveDisplayDescriptor(
+          name: screen.localizedName,
+          geometry: geometry,
+          backingConversionScale: convertedRect.width / referenceRect.width
+        )
+      }
+    }
+  }
+
+  @MainActor
+  final class SelectionOverlayController: NSObject {
+    private struct Overlay {
+      let panel: SelectionOverlayPanel
+      let view: SelectionOverlayView
+      let descriptor: LiveDisplayDescriptor
+    }
+
+    private let screens: [NSScreen]
+    private let descriptors: [LiveDisplayDescriptor]
+    private let completion: (SelectionOutcome) -> Void
+    private var overlays: [Overlay] = []
+    private var session: SelectionSession?
+    private var started = false
+    private var isFinishing = false
+    private var pushedCrosshair = false
+
+    init(
+      screens: [NSScreen] = NSScreen.screens,
+      descriptors: [LiveDisplayDescriptor]? = nil,
+      completion: @escaping (SelectionOutcome) -> Void
+    ) throws {
+      guard !screens.isEmpty else {
+        throw SelectionOverlaySpikeError.noDisplays
+      }
+      let resolvedDescriptors = try descriptors ?? LiveDisplayDescriptor.current()
+      guard resolvedDescriptors.count == screens.count else {
+        throw SelectionOverlaySpikeError.invalidDisplayGeometry
+      }
+
+      self.screens = screens
+      self.descriptors = resolvedDescriptors
+      self.completion = completion
+      super.init()
+    }
+
+    func start() {
+      guard !started else { return }
+      started = true
+      session = SelectionSession(displays: descriptors.map(\.geometry)) { [weak self] outcome in
+        self?.finish(with: outcome)
+      }
+
+      overlays = zip(screens, descriptors).map { screen, descriptor in
+        let panel = SelectionOverlayPanel(screen: screen)
+        let view = SelectionOverlayView(
+          frame: CGRect(origin: .zero, size: screen.frame.size),
+          displayID: descriptor.id,
+          displayFrame: descriptor.geometry.appKitFrame,
+          controller: self
+        )
+        panel.contentView = view
+        return Overlay(panel: panel, view: view, descriptor: descriptor)
+      }
+
+      NotificationCenter.default.addObserver(
+        self,
+        selector: #selector(screenParametersDidChange),
+        name: NSApplication.didChangeScreenParametersNotification,
+        object: nil
+      )
+      NotificationCenter.default.addObserver(
+        self,
+        selector: #selector(applicationWillTerminate),
+        name: NSApplication.willTerminateNotification,
+        object: nil
+      )
+
+      NSCursor.crosshair.push()
+      pushedCrosshair = true
+      for overlay in overlays {
+        overlay.panel.orderFrontRegardless()
+      }
+
+      let pointer = NSEvent.mouseLocation
+      if let pointerOverlay = overlays.first(where: {
+        $0.descriptor.geometry.contains(point: pointer)
+      }) {
+        pointerOverlay.panel.makeKey()
+        pointerOverlay.panel.makeFirstResponder(pointerOverlay.view)
+      }
+      NSCursor.crosshair.set()
+    }
+
+    func mouseDown(at point: CGPoint, on displayID: CGDirectDisplayID) {
+      guard !isFinishing, session?.begin(on: displayID, at: point) == true else { return }
+      if let overlay = overlays.first(where: { $0.descriptor.id == displayID }) {
+        overlay.panel.makeKey()
+        overlay.panel.makeFirstResponder(overlay.view)
+      }
+      updateOverlayViews()
+    }
+
+    func mouseDragged(to point: CGPoint) {
+      guard !isFinishing else { return }
+      session?.update(to: point)
+      updateOverlayViews()
+    }
+
+    func mouseUp(at point: CGPoint) {
+      guard !isFinishing else { return }
+      session?.finish(at: point)
+    }
+
+    func cancelWithEscape() {
+      session?.cancel(.escape)
+    }
+
+    private func updateOverlayViews() {
+      let initiatingDisplayID = session?.currentDisplayID
+      let selectionRect = session?.currentAppKitRect
+      for overlay in overlays {
+        overlay.view.selectionRect =
+          overlay.descriptor.id == initiatingDisplayID ? selectionRect : nil
+      }
+    }
+
+    private func finish(with outcome: SelectionOutcome) {
+      guard !isFinishing else { return }
+      isFinishing = true
+      cleanupOverlays()
+
+      precondition(
+        overlays.allSatisfy { !$0.panel.isVisible },
+        "Selection overlay panels must be hidden before completion"
+      )
+
+      Task { @MainActor [completion] in
+        await Task.yield()
+        completion(outcome)
+      }
+    }
+
+    private func cleanupOverlays() {
+      NotificationCenter.default.removeObserver(self)
+      for overlay in overlays {
+        overlay.view.selectionRect = nil
+        overlay.panel.orderOut(nil)
+      }
+      if pushedCrosshair {
+        NSCursor.pop()
+        pushedCrosshair = false
+      }
+    }
+
+    @objc private func screenParametersDidChange() {
+      session?.cancel(.displayChanged)
+    }
+
+    @objc private func applicationWillTerminate() {
+      session?.cancel(.applicationTerminated)
+    }
+
+    deinit {
+      NotificationCenter.default.removeObserver(self)
+    }
+  }
+
+  @MainActor
+  private final class SelectionOverlayPanel: NSPanel {
+    init(screen: NSScreen) {
+      super.init(
+        contentRect: screen.frame,
+        styleMask: [.borderless, .nonactivatingPanel],
+        backing: .buffered,
+        defer: false
+      )
+      level = .screenSaver
+      collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
+      isOpaque = false
+      backgroundColor = .clear
+      hasShadow = false
+      hidesOnDeactivate = false
+      ignoresMouseEvents = false
+      animationBehavior = .none
+      isReleasedWhenClosed = false
+      acceptsMouseMovedEvents = true
+    }
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+  }
+
+  @MainActor
+  private final class SelectionOverlayView: NSView {
+    let displayID: CGDirectDisplayID
+    let displayFrame: CGRect
+    weak var controller: SelectionOverlayController?
+
+    var selectionRect: CGRect? {
+      didSet { needsDisplay = true }
+    }
+
+    init(
+      frame: CGRect,
+      displayID: CGDirectDisplayID,
+      displayFrame: CGRect,
+      controller: SelectionOverlayController
+    ) {
+      self.displayID = displayID
+      self.displayFrame = displayFrame
+      self.controller = controller
+      super.init(frame: frame)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func resetCursorRects() {
+      addCursorRect(bounds, cursor: .crosshair)
+    }
+
+    override func cursorUpdate(with event: NSEvent) {
+      NSCursor.crosshair.set()
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+      NSCursor.crosshair.set()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+      NSCursor.crosshair.set()
+      guard let point = globalPoint(for: event) else { return }
+      controller?.mouseDown(at: point, on: displayID)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+      NSCursor.crosshair.set()
+      guard let point = globalPoint(for: event) else { return }
+      controller?.mouseDragged(to: point)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+      guard let point = globalPoint(for: event) else { return }
+      controller?.mouseUp(at: point)
+    }
+
+    override func keyDown(with event: NSEvent) {
+      if event.keyCode == 53 || event.charactersIgnoringModifiers == "\u{1b}" {
+        controller?.cancelWithEscape()
+      } else {
+        super.keyDown(with: event)
+      }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+      super.draw(dirtyRect)
+      guard let selectionRect else { return }
+
+      let localSelection = selectionRect.offsetBy(
+        dx: -displayFrame.minX,
+        dy: -displayFrame.minY
+      )
+      guard let context = NSGraphicsContext.current?.cgContext else { return }
+
+      context.saveGState()
+      context.setFillColor(NSColor.black.withAlphaComponent(0.18).cgColor)
+      context.fill(bounds)
+      context.setBlendMode(.clear)
+      context.fill(localSelection)
+      context.restoreGState()
+
+      let borderRect = localSelection.insetBy(dx: 1.5, dy: 1.5)
+      let border = NSBezierPath(rect: borderRect)
+      border.lineJoinStyle = .miter
+      border.lineWidth = 3
+      NSColor.black.setStroke()
+      border.stroke()
+      border.lineWidth = 1
+      NSColor.white.setStroke()
+      border.stroke()
+    }
+
+    private func globalPoint(for event: NSEvent) -> CGPoint? {
+      window?.convertPoint(toScreen: event.locationInWindow)
+    }
+  }
+#endif

--- a/CopyLasso/SelectionOverlaySpikeView.swift
+++ b/CopyLasso/SelectionOverlaySpikeView.swift
@@ -1,0 +1,244 @@
+#if DEBUG
+  import AppKit
+  import Combine
+  import SwiftUI
+
+  @MainActor
+  final class SelectionOverlaySpikeModel: ObservableObject {
+    @Published private(set) var displays: [LiveDisplayDescriptor] = []
+    @Published private(set) var lastOutcome: SelectionOutcome?
+    @Published private(set) var focusWasPreserved: Bool?
+    @Published private(set) var errorMessage: String?
+    @Published private(set) var isWaiting = false
+    @Published private(set) var isSelecting = false
+
+    private var overlayController: SelectionOverlayController?
+    private var delayedTask: Task<Void, Never>?
+
+    init() {
+      refreshDisplays()
+    }
+
+    var screensHaveSeparateSpaces: Bool {
+      NSScreen.screensHaveSeparateSpaces
+    }
+
+    func beginNow() {
+      delayedTask?.cancel()
+      delayedTask = nil
+      isWaiting = false
+      guard overlayController == nil else { return }
+
+      refreshDisplays()
+      let frontmostProcessIdentifier = NSWorkspace.shared.frontmostApplication?.processIdentifier
+      do {
+        let controller = try SelectionOverlayController { [weak self] outcome in
+          guard let self else { return }
+          lastOutcome = outcome
+          let currentIdentifier = NSWorkspace.shared.frontmostApplication?.processIdentifier
+          focusWasPreserved = frontmostProcessIdentifier == currentIdentifier
+          isSelecting = false
+          overlayController = nil
+          refreshDisplays()
+        }
+        overlayController = controller
+        isSelecting = true
+        errorMessage = nil
+        controller.start()
+      } catch {
+        errorMessage = error.localizedDescription
+        isSelecting = false
+      }
+    }
+
+    func beginAfterFiveSeconds() {
+      guard overlayController == nil, delayedTask == nil else { return }
+      isWaiting = true
+      errorMessage = nil
+      delayedTask = Task { @MainActor [weak self] in
+        do {
+          try await Task.sleep(for: .seconds(5))
+        } catch {
+          return
+        }
+        guard let self else { return }
+        delayedTask = nil
+        isWaiting = false
+        beginNow()
+      }
+    }
+
+    func stop() {
+      delayedTask?.cancel()
+      delayedTask = nil
+      isWaiting = false
+      overlayController?.cancelWithEscape()
+    }
+
+    private func refreshDisplays() {
+      do {
+        displays = try LiveDisplayDescriptor.current()
+        errorMessage = nil
+      } catch {
+        displays = []
+        errorMessage = error.localizedDescription
+      }
+    }
+  }
+
+  struct SelectionOverlaySpikeView: View {
+    @StateObject private var model = SelectionOverlaySpikeModel()
+
+    var body: some View {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 16) {
+          Text("G07 Selection Overlay Spike")
+            .font(.title)
+            .accessibilityIdentifier("copylasso.selection-spike.title")
+
+          Text(
+            "Debug-only geometry proof. The overlay does not capture pixels, run OCR, or change the clipboard."
+          )
+          .foregroundStyle(.secondary)
+
+          calibrationCard
+
+          HStack {
+            Button("Begin Selection Now") {
+              model.beginNow()
+            }
+            .accessibilityIdentifier("copylasso.selection-spike.begin-now")
+
+            Button("Begin in 5 Seconds") {
+              model.beginAfterFiveSeconds()
+            }
+            .accessibilityIdentifier("copylasso.selection-spike.begin-delayed")
+          }
+          .disabled(model.isSelecting || model.isWaiting)
+
+          if model.isWaiting {
+            ProgressView("Selection begins in 5 seconds…")
+          } else if model.isSelecting {
+            Text("Drag on any display, or press Escape to cancel.")
+              .foregroundStyle(.secondary)
+          }
+
+          displayInventory
+          outcomeView
+
+          if let errorMessage = model.errorMessage {
+            Text(errorMessage)
+              .foregroundStyle(.red)
+              .accessibilityIdentifier("copylasso.selection-spike.error")
+          }
+        }
+        .padding(20)
+      }
+      .frame(minWidth: 860, minHeight: 700)
+      .task {
+        NSApplication.shared.windows.first?.center()
+      }
+      .onDisappear {
+        model.stop()
+      }
+    }
+
+    private var calibrationCard: some View {
+      HStack(spacing: 0) {
+        VStack(spacing: 0) {
+          Rectangle().fill(.blue)
+          Rectangle().fill(.orange)
+        }
+        VStack(spacing: 0) {
+          Rectangle().fill(.green)
+          Rectangle().fill(.purple)
+        }
+        Text("COPYLASSO\nG07\n320 × 180 pt")
+          .font(.system(size: 20, weight: .bold, design: .monospaced))
+          .multilineTextAlignment(.center)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .background(.white)
+          .foregroundStyle(.black)
+      }
+      .frame(width: 320, height: 180)
+      .clipShape(RoundedRectangle(cornerRadius: 8))
+      .overlay(RoundedRectangle(cornerRadius: 8).stroke(.primary, lineWidth: 2))
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel("CopyLasso G07 calibration card, 320 by 180 points")
+      .accessibilityIdentifier("copylasso.selection-spike.calibration")
+    }
+
+    private var displayInventory: some View {
+      GroupBox("Current displays") {
+        VStack(alignment: .leading, spacing: 10) {
+          Text("Separate Spaces: \(model.screensHaveSeparateSpaces ? "enabled" : "disabled")")
+          ForEach(model.displays) { display in
+            Text(displaySummary(display))
+              .font(.system(.caption, design: .monospaced))
+              .textSelection(.enabled)
+          }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+      }
+    }
+
+    @ViewBuilder
+    private var outcomeView: some View {
+      GroupBox("Last outcome") {
+        if let outcome = model.lastOutcome {
+          VStack(alignment: .leading, spacing: 6) {
+            switch outcome {
+            case .selected(let result):
+              Text("Selected display ID: \(result.displayID)")
+                .accessibilityIdentifier("copylasso.selection-spike.selected")
+              rectRow("AppKit global", result.appKitGlobalRect)
+              rectRow("Display local", result.displayLocalRect)
+              rectRow("Core Graphics global", result.coreGraphicsGlobalRect)
+              rectRow("Core Graphics local", result.coreGraphicsDisplayLocalRect)
+              rectRow("Backing pixels", result.backingPixelRect)
+            case .cancelled(let reason):
+              Text("Cancelled: \(reason.rawValue)")
+                .accessibilityIdentifier("copylasso.selection-spike.cancelled")
+            }
+            if let focusWasPreserved = model.focusWasPreserved {
+              Text("Frontmost application preserved: \(focusWasPreserved ? "yes" : "no")")
+            }
+          }
+          .font(.system(.body, design: .monospaced))
+          .textSelection(.enabled)
+          .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+          Text("No selection has been attempted.")
+            .foregroundStyle(.secondary)
+            .accessibilityIdentifier("copylasso.selection-spike.no-outcome")
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+      }
+    }
+
+    private func rectRow(_ label: String, _ rect: CGRect) -> some View {
+      Text("\(label): \(format(rect))")
+    }
+
+    private func displaySummary(_ display: LiveDisplayDescriptor) -> String {
+      let geometry = display.geometry
+      return
+        "\(display.name) | ID \(display.id) | AppKit \(format(geometry.appKitFrame)) | CG \(format(geometry.coreGraphicsBounds)) | scale \(format(geometry.backingScale))× | backing check \(format(display.backingConversionScale))× \(display.backingScaleMatchesConversion ? "match" : "MISMATCH")"
+    }
+
+    private func format(_ rect: CGRect) -> String {
+      String(
+        format: "x %.2f, y %.2f, w %.2f, h %.2f",
+        locale: Locale(identifier: "en_US_POSIX"),
+        rect.origin.x,
+        rect.origin.y,
+        rect.width,
+        rect.height
+      )
+    }
+
+    private func format(_ value: CGFloat) -> String {
+      String(format: "%.2f", locale: Locale(identifier: "en_US_POSIX"), value)
+    }
+  }
+#endif

--- a/CopyLassoTests/SelectionOverlaySpikeTests.swift
+++ b/CopyLassoTests/SelectionOverlaySpikeTests.swift
@@ -1,0 +1,289 @@
+import CoreGraphics
+import XCTest
+
+@testable import CopyLasso
+
+final class SelectionOverlaySpikeTests: XCTestCase {
+  func testForwardAndReverseDragsProduceTheSameSelection() throws {
+    let display = try makeDisplay()
+
+    let forward = try XCTUnwrap(
+      display.selectionResult(
+        from: CGPoint(x: 10, y: 20),
+        to: CGPoint(x: 50, y: 70)
+      )
+    )
+    let reverse = try XCTUnwrap(
+      display.selectionResult(
+        from: CGPoint(x: 50, y: 70),
+        to: CGPoint(x: 10, y: 20)
+      )
+    )
+
+    XCTAssertEqual(forward, reverse)
+    XCTAssertEqual(forward.appKitGlobalRect, CGRect(x: 10, y: 20, width: 40, height: 50))
+    XCTAssertEqual(forward.displayLocalRect, CGRect(x: 10, y: 20, width: 40, height: 50))
+    XCTAssertEqual(
+      forward.coreGraphicsDisplayLocalRect,
+      CGRect(x: 10, y: 30, width: 40, height: 50)
+    )
+  }
+
+  func testEndpointsClampToEveryDisplayEdge() throws {
+    let display = try makeDisplay()
+    let cases: [(CGPoint, CGRect)] = [
+      (CGPoint(x: -20, y: 60), CGRect(x: 0, y: 50, width: 50, height: 10)),
+      (CGPoint(x: 120, y: 60), CGRect(x: 50, y: 50, width: 50, height: 10)),
+      (CGPoint(x: 60, y: -20), CGRect(x: 50, y: 0, width: 10, height: 50)),
+      (CGPoint(x: 60, y: 120), CGRect(x: 50, y: 50, width: 10, height: 50)),
+    ]
+
+    for (endpoint, expected) in cases {
+      let result = try XCTUnwrap(
+        display.selectionResult(from: CGPoint(x: 50, y: 50), to: endpoint)
+      )
+      XCTAssertEqual(result.appKitGlobalRect, expected)
+    }
+  }
+
+  func testCrossDisplayEndpointClampsToInitiatingDisplay() throws {
+    let display = try makeDisplay(
+      appKitFrame: CGRect(x: -100, y: 25, width: 100, height: 100),
+      coreGraphicsBounds: CGRect(x: -100, y: 0, width: 100, height: 100)
+    )
+
+    let result = try XCTUnwrap(
+      display.selectionResult(from: CGPoint(x: -50, y: 75), to: CGPoint(x: 500, y: 500))
+    )
+
+    XCTAssertEqual(result.appKitGlobalRect, CGRect(x: -50, y: 75, width: 50, height: 50))
+    XCTAssertEqual(result.displayLocalRect, CGRect(x: 50, y: 50, width: 50, height: 50))
+  }
+
+  func testNegativeCoordinateDisplayUsesItsOwnCoreGraphicsOrigin() throws {
+    let display = try makeDisplay(
+      id: 42,
+      appKitFrame: CGRect(x: -200, y: -50, width: 200, height: 100),
+      coreGraphicsBounds: CGRect(x: -200, y: 30, width: 200, height: 100)
+    )
+
+    let result = try XCTUnwrap(
+      display.selectionResult(from: CGPoint(x: -180, y: -40), to: CGPoint(x: -100, y: 20))
+    )
+
+    XCTAssertEqual(result.displayID, 42)
+    XCTAssertEqual(result.displayLocalRect, CGRect(x: 20, y: 10, width: 80, height: 60))
+    XCTAssertEqual(
+      result.coreGraphicsDisplayLocalRect,
+      CGRect(x: 20, y: 30, width: 80, height: 60)
+    )
+    XCTAssertEqual(
+      result.coreGraphicsGlobalRect,
+      CGRect(x: -180, y: 60, width: 80, height: 60)
+    )
+  }
+
+  func testYFlipIsDisplayLocalForDisplaysAboveBelowAndBesidePrimary() throws {
+    let frames = [
+      (
+        CGRect(x: 0, y: 100, width: 100, height: 100),
+        CGRect(x: 0, y: -100, width: 100, height: 100)
+      ),
+      (
+        CGRect(x: 0, y: -100, width: 100, height: 100),
+        CGRect(x: 0, y: 100, width: 100, height: 100)
+      ),
+      (
+        CGRect(x: -100, y: 0, width: 100, height: 100),
+        CGRect(x: -100, y: 0, width: 100, height: 100)
+      ),
+    ]
+
+    for (appKitFrame, coreGraphicsBounds) in frames {
+      let display = try makeDisplay(
+        appKitFrame: appKitFrame,
+        coreGraphicsBounds: coreGraphicsBounds
+      )
+      let result = try XCTUnwrap(
+        display.selectionResult(
+          from: CGPoint(x: appKitFrame.minX + 10, y: appKitFrame.minY + 20),
+          to: CGPoint(x: appKitFrame.minX + 30, y: appKitFrame.minY + 50)
+        )
+      )
+
+      XCTAssertEqual(
+        result.coreGraphicsDisplayLocalRect,
+        CGRect(x: 10, y: 50, width: 20, height: 30)
+      )
+      XCTAssertEqual(
+        result.coreGraphicsGlobalRect,
+        CGRect(
+          x: coreGraphicsBounds.minX + 10,
+          y: coreGraphicsBounds.minY + 50,
+          width: 20,
+          height: 30
+        )
+      )
+    }
+  }
+
+  func testBackingPixelConversionSupportsOneOnePointFiveAndTwoX() throws {
+    let appKitRect = CGRect(x: 10.2, y: 40.6, width: 20.2, height: 39.2)
+    let expected: [(CGFloat, CGRect)] = [
+      (1, CGRect(x: 10, y: 20, width: 21, height: 40)),
+      (1.5, CGRect(x: 15, y: 30, width: 31, height: 60)),
+      (2, CGRect(x: 20, y: 40, width: 41, height: 79)),
+    ]
+
+    for (scale, expectedPixels) in expected {
+      let display = try makeDisplay(scale: scale)
+      let result = try XCTUnwrap(
+        display.selectionResult(
+          from: appKitRect.origin,
+          to: CGPoint(x: appKitRect.maxX, y: appKitRect.maxY)
+        )
+      )
+      XCTAssertEqual(result.backingPixelRect, expectedPixels)
+    }
+  }
+
+  func testSidecarStyleGeometryDoesNotDependOnRuntimeDisplayID() throws {
+    let display = try makeDisplay(
+      id: 9_999,
+      appKitFrame: CGRect(x: -1298, y: 126, width: 1298, height: 954),
+      coreGraphicsBounds: CGRect(x: -1298, y: 0, width: 1298, height: 954),
+      scale: 2
+    )
+
+    let result = try XCTUnwrap(
+      display.selectionResult(from: CGPoint(x: -1200, y: 200), to: CGPoint(x: -1000, y: 400))
+    )
+
+    XCTAssertEqual(result.displayID, 9_999)
+    XCTAssertEqual(result.displayLocalRect, CGRect(x: 98, y: 74, width: 200, height: 200))
+    XCTAssertEqual(
+      result.coreGraphicsDisplayLocalRect,
+      CGRect(x: 98, y: 680, width: 200, height: 200)
+    )
+    XCTAssertEqual(
+      result.coreGraphicsGlobalRect,
+      CGRect(x: -1200, y: 680, width: 200, height: 200)
+    )
+    XCTAssertEqual(result.backingPixelRect, CGRect(x: 196, y: 1360, width: 400, height: 400))
+  }
+
+  func testExactlyFourPointsIsAcceptedAndSmallerDimensionCancels() throws {
+    let display = try makeDisplay()
+
+    XCTAssertNotNil(
+      try display.selectionResult(from: CGPoint(x: 10, y: 10), to: CGPoint(x: 14, y: 14))
+    )
+    XCTAssertNil(
+      try display.selectionResult(from: CGPoint(x: 10, y: 10), to: CGPoint(x: 13.999, y: 20))
+    )
+    XCTAssertNil(
+      try display.selectionResult(from: CGPoint(x: 10, y: 10), to: CGPoint(x: 20, y: 13.999))
+    )
+  }
+
+  func testInvalidDisplayGeometryIsRejected() {
+    let invalidFrames = [
+      CGRect(x: 0, y: 0, width: 0, height: 100),
+      CGRect(x: 0, y: 0, width: 100, height: -1),
+      CGRect(x: CGFloat.infinity, y: 0, width: 100, height: 100),
+    ]
+
+    for frame in invalidFrames {
+      XCTAssertThrowsError(
+        try makeDisplay(appKitFrame: frame)
+      )
+      XCTAssertThrowsError(
+        try makeDisplay(coreGraphicsBounds: frame)
+      )
+    }
+    XCTAssertThrowsError(try makeDisplay(scale: 0))
+    XCTAssertThrowsError(try makeDisplay(scale: -1))
+    XCTAssertThrowsError(try makeDisplay(scale: .infinity))
+  }
+
+  func testSessionCompletesAValidSelectionExactlyOnce() throws {
+    let display = try makeDisplay()
+    var outcomes: [SelectionOutcome] = []
+    let session = SelectionSession(displays: [display]) { outcomes.append($0) }
+
+    XCTAssertTrue(session.begin(on: display.displayID, at: CGPoint(x: 10, y: 10)))
+    session.update(to: CGPoint(x: 30, y: 40))
+    session.finish(at: CGPoint(x: 50, y: 60))
+    session.cancel(.escape)
+    session.finish(at: CGPoint(x: 80, y: 80))
+
+    XCTAssertEqual(outcomes.count, 1)
+    guard case .selected(let result) = outcomes[0] else {
+      return XCTFail("Expected a selection")
+    }
+    XCTAssertEqual(result.appKitGlobalRect, CGRect(x: 10, y: 10, width: 40, height: 50))
+  }
+
+  func testSessionReportsTooSmallAsCancellation() throws {
+    let display = try makeDisplay()
+    var outcome: SelectionOutcome?
+    let session = SelectionSession(displays: [display]) { outcome = $0 }
+
+    XCTAssertTrue(session.begin(on: display.displayID, at: CGPoint(x: 10, y: 10)))
+    session.finish(at: CGPoint(x: 12, y: 40))
+
+    XCTAssertEqual(outcome, .cancelled(.tooSmall))
+  }
+
+  func testEscapeBeforeAndDuringDragCancels() throws {
+    let display = try makeDisplay()
+
+    for beginDrag in [false, true] {
+      var outcome: SelectionOutcome?
+      let session = SelectionSession(displays: [display]) { outcome = $0 }
+      if beginDrag {
+        XCTAssertTrue(session.begin(on: display.displayID, at: CGPoint(x: 10, y: 10)))
+        session.update(to: CGPoint(x: 30, y: 40))
+      }
+      session.cancel(.escape)
+      XCTAssertEqual(outcome, .cancelled(.escape))
+    }
+  }
+
+  func testDisplayChangeAndApplicationTerminationCancelExactlyOnce() throws {
+    let display = try makeDisplay()
+
+    for reason in [SelectionCancellationReason.displayChanged, .applicationTerminated] {
+      var outcomes: [SelectionOutcome] = []
+      let session = SelectionSession(displays: [display]) { outcomes.append($0) }
+      XCTAssertTrue(session.begin(on: display.displayID, at: CGPoint(x: 10, y: 10)))
+      session.cancel(reason)
+      session.cancel(reason)
+      XCTAssertEqual(outcomes, [.cancelled(reason)])
+    }
+  }
+
+  func testSessionRejectsUnknownDisplayAndTracksClampedDragRect() throws {
+    let display = try makeDisplay()
+    let session = SelectionSession(displays: [display]) { _ in }
+
+    XCTAssertFalse(session.begin(on: 999, at: .zero))
+    XCTAssertTrue(session.begin(on: display.displayID, at: CGPoint(x: 40, y: 40)))
+    session.update(to: CGPoint(x: 200, y: -100))
+    XCTAssertEqual(session.currentAppKitRect, CGRect(x: 40, y: 0, width: 60, height: 40))
+  }
+
+  private func makeDisplay(
+    id: CGDirectDisplayID = 1,
+    appKitFrame: CGRect = CGRect(x: 0, y: 0, width: 100, height: 100),
+    coreGraphicsBounds: CGRect = CGRect(x: 0, y: 0, width: 100, height: 100),
+    scale: CGFloat = 1
+  ) throws -> DisplayGeometry {
+    try DisplayGeometry(
+      displayID: id,
+      appKitFrame: appKitFrame,
+      coreGraphicsBounds: coreGraphicsBounds,
+      backingScale: scale
+    )
+  }
+}

--- a/CopyLassoUITests/CopyLassoUITests.swift
+++ b/CopyLassoUITests/CopyLassoUITests.swift
@@ -26,4 +26,16 @@ final class CopyLassoUITests: XCTestCase {
     XCTAssertTrue(app.buttons["copylasso.capture-spike.clear"].exists)
     XCTAssertTrue(app.buttons["copylasso.capture-spike.reset-history"].exists)
   }
+
+  @MainActor
+  func testSelectionOverlaySpikeHarnessLaunchesWithoutPresentingOverlay() {
+    let app = XCUIApplication()
+    app.launchArguments = ["--g07-selection-spike"]
+    app.launch()
+
+    XCTAssertTrue(app.staticTexts["copylasso.selection-spike.title"].waitForExistence(timeout: 5))
+    XCTAssertTrue(app.buttons["copylasso.selection-spike.begin-now"].exists)
+    XCTAssertTrue(app.buttons["copylasso.selection-spike.begin-delayed"].exists)
+    XCTAssertTrue(app.staticTexts["copylasso.selection-spike.no-outcome"].exists)
+  }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CopyLasso is a free, open-source macOS utility for copying visible text from anywhere on screen. Press a global shortcut, drag around text, and receive the recognized plain text on the clipboard.
 
-> **Project status:** CopyLasso is in early pre-release development. The repository contains a buildable placeholder application plus successful internal OCR and screen-capture feasibility experiments, but production capture, the OCR workflow, and the intended menu-bar experience are not implemented, and no public release is available.
+> **Project status:** CopyLasso is in early pre-release development. The repository contains a buildable placeholder application plus successful internal OCR, screen-capture, and multi-display selection feasibility experiments, but the production workflow and intended menu-bar experience are not implemented, and no public release is available.
 
 ## Planned v0.1 Experience
 

--- a/docs/architecture/ADR-003-selection-overlay.md
+++ b/docs/architecture/ADR-003-selection-overlay.md
@@ -1,0 +1,91 @@
+# ADR-003: AppKit Overlay and Per-Display Geometry Are Viable
+
+- **Status:** Accepted
+- **Date:** July 10, 2026
+- **Scope:** G07 feasibility spike; production selection remains deferred to G13 and region capture to G14
+
+## Context
+
+CopyLasso must let a user begin a rectangular selection on any attached display without activating the app, dimming unrelated displays, or including the overlay in the later capture. AppKit and Core Graphics describe the same display with different origins and Y-axis conventions, and backing pixels may use a nonintegral scale. G07 tests the windowing and geometry assumptions before they become production architecture.
+
+The experiment is Debug-only and is launched explicitly with `--g07-selection-spike`. Launching it presents a diagnostic window but does not present overlays. It never captures pixels, calls Vision, writes the clipboard, or persists selection data.
+
+## Decision
+
+The AppKit approach is viable. CopyLasso will use one transparent, borderless `NSPanel` per `NSScreen` during selection. Each panel:
+
+- uses [`.nonactivatingPanel`](https://developer.apple.com/documentation/appkit/nswindow/stylemask-swift.struct/nonactivatingpanel) so the user's frontmost application stays active;
+- covers the complete `NSScreen.frame`, including menu-bar and Dock regions;
+- uses `.canJoinAllSpaces`, `.fullScreenAuxiliary`, and `.ignoresCycle` [collection behaviors](https://developer.apple.com/documentation/appkit/nswindow/collectionbehavior-swift.struct);
+- sits at screen-saver level and does not enter normal window cycling;
+- is visually clear before mouse-down;
+- displays a crosshair and, while dragging, dims only the initiating display outside the selection with 18% black; and
+- draws a black-and-white selection border that remains visible over light and dark content.
+
+The panel under the pointer becomes key and explicitly makes its overlay view first responder without activating CopyLasso. This gives Escape a deterministic path before or during a drag. A drag remains owned by its initiating display; moving the pointer onto another display clamps the endpoint to the initiating display edge. Unrelated display panels remain fully transparent.
+
+The spike intentionally does not set `NSWindow.SharingType.none`. Apple now documents [`none`](https://developer.apple.com/documentation/appkit/nswindow/sharingtype-swift.enum/none) as a legacy value that should not be used to hide a window from screen capture.
+
+## Coordinate Conventions
+
+`DisplayGeometry` stores the stable `CGDirectDisplayID`, the AppKit global frame, the matching `CGDisplayBounds`, and [`NSScreen.backingScaleFactor`](https://developer.apple.com/documentation/appkit/nsscreen/backingscalefactor). A result contains these representations:
+
+| Representation | Origin and orientation |
+| --- | --- |
+| AppKit global | Bottom-left, in the virtual desktop |
+| Display local | Bottom-left, relative to the initiating `NSScreen` |
+| Core Graphics global | Top-left, offset by that display's `CGDisplayBounds` origin |
+| Core Graphics display local | Top-left, relative to the initiating display |
+| Backing pixels | Core Graphics display-local coordinates, outward rounded |
+
+Conversion is per display rather than based on the primary display:
+
+1. Clamp both endpoints to the initiating AppKit frame and normalize forward or reverse drags.
+2. Subtract the AppKit frame origin to obtain the display-local bottom-left rectangle.
+3. Flip local Y with `displayHeight - localRect.maxY`.
+4. Add that display's Core Graphics bounds origin for the global top-left rectangle.
+5. Multiply the local top-left rectangle by the backing scale, using `floor` for minimum edges and `ceil` for maximum edges so partially covered pixels are included.
+
+The harness cross-checks the reported backing scale against `NSScreen.convertRectToBacking`. Invalid frames, nonfinite coordinates, and nonpositive scales are rejected. Unit tests cover 1×, 1.5×, and 2× scaling; negative origins; displays above, below, and beside the primary; all edge clamps; and the current Sidecar-style offset shape without embedding its runtime display identifier.
+
+## Completion and Cancellation
+
+A selection is valid only when both width and height are at least 4 points; exactly 4 points is accepted. A click or smaller drag is a normal `.tooSmall` cancellation. Escape, display reconfiguration, and application termination are also normal cancellation outcomes rather than application errors.
+
+Every path completes at most once. On mouse-up or cancellation, the controller synchronously:
+
+1. removes display and termination observers;
+2. clears overlay drawing state;
+3. orders out every panel;
+4. restores the cursor stack;
+5. verifies that no panel remains visible; and
+6. delivers only the geometry outcome on the next main-actor turn.
+
+That order establishes the G14 boundary: a future capture may begin only from the completion callback, after the overlay is absent. The G07 spike itself never performs capture.
+
+## Live Evidence
+
+The signed Debug experiment was exercised on macOS 26.5.1 (`25F80`) with Xcode 26.6 (`17F113`) and these freshly enumerated displays:
+
+| Display | Runtime ID | AppKit frame | Core Graphics bounds | Scale and backing check |
+| --- | ---: | --- | --- | --- |
+| Dell S2721HGF | `4` | `(0, 0, 1920, 1080)` | `(0, 0, 1920, 1080)` | 1×, matched |
+| Sidecar Display (AirPlay) | `11` | `(-1298, 126, 1298, 954)` | `(-1298, 0, 1298, 954)` | 2×, matched |
+
+Runtime identifiers are evidence only and are not hardcoded in the app or tests. The in-app readback reported that the workstation currently uses separate Spaces per display.
+
+On the Dell, a known 320 × 180-point forward drag reported AppKit global `(500, 650, 320, 180)`, Core Graphics global `(500, 250, 320, 180)`, and backing pixels `(500, 250, 320, 180)`. The frontmost application remained unchanged. Forward and reverse drags, click and tiny-drag cancellation, Escape before and during a drag, and every outer edge clamp completed without leaving a panel visible.
+
+On Sidecar, a hand-driven selection reported display ID `11`, AppKit global `(-1129.42, 740.02, 211.03, 192.09)`, Core Graphics global `(-1129.42, 147.89, 211.03, 192.09)`, and outward-rounded backing pixels `(337, 295, 423, 385)`. This matches the 2× scale. The frontmost application remained unchanged. Hand-driven drags in both cross-display directions stopped the border at the initiating display edge and dimmed only that display, as designed. Pressing Escape during a hand-driven drag immediately removed the dim and border, reported `.escape`, preserved focus, and ignored the later mouse-up.
+
+At Dell 1600 × 900 and 144 Hz, live descriptors rebuilt to `(0, 0, 1600, 900)` and the Sidecar AppKit origin adjusted to `(-1298, -54)`. A new 320 × 180-point selection still produced an exact 320 × 180-pixel result. The Dell was then restored to 1920 × 1080 at 144 Hz, and both displays returned to the frames recorded above.
+
+With TextEdit in a separate full-screen Space, the five-second trigger left the panel transparent until mouse-down, changed the cursor to a crosshair, and then displayed the expected initiating-display dim and border over TextEdit. It did not switch Spaces or bring CopyLasso forward. Final inspection found no CopyLasso process or window after termination, and no panel, dim, border, or crosshair remained after any completed or cancelled session.
+
+## Consequences and Limits
+
+- G13 may turn the proven behavior into production selection architecture without changing the coordinate contract.
+- G14 must capture only after the selection completion callback and must use the selected display's local Core Graphics rectangle.
+- Display configuration changes cancel the current session; production code must rebuild descriptors before another selection.
+- Full hardening across more physical arrangements, display rotations, and macOS versions remains G19 and G29 work.
+- G07 introduces no public API, dependency, permission request, pixel capture, OCR integration, clipboard behavior, onboarding, or production UI.

--- a/docs/architecture/build-configuration.md
+++ b/docs/architecture/build-configuration.md
@@ -10,7 +10,7 @@ The shared `CopyLasso` scheme contains:
 - `CopyLassoTests`, the XCTest unit-test bundle; and
 - `CopyLassoUITests`, the XCTest UI-test bundle.
 
-The normal application currently presents only a placeholder window. Debug builds also contain internal OCR and screen-capture feasibility experiments; they are not production flows. Menu-bar behavior, global shortcuts, user-facing capture, onboarding, settings, and login-at-launch behavior remain unimplemented.
+The normal application currently presents only a placeholder window. Debug builds also contain internal OCR, screen-capture, and selection-overlay feasibility experiments; they are not production flows. Menu-bar behavior, global shortcuts, user-facing capture, onboarding, settings, and login-at-launch behavior remain unimplemented.
 
 ## Supported Configuration
 
@@ -29,6 +29,8 @@ The normal application currently presents only a placeholder window. Debug build
 | Hardened Runtime | Enabled |
 
 Release builds explicitly set both macOS architectures and disable `ONLY_ACTIVE_ARCH`. The canonical pipeline inspects the built executable with `lipo`; checking the build setting alone is not sufficient.
+
+The G06 screen-capture sources and G07 selection-overlay sources are explicitly excluded from the Release target. The canonical pipeline also inspects both compiled Release modules and fails if either Debug-only model is present.
 
 ## Signing
 

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -173,6 +173,26 @@ open 'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapt
 
 Current macOS permission and warning observations are recorded in [ADR-002](architecture/ADR-002-screen-capture.md). Do not use an ad hoc identity for this matrix, do not reset another application's permission, and do not treat Core Graphics preflight as authoritative when an actual ScreenCaptureKit request returns a denial.
 
+## G07 Debug Selection-Overlay Spike
+
+The internal G07 harness is also compiled only into Debug builds. Build it into a fixed ignored DerivedData path and launch it with the opt-in argument:
+
+```sh
+xcodebuild build \
+  -project CopyLasso.xcodeproj \
+  -scheme CopyLasso \
+  -configuration Debug \
+  -destination 'platform=macOS,arch=arm64' \
+  -derivedDataPath .build/g07-signed
+
+open -n .build/g07-signed/Build/Products/Debug/CopyLasso.app \
+  --args --g07-selection-spike
+```
+
+Launching the harness enumerates display geometry for diagnostic text but does not present an overlay. **Begin Selection Now** starts immediately. **Begin in 5 Seconds** provides time to switch to another application, Space, or full-screen window. Drag on any display and release to report AppKit, Core Graphics, and backing-pixel rectangles; press Escape to cancel.
+
+Every overlay panel is clear until mouse-down. During a drag only the initiating display is lightly dimmed, and an endpoint crossing onto another display clamps to the initiating display edge. The experiment never requests Screen Recording permission, captures pixels, calls OCR, or changes the clipboard. Its coordinate model and current live evidence are recorded in [ADR-003](architecture/ADR-003-selection-overlay.md).
+
 ## GitHub Actions
 
 `.github/workflows/ci.yml` runs for pull requests targeting `main` and pushes to `main`. It explicitly selects Xcode 26.6 and executes `scripts/ci.sh` on the GitHub-hosted macOS 26 Apple Silicon and Intel runner images. The workflow has read-only repository contents permission, persists no checkout credential, uses no secrets or cache, and bounds concurrent runs and job duration.
@@ -188,4 +208,4 @@ The required check names are `build and test (arm64)` and `build and test (x86_6
 
 ## Current Boundary
 
-The repository contains the buildable application and test scaffold plus internal Vision OCR and ScreenCaptureKit feasibility experiments. Menu-bar behavior, global shortcuts, production capture and OCR integration, onboarding, settings, login-at-launch behavior, packaging, and release automation remain intentionally unimplemented.
+The repository contains the buildable application and test scaffold plus internal Vision OCR, ScreenCaptureKit, and AppKit selection-overlay feasibility experiments. Menu-bar behavior, global shortcuts, production capture and OCR integration, onboarding, settings, login-at-launch behavior, packaging, and release automation remain intentionally unimplemented.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -156,6 +156,10 @@ for release_architecture in arm64 x86_64; do
         echo "The Debug-only screen-capture spike was compiled into Release." >&2
         exit 1
     fi
+    if /usr/bin/grep -a -q 'SelectionOverlayController\|DisplayGeometry' "$release_module"; then
+        echo "The Debug-only selection-overlay spike was compiled into Release." >&2
+        exit 1
+    fi
 done
 
 readonly release_architectures="$(xcrun lipo -archs "$release_executable")"


### PR DESCRIPTION
## Summary

- add a Debug-only multi-display AppKit selection-overlay harness
- prove per-display AppKit, Core Graphics, and backing-pixel coordinate conversion
- document the viable overlay strategy and keep all G07 spike sources out of Release

## Verification

- `./scripts/ci.sh`
- `COPYLASSO_CI_ARCH=x86_64 ./scripts/ci.sh`
- signed placeholder, G06, and inert G07 UI smoke tests
- manual Dell and Sidecar matrix, including cross-display clamping, Escape, all edge paths, alternate Dell resolution, separate Spaces, and full-screen TextEdit
- Universal 2 Release inspection and Debug-spike module-exclusion assertions

## Scope

This PR does not capture pixels, call OCR, modify the clipboard, add production selection architecture, or begin G08.