### PR TITLE
G12: implement production permission handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ All notable changes to CopyLasso will be documented in this file.
 - A dockless native menu-bar shell with reusable Capture Text routing, reopenable Settings and About windows, and a tested Quit boundary.
 - Versioned first-run setup, persistent native Settings, explicit Launch at Login reconciliation, and a configurable global shortcut shared with the menu capture command.
 - KeyboardShortcuts 3.0.1 with exact Swift Package Manager resolution and an MIT third-party notice.
+- Production Core Graphics Screen Recording permission observation and requests, persistent neutral history, a singleton nonactivating recovery panel with explicit retry feedback, and a temporary post-approval selection boundary.

--- a/CopyLasso/App/CopyLassoApp.swift
+++ b/CopyLasso/App/CopyLassoApp.swift
@@ -8,15 +8,15 @@ struct CopyLassoApp: App {
   private let globalShortcutController: GlobalShortcutController
 
   init() {
-    let coordinator = CaptureCoordinator()
-    let captureCommand = CaptureCommand(coordinator: coordinator)
     let settingsStore = UserDefaultsSettingsStore()
     let shortcutStore = KeyboardShortcutsStore()
     let launchAtLoginService: any LaunchAtLoginServicing
+    let permissionService: any ScreenCapturePermissionService
 
     #if DEBUG
       let arguments = ProcessInfo.processInfo.arguments
-      if arguments.contains("--g10-g11-ui-testing") {
+      let isUITesting = arguments.contains("--g10-g11-ui-testing")
+      if isUITesting {
         launchAtLoginService = DebugLaunchAtLoginService(
           status: Self.debugLaunchAtLoginStatus(arguments: arguments)
         )
@@ -24,7 +24,7 @@ struct CopyLassoApp: App {
         launchAtLoginService = SystemLaunchAtLoginService()
       }
       if arguments.contains("--g10-g11-reset-settings") {
-        if !arguments.contains("--g10-g11-ui-testing") {
+        if !isUITesting {
           try? launchAtLoginService.disable()
         }
         settingsStore.reset()
@@ -33,8 +33,13 @@ struct CopyLassoApp: App {
       if arguments.contains("--g10-g11-complete-onboarding") {
         settingsStore.completedOnboardingVersion = SettingsController.currentOnboardingVersion
       }
+      permissionService =
+        isUITesting
+        ? DebugScreenCapturePermissionService(arguments: arguments)
+        : SystemScreenCapturePermissionService(historyStore: settingsStore)
     #else
       launchAtLoginService = SystemLaunchAtLoginService()
+      permissionService = SystemScreenCapturePermissionService(historyStore: settingsStore)
     #endif
 
     settingsController = SettingsController(
@@ -42,6 +47,17 @@ struct CopyLassoApp: App {
       launchAtLoginService: launchAtLoginService,
       shortcutStore: shortcutStore
     )
+    let coordinator = CaptureCoordinator()
+    let recoveryController = PermissionRecoveryPanelController(
+      permissionService: permissionService
+    )
+    let captureCommand = CaptureCommand(
+      coordinator: coordinator,
+      permissionService: permissionService,
+      selectionService: PendingRegionSelectionService(),
+      recoveryPresenter: recoveryController
+    )
+    recoveryController.captureRequester = captureCommand
     commandHandler = MenuBarCommandHandler(
       captureCommand: captureCommand,
       applicationTerminator: SystemApplicationTerminator()

--- a/CopyLasso/CaptureWorkflow/CaptureCommand.swift
+++ b/CopyLasso/CaptureWorkflow/CaptureCommand.swift
@@ -1,18 +1,13 @@
 @MainActor
-final class CaptureCommand {
-  typealias Completion = @MainActor @Sendable () -> Void
-  typealias CompletionScheduler = @MainActor (@escaping Completion) -> Void
-
-  private static let stubCompletionEvents: [CaptureEvent] = [
-    .permissionGranted,
-    .selectionCompleted,
-    .captureCompleted,
-    .recognitionCompleted,
-    .completionFinished,
-  ]
+final class CaptureCommand: CaptureRequesting {
+  typealias Work = @MainActor @Sendable () async -> Void
+  typealias WorkScheduler = @MainActor (@escaping Work) -> Void
 
   private let coordinator: CaptureCoordinator
-  private let scheduleCompletion: CompletionScheduler
+  private let permissionService: any ScreenCapturePermissionService
+  private let selectionService: any RegionSelectionService
+  private let recoveryPresenter: any PermissionRecoveryPresenting
+  private let scheduleWork: WorkScheduler
 
   var isEnabled: Bool {
     !coordinator.isBusy
@@ -20,10 +15,16 @@ final class CaptureCommand {
 
   init(
     coordinator: CaptureCoordinator,
-    scheduleCompletion: @escaping CompletionScheduler = CaptureCommand.scheduleOnNextMainActorTurn
+    permissionService: any ScreenCapturePermissionService,
+    selectionService: any RegionSelectionService,
+    recoveryPresenter: any PermissionRecoveryPresenting,
+    scheduleWork: @escaping WorkScheduler = CaptureCommand.scheduleOnNextMainActorTurn
   ) {
     self.coordinator = coordinator
-    self.scheduleCompletion = scheduleCompletion
+    self.permissionService = permissionService
+    self.selectionService = selectionService
+    self.recoveryPresenter = recoveryPresenter
+    self.scheduleWork = scheduleWork
   }
 
   @discardableResult
@@ -33,28 +34,89 @@ final class CaptureCommand {
       return result
     }
 
-    scheduleCompletion { [weak self] in
-      self?.completeStubIfStillRequested()
+    scheduleWork { [weak self] in
+      await self?.runPermissionFlowIfStillRequested()
     }
     return result
   }
 
-  private func completeStubIfStillRequested() {
+  private func runPermissionFlowIfStillRequested() async {
     guard coordinator.state == .requestingPermission else {
       return
     }
 
-    for event in Self.stubCompletionEvents {
-      guard case .transitioned = coordinator.handle(event) else {
-        return
+    let observation = permissionService.currentObservation()
+    switch observation {
+    case .granted:
+      await proceedToSelection()
+    case .notGrantedNeverRequested:
+      let requestObservation = permissionService.requestAccess()
+      if requestObservation == .granted {
+        await proceedToSelection()
+      } else {
+        finishPermissionFailure(requestObservation)
       }
+    case .notGrantedAfterRequest, .notGrantedAfterPreviouslyGranted:
+      finishPermissionFailure(observation)
     }
   }
 
-  private static func scheduleOnNextMainActorTurn(_ completion: @escaping Completion) {
+  private func proceedToSelection() async {
+    recoveryPresenter.dismiss()
+    guard case .transitioned = coordinator.handle(.permissionGranted) else {
+      return
+    }
+
+    do {
+      let outcome = try await selectionService.selectRegion()
+      switch outcome {
+      case .selected:
+        _ = coordinator.handle(.fail(.internal))
+      case .cancelled(let reason):
+        _ = coordinator.handle(.cancel(reason.captureCancellationReason))
+      }
+    } catch {
+      _ = coordinator.handle(.fail(.selection))
+    }
+    resetTerminalState()
+  }
+
+  private func finishPermissionFailure(
+    _ observation: ScreenCaptureAuthorizationObservation
+  ) {
+    _ = coordinator.handle(.fail(.permission))
+    recoveryPresenter.present(observation)
+    resetTerminalState()
+  }
+
+  private func resetTerminalState() {
+    switch coordinator.state {
+    case .cancelled, .failed:
+      _ = coordinator.handle(.reset)
+    case .idle, .requestingPermission, .selecting, .capturing, .recognizing, .completing:
+      break
+    }
+  }
+
+  private static func scheduleOnNextMainActorTurn(_ work: @escaping Work) {
     Task { @MainActor in
       await Task.yield()
-      completion()
+      await work()
+    }
+  }
+}
+
+extension SelectionCancellationReason {
+  fileprivate var captureCancellationReason: CaptureCancellationReason {
+    switch self {
+    case .escape:
+      .user
+    case .tooSmall:
+      .selectionTooSmall
+    case .displayChanged:
+      .displayChanged
+    case .applicationTerminated:
+      .applicationTerminated
     }
   }
 }

--- a/CopyLasso/Services/DebugScreenCapturePermissionService.swift
+++ b/CopyLasso/Services/DebugScreenCapturePermissionService.swift
@@ -1,0 +1,76 @@
+#if DEBUG
+  @MainActor
+  final class DebugScreenCapturePermissionService: ScreenCapturePermissionService {
+    private let currentResults: [ScreenCaptureAuthorizationObservation]
+    private let requestResult: ScreenCaptureAuthorizationObservation
+    private let settingsOpenResult: Bool
+    private var currentIndex = 0
+
+    init(arguments: [String]) {
+      let sequence = Self.argumentValue(
+        prefix: "--g12-permission-sequence=",
+        arguments: arguments
+      )?
+      .split(separator: ",")
+      .compactMap { Self.observation(named: String($0)) }
+
+      if let sequence, !sequence.isEmpty {
+        currentResults = sequence
+      } else {
+        let value = Self.argumentValue(
+          prefix: "--g12-permission=",
+          arguments: arguments
+        )
+        currentResults = [Self.observation(named: value ?? "granted") ?? .granted]
+      }
+
+      let requestValue = Self.argumentValue(
+        prefix: "--g12-request=",
+        arguments: arguments
+      )
+      requestResult =
+        Self.observation(named: requestValue ?? "after-request")
+        ?? .notGrantedAfterRequest
+      settingsOpenResult = !arguments.contains("--g12-settings-open=failure")
+    }
+
+    func currentObservation() -> ScreenCaptureAuthorizationObservation {
+      let result = currentResults[min(currentIndex, currentResults.count - 1)]
+      if currentIndex < currentResults.count - 1 {
+        currentIndex += 1
+      }
+      return result
+    }
+
+    func requestAccess() -> ScreenCaptureAuthorizationObservation {
+      requestResult
+    }
+
+    func openSystemSettings() -> Bool {
+      settingsOpenResult
+    }
+
+    private static func argumentValue(prefix: String, arguments: [String]) -> String? {
+      arguments.last(where: { $0.hasPrefix(prefix) })?
+        .dropFirst(prefix.count)
+        .description
+    }
+
+    private static func observation(
+      named name: String
+    ) -> ScreenCaptureAuthorizationObservation? {
+      switch name {
+      case "granted":
+        .granted
+      case "never-requested":
+        .notGrantedNeverRequested
+      case "after-request":
+        .notGrantedAfterRequest
+      case "previously-granted":
+        .notGrantedAfterPreviouslyGranted
+      default:
+        nil
+      }
+    }
+  }
+#endif

--- a/CopyLasso/Services/PendingRegionSelectionService.swift
+++ b/CopyLasso/Services/PendingRegionSelectionService.swift
@@ -1,0 +1,12 @@
+enum PendingRegionSelectionError: Error, Equatable, Sendable {
+  case unavailableUntilG13
+}
+
+@MainActor
+final class PendingRegionSelectionService: RegionSelectionService {
+  func selectRegion() async throws -> SelectionOutcome {
+    throw PendingRegionSelectionError.unavailableUntilG13
+  }
+
+  func cancelSelection() {}
+}

--- a/CopyLasso/Services/PermissionRecoveryService.swift
+++ b/CopyLasso/Services/PermissionRecoveryService.swift
@@ -1,0 +1,11 @@
+@MainActor
+protocol PermissionRecoveryPresenting: AnyObject {
+  func present(_ observation: ScreenCaptureAuthorizationObservation)
+  func dismiss()
+}
+
+@MainActor
+protocol CaptureRequesting: AnyObject {
+  @discardableResult
+  func perform() -> CaptureTransitionResult
+}

--- a/CopyLasso/Services/ScreenCapturePermissionService.swift
+++ b/CopyLasso/Services/ScreenCapturePermissionService.swift
@@ -1,5 +1,64 @@
+import AppKit
+import CoreGraphics
+
 @MainActor
 protocol ScreenCapturePermissionService: AnyObject {
   func currentObservation() -> ScreenCaptureAuthorizationObservation
   func requestAccess() -> ScreenCaptureAuthorizationObservation
+  func openSystemSettings() -> Bool
+}
+
+@MainActor
+struct ScreenCapturePermissionClient {
+  static let screenRecordingSettingsURL = URL(
+    string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+  )!
+
+  let preflight: () -> Bool
+  let request: () -> Bool
+  let openURL: (URL) -> Bool
+
+  static let live = ScreenCapturePermissionClient(
+    preflight: { CGPreflightScreenCaptureAccess() },
+    request: { CGRequestScreenCaptureAccess() },
+    openURL: { NSWorkspace.shared.open($0) }
+  )
+}
+
+@MainActor
+final class SystemScreenCapturePermissionService: ScreenCapturePermissionService {
+  private let historyStore: any ScreenCapturePermissionHistoryStoring
+  private let client: ScreenCapturePermissionClient
+
+  init(
+    historyStore: any ScreenCapturePermissionHistoryStoring,
+    client: ScreenCapturePermissionClient = .live
+  ) {
+    self.historyStore = historyStore
+    self.client = client
+  }
+
+  func currentObservation() -> ScreenCaptureAuthorizationObservation {
+    observation(granted: client.preflight())
+  }
+
+  func requestAccess() -> ScreenCaptureAuthorizationObservation {
+    var history = historyStore.history
+    history.hasRequested = true
+    historyStore.history = history
+    return observation(granted: client.request())
+  }
+
+  func openSystemSettings() -> Bool {
+    client.openURL(ScreenCapturePermissionClient.screenRecordingSettingsURL)
+  }
+
+  private func observation(granted: Bool) -> ScreenCaptureAuthorizationObservation {
+    var history = historyStore.history
+    if granted {
+      history.hasObservedGranted = true
+      historyStore.history = history
+    }
+    return history.observation(preflightGranted: granted)
+  }
 }

--- a/CopyLasso/SharedUI/PermissionRecoveryPanel.swift
+++ b/CopyLasso/SharedUI/PermissionRecoveryPanel.swift
@@ -1,0 +1,269 @@
+import AppKit
+import Observation
+import SwiftUI
+
+struct PermissionRecoveryContent: Equatable {
+  static let instructions =
+    "Open System Settings > Privacy & Security > Screen & System Audio Recording and enable "
+    + "CopyLasso. If macOS asks, choose Quit & Reopen. Otherwise return here and choose Try "
+    + "Again."
+
+  let title = "Screen Recording Access Needed"
+  let status: String
+  let instructions = Self.instructions
+
+  init(observation: ScreenCaptureAuthorizationObservation) {
+    switch observation {
+    case .granted:
+      status = "Screen Recording access is available."
+    case .notGrantedNeverRequested:
+      status = "Screen Recording access is not available yet."
+    case .notGrantedAfterRequest:
+      status =
+        "macOS does not tell CopyLasso whether access was denied or is still awaiting approval."
+    case .notGrantedAfterPreviouslyGranted:
+      status = "Screen Recording access was available before and may have been turned off."
+    }
+  }
+}
+
+@MainActor
+@Observable
+final class PermissionRecoveryModel {
+  private(set) var observation: ScreenCaptureAuthorizationObservation?
+  private(set) var settingsOpenFailed = false
+  private(set) var isPresented = false
+  private(set) var retryStatus: String?
+  private var isRetrying = false
+
+  var content: PermissionRecoveryContent? {
+    observation.map(PermissionRecoveryContent.init)
+  }
+
+  func present(_ observation: ScreenCaptureAuthorizationObservation) {
+    self.observation = observation
+    settingsOpenFailed = false
+    if isRetrying {
+      retryStatus =
+        "Access is still unavailable. If you chose Later, quit and reopen CopyLasso, then "
+        + "choose Try Again."
+    } else {
+      retryStatus = nil
+    }
+    isRetrying = false
+    isPresented = true
+  }
+
+  func recordSettingsOpenResult(_ succeeded: Bool) {
+    settingsOpenFailed = !succeeded
+  }
+
+  func beginRetry() {
+    isRetrying = true
+    retryStatus = "Checking Screen Recording access…"
+  }
+
+  func recordRetryRejection() {
+    isRetrying = false
+    retryStatus = "CopyLasso is already checking Screen Recording access."
+  }
+
+  func dismiss() {
+    isRetrying = false
+    retryStatus = nil
+    isPresented = false
+  }
+}
+
+@MainActor
+struct PermissionRecoveryPanelActions {
+  let openSystemSettings: () -> Void
+  let tryAgain: () -> Void
+  let cancel: () -> Void
+}
+
+@MainActor
+protocol PermissionRecoveryPanelHosting: AnyObject {
+  func show()
+  func hide()
+}
+
+@MainActor
+final class PermissionRecoveryPanelController: PermissionRecoveryPresenting {
+  typealias PanelFactory =
+    @MainActor (
+      PermissionRecoveryModel,
+      PermissionRecoveryPanelActions
+    ) -> any PermissionRecoveryPanelHosting
+
+  let model = PermissionRecoveryModel()
+  weak var captureRequester: (any CaptureRequesting)?
+
+  private let permissionService: any ScreenCapturePermissionService
+  private let makePanel: PanelFactory
+  private var panel: (any PermissionRecoveryPanelHosting)?
+
+  init(
+    permissionService: any ScreenCapturePermissionService,
+    makePanel: @escaping PanelFactory = { model, actions in
+      AppKitPermissionRecoveryPanelHost(model: model, actions: actions)
+    }
+  ) {
+    self.permissionService = permissionService
+    self.makePanel = makePanel
+  }
+
+  func present(_ observation: ScreenCaptureAuthorizationObservation) {
+    model.present(observation)
+    ensurePanel().show()
+  }
+
+  func dismiss() {
+    model.dismiss()
+    panel?.hide()
+  }
+
+  private func ensurePanel() -> any PermissionRecoveryPanelHosting {
+    if let panel {
+      return panel
+    }
+
+    let actions = PermissionRecoveryPanelActions(
+      openSystemSettings: { [weak self] in
+        guard let self else { return }
+        model.recordSettingsOpenResult(permissionService.openSystemSettings())
+      },
+      tryAgain: { [weak self] in
+        guard let self else { return }
+        model.beginRetry()
+        guard case .transitioned = captureRequester?.perform() else {
+          model.recordRetryRejection()
+          return
+        }
+      },
+      cancel: { [weak self] in
+        self?.dismiss()
+      }
+    )
+    let panel = makePanel(model, actions)
+    self.panel = panel
+    return panel
+  }
+}
+
+private struct PermissionRecoveryView: View {
+  @Bindable var model: PermissionRecoveryModel
+  let actions: PermissionRecoveryPanelActions
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      if let content = model.content {
+        Text(content.title)
+          .font(.title2.weight(.semibold))
+          .accessibilityIdentifier("copylasso.permission-recovery.title")
+
+        Text(content.status)
+          .lineLimit(nil)
+          .fixedSize(horizontal: false, vertical: true)
+          .accessibilityIdentifier("copylasso.permission-recovery.status")
+
+        Text(content.instructions)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+          .accessibilityIdentifier("copylasso.permission-recovery.instructions")
+      }
+
+      if model.settingsOpenFailed {
+        Text(
+          "System Settings could not be opened automatically. Open it manually and go to "
+            + "Privacy & Security > Screen & System Audio Recording."
+        )
+        .foregroundStyle(.red)
+        .fixedSize(horizontal: false, vertical: true)
+        .accessibilityIdentifier("copylasso.permission-recovery.settings-failure")
+      }
+
+      if let retryStatus = model.retryStatus {
+        Text(retryStatus)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+          .accessibilityIdentifier("copylasso.permission-recovery.retry-status")
+      }
+
+      HStack {
+        Button("Open System Settings", action: actions.openSystemSettings)
+          .keyboardShortcut(.defaultAction)
+          .accessibilityIdentifier("copylasso.permission-recovery.open-settings")
+
+        Button("Try Again", action: actions.tryAgain)
+          .accessibilityIdentifier("copylasso.permission-recovery.try-again")
+
+        Spacer()
+
+        Button("Cancel", action: actions.cancel)
+          .keyboardShortcut(.cancelAction)
+          .accessibilityIdentifier("copylasso.permission-recovery.cancel")
+      }
+    }
+    .padding(24)
+    .frame(width: 520)
+  }
+}
+
+@MainActor
+private final class AppKitPermissionRecoveryPanelHost: NSObject,
+  PermissionRecoveryPanelHosting, NSWindowDelegate
+{
+  private let panel: NonactivatingPermissionRecoveryPanel
+  private let cancel: () -> Void
+  private var hasPositionedPanel = false
+
+  init(
+    model: PermissionRecoveryModel,
+    actions: PermissionRecoveryPanelActions
+  ) {
+    cancel = actions.cancel
+    panel = NonactivatingPermissionRecoveryPanel(
+      contentRect: NSRect(x: 0, y: 0, width: 520, height: 280),
+      styleMask: [.titled, .closable, .nonactivatingPanel],
+      backing: .buffered,
+      defer: false
+    )
+    super.init()
+
+    panel.title = "Screen Recording Access Needed"
+    panel.becomesKeyOnlyIfNeeded = false
+    panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
+    panel.hidesOnDeactivate = false
+    panel.isFloatingPanel = true
+    panel.isReleasedWhenClosed = false
+    panel.level = .floating
+    panel.animationBehavior = .utilityWindow
+    panel.contentViewController = NSHostingController(
+      rootView: PermissionRecoveryView(model: model, actions: actions)
+    )
+    panel.delegate = self
+  }
+
+  func show() {
+    if !hasPositionedPanel {
+      panel.center()
+      hasPositionedPanel = true
+    }
+    panel.orderFrontRegardless()
+    panel.makeKey()
+  }
+
+  func hide() {
+    panel.orderOut(nil)
+  }
+
+  func windowWillClose(_ notification: Notification) {
+    cancel()
+  }
+}
+
+private final class NonactivatingPermissionRecoveryPanel: NSPanel {
+  override var canBecomeKey: Bool { true }
+  override var canBecomeMain: Bool { false }
+}

--- a/CopyLassoTests/App/GlobalShortcutControllerTests.swift
+++ b/CopyLassoTests/App/GlobalShortcutControllerTests.swift
@@ -37,7 +37,7 @@ final class GlobalShortcutControllerTests: XCTestCase {
     for _ in 0..<3 {
       context.events.emit(.keyUp)
       await waitForState(.requestingPermission, coordinator: context.coordinator)
-      context.scheduler.runNext()
+      await context.scheduler.runNext()
       XCTAssertEqual(context.coordinator.state, .idle)
     }
 
@@ -60,9 +60,9 @@ final class GlobalShortcutControllerTests: XCTestCase {
   private func makeContext() -> Context {
     let coordinator = CaptureCoordinator()
     let scheduler = ShortcutCaptureCompletionScheduler()
-    let command = CaptureCommand(
+    let command = makeTestCaptureCommand(
       coordinator: coordinator,
-      scheduleCompletion: scheduler.schedule
+      scheduleWork: scheduler.schedule
     )
     let events = StubGlobalShortcutEventSource()
     let controller = GlobalShortcutController(
@@ -97,7 +97,7 @@ final class GlobalShortcutControllerTests: XCTestCase {
 
 @MainActor
 private final class ShortcutCaptureCompletionScheduler {
-  typealias Completion = @MainActor @Sendable () -> Void
+  typealias Completion = @MainActor @Sendable () async -> Void
 
   private var completions: [Completion] = []
   private(set) var scheduledCompletionCount = 0
@@ -107,10 +107,10 @@ private final class ShortcutCaptureCompletionScheduler {
     completions.append(completion)
   }
 
-  func runNext() {
+  func runNext() async {
     guard !completions.isEmpty else {
       return XCTFail("Expected a completion")
     }
-    completions.removeFirst()()
+    await completions.removeFirst()()
   }
 }

--- a/CopyLassoTests/App/MenuBarShellTests.swift
+++ b/CopyLassoTests/App/MenuBarShellTests.swift
@@ -6,10 +6,11 @@ import XCTest
 final class MenuBarShellTests: XCTestCase {
   func testQuitRoutesToTheInjectedApplicationTerminatorExactlyOnce() {
     let terminator = SpyApplicationTerminator()
+    let coordinator = CaptureCoordinator()
     let handler = MenuBarCommandHandler(
-      captureCommand: CaptureCommand(
-        coordinator: CaptureCoordinator(),
-        scheduleCompletion: { _ in }
+      captureCommand: makeTestCaptureCommand(
+        coordinator: coordinator,
+        scheduleWork: { _ in }
       ),
       applicationTerminator: terminator
     )

--- a/CopyLassoTests/CaptureWorkflow/CaptureCommandTests.swift
+++ b/CopyLassoTests/CaptureWorkflow/CaptureCommandTests.swift
@@ -4,12 +4,12 @@ import XCTest
 
 @MainActor
 final class CaptureCommandTests: XCTestCase {
-  func testAcceptedRequestWaitsForScheduledStubCompletion() {
+  func testAcceptedRequestWaitsForScheduledStubCompletion() async {
     let coordinator = CaptureCoordinator()
     let scheduler = ManualCaptureCompletionScheduler()
-    let command = CaptureCommand(
+    let command = makeTestCaptureCommand(
       coordinator: coordinator,
-      scheduleCompletion: scheduler.schedule
+      scheduleWork: scheduler.schedule
     )
 
     XCTAssertTrue(command.isEnabled)
@@ -21,7 +21,7 @@ final class CaptureCommandTests: XCTestCase {
     XCTAssertFalse(command.isEnabled)
     XCTAssertEqual(scheduler.scheduledCompletionCount, 1)
 
-    scheduler.runNext()
+    await scheduler.runNext()
 
     XCTAssertEqual(coordinator.state, .idle)
     XCTAssertTrue(command.isEnabled)
@@ -30,9 +30,9 @@ final class CaptureCommandTests: XCTestCase {
   func testConcurrentRequestIsRejectedWithoutSchedulingAnotherCompletion() {
     let coordinator = CaptureCoordinator()
     let scheduler = ManualCaptureCompletionScheduler()
-    let command = CaptureCommand(
+    let command = makeTestCaptureCommand(
       coordinator: coordinator,
-      scheduleCompletion: scheduler.schedule
+      scheduleWork: scheduler.schedule
     )
 
     XCTAssertEqual(
@@ -51,9 +51,9 @@ final class CaptureCommandTests: XCTestCase {
     for state in CaptureState.nonIdleCaptureCommandTestCases {
       let coordinator = CaptureCoordinator(initialState: state)
       let scheduler = ManualCaptureCompletionScheduler()
-      let command = CaptureCommand(
+      let command = makeTestCaptureCommand(
         coordinator: coordinator,
-        scheduleCompletion: scheduler.schedule
+        scheduleWork: scheduler.schedule
       )
 
       XCTAssertFalse(command.isEnabled)
@@ -63,12 +63,12 @@ final class CaptureCommandTests: XCTestCase {
     }
   }
 
-  func testCaptureCommandCanCompleteThreeSequentialRequests() {
+  func testCaptureCommandCanCompleteThreeSequentialRequests() async {
     let coordinator = CaptureCoordinator()
     let scheduler = ManualCaptureCompletionScheduler()
-    let command = CaptureCommand(
+    let command = makeTestCaptureCommand(
       coordinator: coordinator,
-      scheduleCompletion: scheduler.schedule
+      scheduleWork: scheduler.schedule
     )
 
     for _ in 0..<3 {
@@ -76,7 +76,7 @@ final class CaptureCommandTests: XCTestCase {
         command.perform(),
         .transitioned(from: .idle, to: .requestingPermission)
       )
-      scheduler.runNext()
+      await scheduler.runNext()
       XCTAssertEqual(coordinator.state, .idle)
     }
 
@@ -84,17 +84,17 @@ final class CaptureCommandTests: XCTestCase {
     XCTAssertEqual(scheduler.pendingCompletionCount, 0)
   }
 
-  func testScheduledCompletionDoesNotOverrideAnUnexpectedStateChange() {
+  func testScheduledCompletionDoesNotOverrideAnUnexpectedStateChange() async {
     let coordinator = CaptureCoordinator()
     let scheduler = ManualCaptureCompletionScheduler()
-    let command = CaptureCommand(
+    let command = makeTestCaptureCommand(
       coordinator: coordinator,
-      scheduleCompletion: scheduler.schedule
+      scheduleWork: scheduler.schedule
     )
 
     _ = command.perform()
     _ = coordinator.handle(.fail(.permission))
-    scheduler.runNext()
+    await scheduler.runNext()
 
     XCTAssertEqual(coordinator.state, .failed(.permission))
   }
@@ -102,7 +102,7 @@ final class CaptureCommandTests: XCTestCase {
 
 @MainActor
 private final class ManualCaptureCompletionScheduler {
-  typealias Completion = @MainActor @Sendable () -> Void
+  typealias Completion = @MainActor @Sendable () async -> Void
 
   private var pendingCompletions: [Completion] = []
   private(set) var scheduledCompletionCount = 0
@@ -116,11 +116,11 @@ private final class ManualCaptureCompletionScheduler {
     pendingCompletions.append(completion)
   }
 
-  func runNext() {
+  func runNext() async {
     guard !pendingCompletions.isEmpty else {
       return XCTFail("Expected a scheduled completion")
     }
-    pendingCompletions.removeFirst()()
+    await pendingCompletions.removeFirst()()
   }
 }
 

--- a/CopyLassoTests/CaptureWorkflow/CapturePermissionFlowTests.swift
+++ b/CopyLassoTests/CaptureWorkflow/CapturePermissionFlowTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+
+@testable import CopyLasso
+
+@MainActor
+final class CapturePermissionFlowTests: XCTestCase {
+  func testGrantedPermissionReachesSelectionExactlyOnceAndReturnsIdleAfterStubFailure() async {
+    let context = makeContext(current: .granted)
+
+    XCTAssertEqual(
+      context.command.perform(),
+      .transitioned(from: .idle, to: .requestingPermission)
+    )
+    XCTAssertEqual(
+      context.command.perform(),
+      .rejectedBusy(currentState: .requestingPermission)
+    )
+    XCTAssertEqual(context.scheduler.pendingWorkCount, 1)
+
+    await context.scheduler.runNext()
+
+    XCTAssertEqual(context.permission.currentObservationCallCount, 1)
+    XCTAssertEqual(context.permission.requestAccessCallCount, 0)
+    XCTAssertEqual(context.selection.selectRegionCallCount, 1)
+    XCTAssertEqual(context.recovery.presentedObservations, [])
+    XCTAssertEqual(context.recovery.dismissCallCount, 1)
+    XCTAssertEqual(context.coordinator.state, .idle)
+    XCTAssertTrue(context.command.isEnabled)
+  }
+
+  func testFirstRequestCanGrantAndReachSelection() async {
+    let context = makeContext(
+      current: .notGrantedNeverRequested,
+      request: .granted
+    )
+
+    _ = context.command.perform()
+    await context.scheduler.runNext()
+
+    XCTAssertEqual(context.permission.requestAccessCallCount, 1)
+    XCTAssertEqual(context.selection.selectRegionCallCount, 1)
+    XCTAssertEqual(context.coordinator.state, .idle)
+  }
+
+  func testFirstRequestDenialPresentsRecoveryWithoutSelectionAndReturnsIdle() async {
+    let context = makeContext(
+      current: .notGrantedNeverRequested,
+      request: .notGrantedAfterRequest
+    )
+
+    _ = context.command.perform()
+    await context.scheduler.runNext()
+
+    XCTAssertEqual(context.permission.requestAccessCallCount, 1)
+    XCTAssertEqual(context.selection.selectRegionCallCount, 0)
+    XCTAssertEqual(context.recovery.presentedObservations, [.notGrantedAfterRequest])
+    XCTAssertEqual(context.coordinator.state, .idle)
+    XCTAssertTrue(context.command.isEnabled)
+  }
+
+  func testKnownUnavailableStatesNeverRequestOrBeginSelection() async {
+    for observation in [
+      ScreenCaptureAuthorizationObservation.notGrantedAfterRequest,
+      .notGrantedAfterPreviouslyGranted,
+    ] {
+      let context = makeContext(current: observation)
+
+      _ = context.command.perform()
+      await context.scheduler.runNext()
+
+      XCTAssertEqual(context.permission.requestAccessCallCount, 0)
+      XCTAssertEqual(context.selection.selectRegionCallCount, 0)
+      XCTAssertEqual(context.recovery.presentedObservations, [observation])
+      XCTAssertEqual(context.coordinator.state, .idle)
+    }
+  }
+
+  func testRepeatedDeniedAttemptsDoNotRepeatTheSystemRequestOrStackWork() async {
+    let context = makeContext(
+      current: .notGrantedNeverRequested,
+      request: .notGrantedAfterRequest
+    )
+
+    _ = context.command.perform()
+    XCTAssertEqual(context.scheduler.pendingWorkCount, 1)
+    XCTAssertEqual(
+      context.command.perform(),
+      .rejectedBusy(currentState: .requestingPermission)
+    )
+    XCTAssertEqual(context.scheduler.pendingWorkCount, 1)
+    await context.scheduler.runNext()
+
+    context.permission.currentResult = .notGrantedAfterRequest
+    _ = context.command.perform()
+    await context.scheduler.runNext()
+
+    XCTAssertEqual(context.permission.requestAccessCallCount, 1)
+    XCTAssertEqual(
+      context.recovery.presentedObservations,
+      [.notGrantedAfterRequest, .notGrantedAfterRequest]
+    )
+    XCTAssertEqual(context.coordinator.state, .idle)
+  }
+
+  func testThreeGrantedAttemptsRemainReusable() async {
+    let context = makeContext(current: .granted)
+
+    for _ in 0..<3 {
+      _ = context.command.perform()
+      await context.scheduler.runNext()
+      XCTAssertEqual(context.coordinator.state, .idle)
+    }
+
+    XCTAssertEqual(context.selection.selectRegionCallCount, 3)
+    XCTAssertEqual(context.scheduler.scheduledWorkCount, 3)
+  }
+
+  private func makeContext(
+    current: ScreenCaptureAuthorizationObservation,
+    request: ScreenCaptureAuthorizationObservation = .granted
+  ) -> Context {
+    let coordinator = CaptureCoordinator()
+    let permission = StubScreenCapturePermissionService(
+      currentResult: current,
+      requestResult: request
+    )
+    let selection = StubRegionSelectionService(result: .failure(.injected))
+    let recovery = SpyPermissionRecoveryPresenter()
+    let scheduler = ManualCaptureWorkScheduler()
+    let command = CaptureCommand(
+      coordinator: coordinator,
+      permissionService: permission,
+      selectionService: selection,
+      recoveryPresenter: recovery,
+      scheduleWork: scheduler.schedule
+    )
+    return Context(
+      coordinator: coordinator,
+      permission: permission,
+      selection: selection,
+      recovery: recovery,
+      scheduler: scheduler,
+      command: command
+    )
+  }
+
+  private struct Context {
+    let coordinator: CaptureCoordinator
+    let permission: StubScreenCapturePermissionService
+    let selection: StubRegionSelectionService
+    let recovery: SpyPermissionRecoveryPresenter
+    let scheduler: ManualCaptureWorkScheduler
+    let command: CaptureCommand
+  }
+}
+
+@MainActor
+private final class ManualCaptureWorkScheduler {
+  typealias Work = @MainActor @Sendable () async -> Void
+
+  private var pendingWork: [Work] = []
+  private(set) var scheduledWorkCount = 0
+
+  var pendingWorkCount: Int {
+    pendingWork.count
+  }
+
+  func schedule(_ work: @escaping Work) {
+    scheduledWorkCount += 1
+    pendingWork.append(work)
+  }
+
+  func runNext() async {
+    guard !pendingWork.isEmpty else {
+      return XCTFail("Expected scheduled capture work")
+    }
+    await pendingWork.removeFirst()()
+  }
+}

--- a/CopyLassoTests/Services/ScreenCapturePermissionServiceTests.swift
+++ b/CopyLassoTests/Services/ScreenCapturePermissionServiceTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+
+@testable import CopyLasso
+
+@MainActor
+final class ScreenCapturePermissionServiceTests: XCTestCase {
+  func testConstructionPerformsNoPermissionOrSettingsOperation() {
+    let context = makeContext(preflight: false, request: false, openSettings: true)
+
+    _ = context.service
+
+    XCTAssertEqual(context.client.preflightCallCount, 0)
+    XCTAssertEqual(context.client.requestCallCount, 0)
+    XCTAssertEqual(context.client.openedURLs, [])
+  }
+
+  func testCurrentObservationPreservesEveryHistoryInference() {
+    let fresh = makeContext(preflight: false)
+    XCTAssertEqual(fresh.service.currentObservation(), .notGrantedNeverRequested)
+
+    let requested = makeContext(
+      history: ScreenCapturePermissionHistory(hasRequested: true),
+      preflight: false
+    )
+    XCTAssertEqual(requested.service.currentObservation(), .notGrantedAfterRequest)
+
+    let previouslyGranted = makeContext(
+      history: ScreenCapturePermissionHistory(
+        hasRequested: true,
+        hasObservedGranted: true
+      ),
+      preflight: false
+    )
+    XCTAssertEqual(
+      previouslyGranted.service.currentObservation(),
+      .notGrantedAfterPreviouslyGranted
+    )
+  }
+
+  func testCurrentGrantedObservationPersistsDirectlyObservedAccess() {
+    let context = makeContext(preflight: true)
+
+    XCTAssertEqual(context.service.currentObservation(), .granted)
+    XCTAssertTrue(context.history.history.hasObservedGranted)
+    XCTAssertFalse(context.history.history.hasRequested)
+    XCTAssertEqual(context.client.preflightCallCount, 1)
+    XCTAssertEqual(context.client.requestCallCount, 0)
+  }
+
+  func testRequestPersistsHistoryBeforeInvokingTheSystemClient() {
+    let history = StubPermissionHistoryStore()
+    var historyAtRequest: ScreenCapturePermissionHistory?
+    let client = ScreenCapturePermissionClient(
+      preflight: { false },
+      request: {
+        historyAtRequest = history.history
+        return false
+      },
+      openURL: { _ in true }
+    )
+    let service = SystemScreenCapturePermissionService(
+      historyStore: history,
+      client: client
+    )
+
+    XCTAssertEqual(service.requestAccess(), .notGrantedAfterRequest)
+    XCTAssertEqual(
+      historyAtRequest,
+      ScreenCapturePermissionHistory(hasRequested: true)
+    )
+    XCTAssertTrue(history.history.hasRequested)
+    XCTAssertFalse(history.history.hasObservedGranted)
+  }
+
+  func testGrantedRequestPersistsBothHistoryFacts() {
+    let context = makeContext(preflight: false, request: true)
+
+    XCTAssertEqual(context.service.requestAccess(), .granted)
+    XCTAssertEqual(
+      context.history.history,
+      ScreenCapturePermissionHistory(
+        hasRequested: true,
+        hasObservedGranted: true
+      )
+    )
+    XCTAssertEqual(context.client.requestCallCount, 1)
+  }
+
+  func testOpenSystemSettingsUsesTheScreenRecordingPrivacyPaneAndReportsFailure() {
+    let success = makeContext(openSettings: true)
+    XCTAssertTrue(success.service.openSystemSettings())
+    XCTAssertEqual(
+      success.client.openedURLs.map(\.absoluteString),
+      ["x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"]
+    )
+
+    let failure = makeContext(openSettings: false)
+    XCTAssertFalse(failure.service.openSystemSettings())
+    XCTAssertEqual(failure.client.openedURLs.count, 1)
+  }
+
+  private func makeContext(
+    history: ScreenCapturePermissionHistory = ScreenCapturePermissionHistory(),
+    preflight: Bool = false,
+    request: Bool = false,
+    openSettings: Bool = true
+  ) -> Context {
+    let historyStore = StubPermissionHistoryStore(history: history)
+    let client = PermissionClientSpy(
+      preflightResult: preflight,
+      requestResult: request,
+      openResult: openSettings
+    )
+    let service = SystemScreenCapturePermissionService(
+      historyStore: historyStore,
+      client: client.client
+    )
+    return Context(service: service, history: historyStore, client: client)
+  }
+
+  private struct Context {
+    let service: SystemScreenCapturePermissionService
+    let history: StubPermissionHistoryStore
+    let client: PermissionClientSpy
+  }
+}
+
+@MainActor
+private final class StubPermissionHistoryStore: ScreenCapturePermissionHistoryStoring {
+  var history: ScreenCapturePermissionHistory
+
+  init(history: ScreenCapturePermissionHistory = ScreenCapturePermissionHistory()) {
+    self.history = history
+  }
+
+  func reset() {
+    history = ScreenCapturePermissionHistory()
+  }
+}
+
+@MainActor
+private final class PermissionClientSpy {
+  let preflightResult: Bool
+  let requestResult: Bool
+  let openResult: Bool
+  private(set) var preflightCallCount = 0
+  private(set) var requestCallCount = 0
+  private(set) var openedURLs: [URL] = []
+
+  init(preflightResult: Bool, requestResult: Bool, openResult: Bool) {
+    self.preflightResult = preflightResult
+    self.requestResult = requestResult
+    self.openResult = openResult
+  }
+
+  var client: ScreenCapturePermissionClient {
+    ScreenCapturePermissionClient(
+      preflight: { [weak self] in
+        guard let self else { return false }
+        preflightCallCount += 1
+        return preflightResult
+      },
+      request: { [weak self] in
+        guard let self else { return false }
+        requestCallCount += 1
+        return requestResult
+      },
+      openURL: { [weak self] url in
+        guard let self else { return false }
+        openedURLs.append(url)
+        return openResult
+      }
+    )
+  }
+}

--- a/CopyLassoTests/SharedUI/PermissionRecoveryTests.swift
+++ b/CopyLassoTests/SharedUI/PermissionRecoveryTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+
+@testable import CopyLasso
+
+@MainActor
+final class PermissionRecoveryTests: XCTestCase {
+  func testRecoveryCopyDoesNotOverstateAfterRequestState() {
+    let content = PermissionRecoveryContent(
+      observation: .notGrantedAfterRequest
+    )
+
+    XCTAssertEqual(content.title, "Screen Recording Access Needed")
+    XCTAssertEqual(
+      content.status,
+      "macOS does not tell CopyLasso whether access was denied or is still awaiting approval."
+    )
+    XCTAssertEqual(
+      content.instructions,
+      "Open System Settings > Privacy & Security > Screen & System Audio Recording and enable CopyLasso. If macOS asks, choose Quit & Reopen. Otherwise return here and choose Try Again."
+    )
+  }
+
+  func testRecoveryCopyDescribesPriorAccessAsOnlyLikelyRevoked() {
+    let content = PermissionRecoveryContent(
+      observation: .notGrantedAfterPreviouslyGranted
+    )
+
+    XCTAssertEqual(
+      content.status,
+      "Screen Recording access was available before and may have been turned off."
+    )
+    XCTAssertFalse(content.status.localizedCaseInsensitiveContains("revoked"))
+  }
+
+  func testPanelControllerReusesOneHostAndUpdatesItsModel() {
+    let permission = StubScreenCapturePermissionService(
+      currentResult: .notGrantedAfterRequest,
+      requestResult: .notGrantedAfterRequest
+    )
+    let host = SpyPermissionRecoveryPanelHost()
+    var factoryCallCount = 0
+    let controller = PermissionRecoveryPanelController(
+      permissionService: permission,
+      makePanel: { _, _ in
+        factoryCallCount += 1
+        return host
+      }
+    )
+
+    controller.present(.notGrantedAfterRequest)
+    controller.present(.notGrantedAfterPreviouslyGranted)
+
+    XCTAssertEqual(factoryCallCount, 1)
+    XCTAssertEqual(host.showCallCount, 2)
+    XCTAssertEqual(
+      controller.model.observation,
+      .notGrantedAfterPreviouslyGranted
+    )
+  }
+
+  func testPanelActionsOpenSettingsRetryAndCancelWithoutDuplicatingThePanel() {
+    let permission = StubScreenCapturePermissionService(
+      currentResult: .notGrantedAfterRequest,
+      requestResult: .notGrantedAfterRequest
+    )
+    permission.openSystemSettingsResult = false
+    let requester = SpyCaptureRequester()
+    let host = SpyPermissionRecoveryPanelHost()
+    var capturedActions: PermissionRecoveryPanelActions?
+    let controller = PermissionRecoveryPanelController(
+      permissionService: permission,
+      makePanel: { _, actions in
+        capturedActions = actions
+        return host
+      }
+    )
+    controller.captureRequester = requester
+    controller.present(.notGrantedAfterRequest)
+
+    capturedActions?.openSystemSettings()
+    XCTAssertEqual(permission.openSystemSettingsCallCount, 1)
+    XCTAssertTrue(controller.model.settingsOpenFailed)
+
+    capturedActions?.tryAgain()
+    XCTAssertEqual(requester.performCallCount, 1)
+
+    capturedActions?.cancel()
+    XCTAssertEqual(host.hideCallCount, 1)
+    XCTAssertFalse(controller.model.isPresented)
+  }
+
+  func testRetryReportsProgressAndExplainsWhenAccessRemainsUnavailable() {
+    let permission = StubScreenCapturePermissionService(
+      currentResult: .notGrantedAfterRequest,
+      requestResult: .notGrantedAfterRequest
+    )
+    let requester = SpyCaptureRequester()
+    var capturedActions: PermissionRecoveryPanelActions?
+    let controller = PermissionRecoveryPanelController(
+      permissionService: permission,
+      makePanel: { _, actions in
+        capturedActions = actions
+        return SpyPermissionRecoveryPanelHost()
+      }
+    )
+    controller.captureRequester = requester
+    controller.present(.notGrantedAfterRequest)
+
+    capturedActions?.tryAgain()
+    XCTAssertEqual(
+      controller.model.retryStatus,
+      "Checking Screen Recording access…"
+    )
+
+    controller.present(.notGrantedAfterRequest)
+    XCTAssertEqual(
+      controller.model.retryStatus,
+      "Access is still unavailable. If you chose Later, quit and reopen CopyLasso, then choose Try Again."
+    )
+  }
+}
+
+@MainActor
+private final class SpyPermissionRecoveryPanelHost: PermissionRecoveryPanelHosting {
+  private(set) var showCallCount = 0
+  private(set) var hideCallCount = 0
+
+  func show() {
+    showCallCount += 1
+  }
+
+  func hide() {
+    hideCallCount += 1
+  }
+}
+
+@MainActor
+private final class SpyCaptureRequester: CaptureRequesting {
+  private(set) var performCallCount = 0
+
+  @discardableResult
+  func perform() -> CaptureTransitionResult {
+    performCallCount += 1
+    return .transitioned(from: .idle, to: .requestingPermission)
+  }
+}

--- a/CopyLassoTests/TestSupport/CaptureServiceDoubles.swift
+++ b/CopyLassoTests/TestSupport/CaptureServiceDoubles.swift
@@ -10,8 +10,10 @@ enum TestServiceError: Error, Equatable, Sendable {
 final class StubScreenCapturePermissionService: ScreenCapturePermissionService {
   var currentResult: ScreenCaptureAuthorizationObservation
   var requestResult: ScreenCaptureAuthorizationObservation
+  var openSystemSettingsResult = true
   private(set) var currentObservationCallCount = 0
   private(set) var requestAccessCallCount = 0
+  private(set) var openSystemSettingsCallCount = 0
 
   init(
     currentResult: ScreenCaptureAuthorizationObservation,
@@ -29,6 +31,25 @@ final class StubScreenCapturePermissionService: ScreenCapturePermissionService {
   func requestAccess() -> ScreenCaptureAuthorizationObservation {
     requestAccessCallCount += 1
     return requestResult
+  }
+
+  func openSystemSettings() -> Bool {
+    openSystemSettingsCallCount += 1
+    return openSystemSettingsResult
+  }
+}
+
+@MainActor
+final class SpyPermissionRecoveryPresenter: PermissionRecoveryPresenting {
+  private(set) var presentedObservations: [ScreenCaptureAuthorizationObservation] = []
+  private(set) var dismissCallCount = 0
+
+  func present(_ observation: ScreenCaptureAuthorizationObservation) {
+    presentedObservations.append(observation)
+  }
+
+  func dismiss() {
+    dismissCallCount += 1
   }
 }
 
@@ -104,4 +125,21 @@ final class SpyFeedbackService: FeedbackService {
     }
     presentedFeedback.append(feedback)
   }
+}
+
+@MainActor
+func makeTestCaptureCommand(
+  coordinator: CaptureCoordinator,
+  scheduleWork: @escaping CaptureCommand.WorkScheduler
+) -> CaptureCommand {
+  CaptureCommand(
+    coordinator: coordinator,
+    permissionService: StubScreenCapturePermissionService(
+      currentResult: .granted,
+      requestResult: .granted
+    ),
+    selectionService: StubRegionSelectionService(result: .failure(.injected)),
+    recoveryPresenter: SpyPermissionRecoveryPresenter(),
+    scheduleWork: scheduleWork
+  )
 }

--- a/CopyLassoUITests/CopyLassoUITests.swift
+++ b/CopyLassoUITests/CopyLassoUITests.swift
@@ -269,6 +269,142 @@ final class CopyLassoUITests: XCTestCase {
   }
 
   @MainActor
+  func testPermissionRecoveryExplainsPriorRequestWithoutTouchingTCC() {
+    let app = completedApp(extraArguments: ["--g12-permission=after-request"])
+    app.launch()
+    defer { app.terminate() }
+    let pasteboardChangeCount = NSPasteboard.general.changeCount
+
+    openMenu(in: app)
+    menuItem("Capture Text", in: app).click()
+
+    XCTAssertTrue(
+      app.staticTexts["copylasso.permission-recovery.title"]
+        .waitForExistence(timeout: 5)
+    )
+    XCTAssertTrue(app.staticTexts["copylasso.permission-recovery.status"].exists)
+    XCTAssertTrue(app.buttons["copylasso.permission-recovery.open-settings"].exists)
+    XCTAssertTrue(app.buttons["copylasso.permission-recovery.try-again"].exists)
+    XCTAssertTrue(app.buttons["copylasso.permission-recovery.cancel"].exists)
+    XCTAssertEqual(NSPasteboard.general.changeCount, pasteboardChangeCount)
+  }
+
+  @MainActor
+  func testLikelyRevokedRecoveryRemainsSingletonAcrossRepeatedAttempts() {
+    let app = completedApp(extraArguments: ["--g12-permission=previously-granted"])
+    app.launch()
+    defer { app.terminate() }
+
+    for _ in 0..<3 {
+      openMenu(in: app)
+      menuItem("Capture Text", in: app).click()
+      XCTAssertTrue(
+        app.staticTexts["copylasso.permission-recovery.title"]
+          .waitForExistence(timeout: 5)
+      )
+    }
+
+    XCTAssertEqual(
+      app.staticTexts.matching(identifier: "copylasso.permission-recovery.title").count,
+      1
+    )
+    XCTAssertTrue(app.staticTexts["copylasso.permission-recovery.status"].exists)
+
+    app.buttons["copylasso.permission-recovery.try-again"].click()
+    XCTAssertTrue(
+      app.staticTexts["copylasso.permission-recovery.retry-status"]
+        .waitForExistence(timeout: 5)
+    )
+  }
+
+  @MainActor
+  func testPermissionRecoverySettingsFailureRetryAndCancel() {
+    let app = completedApp(
+      extraArguments: [
+        "--g12-permission-sequence=after-request,granted,after-request",
+        "--g12-settings-open=failure",
+      ]
+    )
+    app.launch()
+    defer { app.terminate() }
+
+    openMenu(in: app)
+    menuItem("Capture Text", in: app).click()
+    XCTAssertTrue(
+      app.staticTexts["copylasso.permission-recovery.title"]
+        .waitForExistence(timeout: 5)
+    )
+
+    app.buttons["copylasso.permission-recovery.open-settings"].click()
+    XCTAssertTrue(
+      app.staticTexts["copylasso.permission-recovery.settings-failure"]
+        .waitForExistence(timeout: 5)
+    )
+
+    app.buttons["copylasso.permission-recovery.try-again"].click()
+    XCTAssertTrue(
+      app.staticTexts["copylasso.permission-recovery.title"]
+        .waitForNonExistence(timeout: 5)
+    )
+
+    openMenu(in: app)
+    menuItem("Capture Text", in: app).click()
+    XCTAssertTrue(
+      app.staticTexts["copylasso.permission-recovery.title"]
+        .waitForExistence(timeout: 5)
+    )
+    app.buttons["copylasso.permission-recovery.cancel"].click()
+    XCTAssertTrue(
+      app.staticTexts["copylasso.permission-recovery.title"]
+        .waitForNonExistence(timeout: 5)
+    )
+
+    openMenu(in: app)
+    menuItem("Capture Text", in: app).click()
+    XCTAssertTrue(
+      app.staticTexts["copylasso.permission-recovery.title"]
+        .waitForExistence(timeout: 5)
+    )
+    XCTAssertEqual(
+      app.staticTexts.matching(identifier: "copylasso.permission-recovery.title").count,
+      1
+    )
+  }
+
+  @MainActor
+  func testPermissionRecoverySupportsKeyboardCancelAndAccessibleButtonLabels() {
+    let app = completedApp(extraArguments: ["--g12-permission=after-request"])
+    app.launch()
+    defer { app.terminate() }
+
+    openMenu(in: app)
+    menuItem("Capture Text", in: app).click()
+    XCTAssertTrue(
+      app.staticTexts["copylasso.permission-recovery.title"]
+        .waitForExistence(timeout: 5)
+    )
+
+    XCTAssertEqual(
+      app.buttons["copylasso.permission-recovery.open-settings"].label,
+      "Open System Settings"
+    )
+    XCTAssertEqual(
+      app.buttons["copylasso.permission-recovery.try-again"].label,
+      "Try Again"
+    )
+    XCTAssertEqual(
+      app.buttons["copylasso.permission-recovery.cancel"].label,
+      "Cancel"
+    )
+
+    app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+    XCTAssertTrue(
+      app.staticTexts["copylasso.permission-recovery.title"]
+        .waitForNonExistence(timeout: 5)
+    )
+  }
+
+  @MainActor
   private func statusItem(in app: XCUIApplication) -> XCUIElement {
     app.menuBars.statusItems["CopyLasso"]
   }
@@ -310,6 +446,7 @@ final class CopyLassoUITests: XCTestCase {
         "--g10-g11-ui-testing",
         "--g10-g11-reset-settings",
         "--g10-g11-complete-onboarding",
+        "--g12-permission=granted",
       ] + extraArguments
     return app
   }

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -21,11 +21,13 @@ CopyLasso v0.1 has no:
 - analytics or telemetry; or
 - logging of screenshots, recognized text, clipboard text, or copied-text previews.
 
-The application stores only ordinary preferences needed for versioned onboarding, shortcut configuration, permission-history presentation, and settings behavior. Launch at Login state is read from macOS rather than copied into a preference that could become stale. These values never contain captured images or recognized text.
+The application stores only ordinary preferences needed for versioned onboarding, shortcut configuration, permission-history presentation, and settings behavior. Its permission history records only whether CopyLasso has requested Screen Recording access and whether access was previously observed; it does not store screen content or a definitive macOS authorization status. Launch at Login state is read from macOS rather than copied into a preference that could become stale. These values never contain captured images or recognized text.
 
 ## macOS Permissions
 
-CopyLasso needs macOS Screen Recording permission to capture the selected pixels. It requests that permission only when the user first attempts a capture and provides recovery guidance if access is denied or later revoked.
+CopyLasso needs macOS Screen Recording permission to capture the selected pixels. It performs no permission check or request merely by launching. A user-initiated Capture Text command checks access and requests it only when the current CopyLasso preference history has never requested it. When access remains unavailable, a nonactivating recovery panel explains the manual System Settings path without claiming macOS can distinguish denial from pending approval or definitively identify revocation.
+
+Core Graphics preflight can remain stale inside a running process after access changes. G12 detects revocation once preflight reflects it, typically after relaunch. A future real capture denial will be authoritative even if preflight still reports access. No screen pixels are captured by the current production workflow.
 
 The v0.1 core workflow does not require Accessibility or Input Monitoring permission. macOS may prevent protected or DRM-restricted content from being captured, and CopyLasso does not attempt to bypass those protections.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CopyLasso is a free, open-source macOS utility for copying visible text from anywhere on screen. Press a global shortcut, drag around text, and receive the recognized plain text on the clipboard.
 
-> **Project status:** CopyLasso is in early pre-release development. The dockless app now includes first-run setup, persistent native Settings, explicit Launch at Login control, and a configurable global shortcut that reaches the same tested no-side-effect Capture Text stub as the menu. OCR, screen-capture, and multi-display selection feasibility are proven, but the production capture workflow is not connected and no public release is available.
+> **Project status:** CopyLasso is in early pre-release development. The dockless app now includes first-run setup, persistent native Settings, explicit Launch at Login control, a configurable global shortcut, and production Screen Recording permission handling with nonactivating recovery guidance. An authorized request currently stops at a temporary selection boundary; production selection, capture, OCR, clipboard, and feedback remain unconnected, and no public release is available.
 
 ## Planned v0.1 Experience
 
@@ -29,7 +29,7 @@ See the full [privacy policy](PRIVACY.md) and [v0.1 product contract](docs/v0.1-
 - Swift 6 and the `swift-format` version bundled with that Xcode release
 - An Apple Development signing identity for signed local builds
 
-The current verified baseline is Xcode 26.6 with Swift 6.3.3. See [Architecture Overview](docs/architecture/overview.md) for component boundaries, [Development Environment](docs/development-environment.md) for setup and canonical commands, and [Build Configuration](docs/architecture/build-configuration.md) for target and signing decisions.
+The current verified baseline is Xcode 26.6 with Swift 6.3.3. See [Architecture Overview](docs/architecture/overview.md) for component boundaries, [Development Environment](docs/development-environment.md) for setup and canonical commands, [Testing](docs/testing.md) for the signed permission matrix, and [Build Configuration](docs/architecture/build-configuration.md) for target and signing decisions.
 
 Run the same unsigned build and unit-test pipeline used by CI:
 

--- a/docs/architecture/ADR-002-screen-capture.md
+++ b/docs/architecture/ADR-002-screen-capture.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** July 10, 2026
-- **Scope:** G06 feasibility spike; production permission UI remains deferred to G11 and production capture to G14
+- **Scope:** G06 feasibility evidence, G12 production permission handling, and the G14 production capture boundary
 
 ## Context
 
@@ -25,6 +25,10 @@ ScreenCaptureKit is viable for CopyLasso v0.1. The internal experiment:
 The experiment uses [`CGPreflightScreenCaptureAccess()`](https://developer.apple.com/documentation/coregraphics/cgpreflightscreencaptureaccess%28%29) and [`CGRequestScreenCaptureAccess()`](https://developer.apple.com/documentation/coregraphics/cgrequestscreencaptureaccess%28%29), plus two preferences recording whether this CopyLasso preferences history has requested or previously observed access. Its labels intentionally say "after a prior request" and "may have been revoked" rather than claiming an unavailable macOS state.
 
 An actual ScreenCaptureKit permission-denied error is authoritative. It overrides a stale positive preflight result and produces the likely-revoked observation.
+
+G12 implements the production permission portion with the same deliberately limited semantics. A `SystemScreenCapturePermissionService` performs Core Graphics preflight only after a user invokes Capture Text, records request history before calling the system request, and records previously observed access only after a direct positive result. A singleton nonactivating recovery panel explains the manual path without claiming macOS can distinguish denial from pending approval. It never retries automatically after System Settings changes.
+
+The approved production split is explicit: G12 detects revocation once Core Graphics preflight reflects it. The same-process stale-positive case observed below remains G14's responsibility, because only the real ScreenCaptureKit attempt can authoritatively report that access is unavailable while preflight still says granted.
 
 CopyLasso will not use `SCContentSharingPicker` because a case-by-case picker cannot preserve the shortcut-to-arbitrary-region workflow. It will not request the managed persistent-content-capture entitlement, which Apple documents for screen-sharing products, and it will not fall back to deprecated Core Graphics screenshot APIs. Apple Developer Technical Support identifies the picker and managed entitlement as the two ways to avoid the direct-capture warning. Neither is appropriate for CopyLasso. See Apple's [ScreenCaptureKit warning discussion](https://developer.apple.com/forums/thread/765103).
 
@@ -54,6 +58,23 @@ The Debug bundle's scoped reset command is:
 
 Apple documents manual permission management in [Control access to screen and system audio recording on Mac](https://support.apple.com/guide/mac-help/control-access-screen-system-audio-recording-mchld6aa7d23/mac).
 
+## G12 Production Permission Evidence
+
+The production Core Graphics lifecycle was verified July 10, 2026 with the same macOS 26.5.1 (`25F80`), Xcode 26.6 (`17F113`), and stable Apple Development signing requirement used for the feasibility work:
+
+| State or action | Production result |
+| --- | --- |
+| Ordinary dockless launch | No Screen Recording check, system prompt, or CopyLasso recovery panel appeared. |
+| First shortcut request and Deny | macOS presented its Screen Recording dialog. After **Deny**, CopyLasso presented one nonactivating recovery panel and did not enter selection. |
+| Repeated denied attempts | Three shortcut attempts reused the same panel without another system request or inconsistent busy state. |
+| Open System Settings | The explicit action intentionally changed focus and opened Screen & System Audio Recording directly. |
+| Enable and choose Later | CopyLasso did not retry automatically. An explicit retry remained unavailable and explained that choosing **Later** requires quitting and reopening. |
+| Relaunch after approval | The designated signing requirement was unchanged. Three shortcut attempts reached the temporary G13 selection boundary, returned to idle, and produced no overlay, pixels, OCR, clipboard mutation, or visible feedback. |
+| Revoke and relaunch | Preflight reflected the revocation and the panel said access was previously available and may have been turned off. **Try Again** updated the same panel with explicit relaunch guidance. |
+| Full-screen focus | The panel appeared in a full-screen TextEdit Space while CopyLasso remained non-frontmost according to Launch Services. |
+
+No ScreenCaptureKit enumeration or capture call occurred, so the private-window-picker-bypass warning did not appear. Source and binary guards also confirmed that G12 added no Accessibility, Input Monitoring, Microphone, Vision, pasteboard, or pixel path.
+
 ## Privacy and Sandbox Results
 
 - App Sandbox and Hardened Runtime remained enabled in the signed experiment.
@@ -73,4 +94,4 @@ Apple documents manual permission management in [Control access to screen and sy
 - The live permission matrix covers the maintainer's current Apple Silicon macOS 26 workstation. macOS 14 compatibility is established by the deployment target and macOS 14 API surface; clean older-system VM behavior remains a later release check.
 - Protected or DRM-controlled content may legitimately capture as blank and is outside the arbitrary-allowed-pixels guarantee.
 - The private-window-picker warning wording and duration are controlled by macOS and may change. Production UI must present recovery guidance without promising a distinction or restart behavior the API cannot prove.
-- G07 may proceed with overlay and coordinate-conversion feasibility. G08 retired the executable harness and live adapter while preserving the authorization-history semantics and narrow permission/capture contracts. G12 and G14 own their production implementations.
+- G07 established overlay and coordinate-conversion feasibility. G08 retired the executable harness and live adapter while preserving the authorization-history semantics and narrow permission/capture contracts. G12 now owns the production Core Graphics lifecycle and recovery UI; G14 remains responsible for authoritative ScreenCaptureKit denial and pixel capture.

--- a/docs/architecture/build-configuration.md
+++ b/docs/architecture/build-configuration.md
@@ -10,7 +10,7 @@ The shared `CopyLasso` scheme contains:
 - `CopyLassoTests`, the XCTest unit-test bundle; and
 - `CopyLassoUITests`, the XCTest UI-test bundle.
 
-The application is a dockless SwiftUI menu-bar utility. Debug and Release compile the same onboarding, Settings, Launch at Login, global-shortcut, production-neutral model, service-contract, and capture-workflow code. Neither configuration contains a live permission, selection, capture, OCR, clipboard, or feedback adapter.
+The application is a dockless SwiftUI menu-bar utility. Debug and Release compile the same onboarding, Settings, Launch at Login, global-shortcut, model, service-contract, capture-workflow, production permission, and recovery-panel code. Neither configuration contains a live selection, capture, OCR, clipboard, or feedback adapter.
 
 ## Supported Configuration
 
@@ -31,7 +31,7 @@ The application is a dockless SwiftUI menu-bar utility. Debug and Release compil
 
 Release builds explicitly set both macOS architectures and disable `ONLY_ACTIVE_ARCH`. The canonical pipeline inspects the built executable with `lipo`; checking the build setting alone is not sufficient.
 
-There is no source-file exclusion list for experimental code. The G05-G07 executable experiments were retired after their decisions were recorded. The canonical pipeline rejects their former launch arguments and live platform symbols, enforces model/workflow import boundaries, and verifies that the neutral coordinator and geometry model compile into both Debug and Release.
+There is no source-file exclusion list for experimental code. The G05-G07 executable experiments were retired after their decisions were recorded. The canonical pipeline rejects their former launch arguments and all live selection, capture, OCR, and pasteboard symbols; permits the two Core Graphics Screen Recording authorization functions only in `ScreenCapturePermissionService.swift`; enforces model/workflow import boundaries; rejects Debug-only G12 controls in Release; and verifies that the coordinator, geometry model, production permission service, and recovery controller compile into both Debug and Release.
 
 Both configurations generate their Info.plist through Xcode and set `LSUIElement` to `YES`. The canonical pipeline checks the build setting and the generated Debug and Release bundles so a normal Dock application cannot be introduced accidentally.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-CopyLasso currently provides a production-neutral capture architecture and a usable dockless shell, not an end-to-end capture workflow. The application includes versioned onboarding, persistent Settings, Launch at Login, and a configurable global shortcut. Feasibility evidence from G05-G07 is retained in the ADRs, while production capture adapters are added incrementally in G12-G17 and connected in G18.
+CopyLasso currently provides a usable dockless shell and the first live boundary of its production capture architecture, not an end-to-end capture workflow. The application includes versioned onboarding, persistent Settings, Launch at Login, a configurable global shortcut, and production Screen Recording permission handling. Feasibility evidence from G05-G07 is retained in the ADRs, while the remaining production adapters are added incrementally in G13-G17 and connected in G18.
 
 ## Components and Dependency Direction
 
@@ -12,18 +12,20 @@ flowchart LR
   Contracts --> Models
   Settings["Settings and onboarding"] --> Services
   Settings --> Models
-  Adapters["Future platform adapters G12-G17"] -. conform .-> Contracts
+  Permission["Core Graphics permission adapter G12"] -. conform .-> Contracts
+  Recovery["Nonactivating recovery panel G12"] --> Permission
+  Adapters["Future platform adapters G13-G17"] -. conform .-> Contracts
 ```
 
 - `App` owns the dockless process, scene lifecycle, menu and shortcut command routing, and application termination boundary. `SharedUI` contains the menu, onboarding, Settings, and auxiliary-window presentation.
-- `CaptureWorkflow` owns phase transitions and busy-state policy. It does not call platform APIs in G08.
-- `Services` declares narrow permission, selection, capture, OCR, clipboard, and feedback boundaries.
+- `CaptureWorkflow` owns phase transitions and busy-state policy. Its G12 command slice invokes only permission and the temporary selection boundary.
+- `Services` declares narrow permission, selection, capture, OCR, clipboard, and feedback boundaries. The Core Graphics permission adapter is isolated here.
 - `Models` contains geometry, observations, authorization observations, and feedback values without AppKit, SwiftUI, ScreenCaptureKit, or Vision dependencies.
 - `Settings` owns the typed `UserDefaults` adapter, onboarding-version policy, shortcut storage boundary, and observable settings controller. The system login-item adapter remains isolated in `Services`.
 
-Dependencies point toward contracts and neutral models. UI and future adapters may depend on them; models and workflow state must never depend on UI or live platform frameworks.
+Dependencies point toward contracts and neutral models. UI and platform adapters may depend on them; models and workflow state must never depend on UI or live platform frameworks.
 
-## Future Data Flow
+## Production Data Flow
 
 ```mermaid
 flowchart LR
@@ -37,13 +39,14 @@ flowchart LR
   Feedback --> Idle["Idle"]
 ```
 
-The coordinator models the corresponding phases: idle, requesting permission, selecting, capturing, recognizing, completing, cancelled, and failed. It carries no image or recognized-text payload in observable state. Menu and global-shortcut requests now reach the same `CaptureCommand`; a no-side-effect stub completes the legal transitions back to idle. G18 will replace that stub with the private transient operation context and real service invocation.
+The coordinator models the corresponding phases: idle, requesting permission, selecting, capturing, recognizing, completing, cancelled, and failed. It carries no image or recognized-text payload in observable state. Menu and global-shortcut requests reach the same `CaptureCommand`. G12 performs a user-initiated Core Graphics preflight, requests access only for a never-requested history, presents recovery for unavailable access, and reaches a temporary selection service after approval. That temporary service intentionally reports that G13 is not yet available, and the command resets to idle without capturing pixels. G18 will connect the complete service chain through a private transient operation context.
 
 Cancellation is a normal result. It enters an explicit cancelled state and returns to idle only after a reset acknowledging cleanup. Failure records only the responsible stage, never captured content, recognized text, raw platform errors, or user data. A request received outside idle is rejected without changing state.
 
 ## Concurrency and Lifetime
 
 - `CaptureCoordinator`, permission, selection, clipboard, and feedback contracts are main-actor isolated because they coordinate application or UI state.
+- The Core Graphics permission adapter performs no work during construction or launch. The singleton recovery panel is nonactivating; only its explicit **Open System Settings** action changes focus.
 - Capture and OCR contracts are asynchronous and `Sendable`. Their future adapters must not block the main actor.
 - The production Vision adapter introduced in G15 will perform user-initiated recognition away from the main actor, following ADR-001.
 - Geometry and future text assembly remain pure and independent of AppKit UI objects and Vision framework types.
@@ -63,4 +66,4 @@ Cancellation is a normal result. It enters an explicit cancelled state and retur
 | G17 | Clipboard and nonactivating feedback adapters |
 | G18 | End-to-end service orchestration, cleanup, and integration tests |
 
-Until the owning goal is implemented, each capture service has only a contract and test double. The settings and shortcut adapters are live, but no hidden capture workflow exists.
+The G12 permission adapter and recovery panel are live. Selection remains a temporary unavailable service, while capture, OCR, clipboard, and feedback have only contracts and test doubles. No hidden pixel or text workflow exists.

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -145,7 +145,7 @@ Interactive Run and UI testing require runnable local signing. Keep any team or 
 
 The G05-G07 executable feasibility harnesses were retired after their evidence was recorded. Their former launch arguments are no longer supported, and neither Debug nor Release contains live Vision, ScreenCaptureKit, overlay, clipboard, or feedback behavior.
 
-The application target now contains the dockless menu-bar shell plus production-neutral models, service contracts, and workflow state. Capture Text exercises only an auto-completing coordinator stub and performs no platform work. See [Architecture Overview](architecture/overview.md) for dependency and actor boundaries, [ADR-001](architecture/ADR-001-vision-ocr.md) for OCR evidence, [ADR-002](architecture/ADR-002-screen-capture.md) for permission and capture evidence, and [ADR-003](architecture/ADR-003-selection-overlay.md) for selection and coordinate evidence. Later production goals reintroduce each live adapter behind the recorded contract.
+The application target now contains the dockless menu-bar shell, production-neutral models and service contracts, and the live Core Graphics Screen Recording permission adapter. Capture Text performs the G12 permission slice and, after authorization, reaches a temporary selection service that intentionally stops before any overlay or pixel access. See [Architecture Overview](architecture/overview.md) for dependency and actor boundaries, [Testing](testing.md) for the signed permission matrix, [ADR-001](architecture/ADR-001-vision-ocr.md) for OCR evidence, [ADR-002](architecture/ADR-002-screen-capture.md) for permission and capture evidence, and [ADR-003](architecture/ADR-003-selection-overlay.md) for selection and coordinate evidence.
 
 ## GitHub Actions
 
@@ -162,8 +162,16 @@ The required check names are `build and test (arm64)` and `build and test (x86_6
 
 ## Current Boundary
 
-The repository contains a buildable dockless menu-bar app with onboarding, persistent Settings, Launch at Login, a configurable global shortcut, production-neutral capture architecture, service test doubles, and retained feasibility evidence. The shortcut and menu both reach the no-side-effect capture coordinator stub; production permission, selection, capture, OCR, clipboard, and feedback adapters remain intentionally unimplemented.
+The repository contains a buildable dockless menu-bar app with onboarding, persistent Settings, Launch at Login, a configurable global shortcut, a production Screen Recording permission service, a singleton nonactivating recovery panel, service test doubles, and retained feasibility evidence. The shortcut and menu both enter the same permission workflow. Selection is a temporary unavailable boundary, and production selection, capture, OCR, clipboard, and feedback remain intentionally unimplemented.
 
 For a development-only clean first-run state, open Settings and choose **Reset Local Development State…**. After confirmation, CopyLasso unregisters its login item and clears its owned preferences and shortcut data before reopening onboarding. This does not reset Screen Recording permission.
+
+Reset the Debug bundle's macOS permission separately only when running the controlled matrix:
+
+```sh
+/usr/bin/tccutil reset ScreenCapture io.github.bennetthilberg.copylasso.debug
+```
+
+The complete order, expected observations, and focus checks are documented in [Testing](testing.md). Use a stably signed Debug build so a rebuild does not create misleading permission churn.
 
 Launch at Login uses `SMAppService.mainApp` and therefore requires a runnable signed app for real verification. The automated unit suite covers status mapping, failure handling, and reconciliation with doubles; final local verification must still enable the real item, log out and back in or reboot, confirm the dockless process starts, then disable it and repeat.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,67 @@
+# Testing CopyLasso
+
+CopyLasso's canonical unsigned build and unit-test pipeline is:
+
+```sh
+./scripts/ci.sh
+```
+
+The pipeline lints all Swift source, resolves the exact package dependency, builds Debug and both XCTest bundles, runs the unit suite serially with timeouts, inspects required build and privacy boundaries, builds Universal 2 Release, and verifies both executable slices. It does not launch the unsigned UI-test runner or alter macOS privacy state.
+
+## Controlled Permission UI Coverage
+
+Signed UI tests use Debug-only permission doubles. They cover prior-request and previously-granted recovery wording, singleton reuse, System Settings failure instructions, retry routing, Cancel, menu availability, keyboard actions, and accessibility identifiers without calling Core Graphics permission functions or changing real TCC state.
+
+The controlled launch arguments begin with `--g12-` and are compiled out of Release. CI inspects the Release executable to prevent them from leaking. The application uses the real production permission service unless the existing `--g10-g11-ui-testing` test boundary is also present.
+
+Run the signed UI suite through Xcode with the shared `CopyLasso` scheme and **My Mac**, or use a locally signed `xcodebuild test` invocation. Keep the development team only in ignored `Local.xcconfig`; never paste signing identity details into logs or documentation.
+
+## Real Screen Recording Permission Matrix
+
+Use one stably Apple Development-signed Debug application for the entire matrix. Changing its signing requirement or bundle identifier can create a different macOS privacy identity and invalidate the result.
+
+First clear CopyLasso-owned development state from **Settings > Reset Local Development State…**, quit CopyLasso, and then reset only the Debug bundle's Screen Recording decision:
+
+```sh
+/usr/bin/tccutil reset ScreenCapture io.github.bennetthilberg.copylasso.debug
+```
+
+This command changes macOS privacy state and must never run automatically in tests or CI.
+
+Verify in this order:
+
+1. Launch CopyLasso normally. Confirm there is no Screen Recording prompt or recovery panel before a user command.
+2. With another application frontmost, invoke **Capture Text**, choose **Deny** in the macOS dialog, and confirm one CopyLasso recovery panel appears. Selection must not begin, and the clipboard must remain unchanged.
+3. Invoke Capture Text again from both the menu and shortcut. Confirm macOS does not stack request dialogs, CopyLasso reuses one recovery panel, and each attempt returns the coordinator to idle.
+4. Choose **Open System Settings**. Confirm the Screen & System Audio Recording pane opens. Enable CopyLasso and follow the actual macOS **Quit & Reopen** prompt if one appears; otherwise return to CopyLasso and explicitly choose **Try Again**. CopyLasso must not retry automatically. If **Later** was chosen and access is still unavailable, **Try Again** reports that CopyLasso must be quit and reopened rather than appearing inert.
+5. After any required relaunch, invoke Capture Text. Confirm authorization reaches the temporary G13 selection boundary and returns to idle without an overlay, captured pixels, OCR, clipboard mutation, or feedback.
+6. Disable CopyLasso in Screen & System Audio Recording and relaunch it. Invoke Capture Text and confirm the recovery copy says access was previously available and may have been turned off; it must not claim definitive revocation.
+7. Repeat recovery while an ordinary full-screen application is frontmost. Confirm presenting or updating CopyLasso's nonactivating panel does not change the frontmost application. Only **Open System Settings** intentionally changes focus.
+8. Confirm macOS did not show the ScreenCaptureKit private-window-picker-bypass warning and that no Accessibility, Input Monitoring, Microphone, or clipboard access was introduced.
+
+Core Graphics preflight may remain positive inside a process after permission is disabled. G12 records revocation only once preflight reflects it, normally after relaunch. G14 must treat an actual ScreenCaptureKit capture denial as authoritative when preflight is stale.
+
+### G12 Verified Result
+
+The production matrix passed July 10, 2026 on macOS 26.5.1 (`25F80`) with Xcode 26.6 (`17F113`) and one stably Apple Development-signed Debug identity:
+
+- Ordinary launch caused no Screen Recording prompt or recovery panel.
+- The first shortcut request displayed only the macOS Screen Recording dialog. Choosing **Deny** produced one CopyLasso recovery panel after the system response.
+- Three subsequent shortcut attempts reused that panel and produced no additional system dialog.
+- **Open System Settings** opened Screen & System Audio Recording directly. Choosing **Later** after enabling access caused no automatic retry; the explicit retry guidance correctly required a relaunch.
+- The designated signing requirement matched across clean build locations. After relaunch, three authorized shortcut requests reached the temporary selection boundary and returned with no overlay, pixels, OCR, clipboard change, or visible feedback.
+- After revocation and relaunch, CopyLasso used the cautious previously-observed-access wording. The panel and its retry update appeared over a full-screen TextEdit Space while Launch Services still reported that CopyLasso was not frontmost.
+- No ScreenCaptureKit private-window-picker warning, Accessibility, Input Monitoring, Microphone, capture, OCR, or pasteboard behavior occurred.
+
+During the revocation check, macOS initially relaunched a retired scaffold from Xcode's default DerivedData because that duplicate bundle remained registered with Launch Services. Its normal window and missing `LSUIElement` identified it as stale, while the current G12 build was verified dockless and free of the retired placeholder. Unregistering only the stale generated build and registering the current signed bundle restored the intended test. Keep one Debug copy registered when validating **Quit & Reopen** so Launch Services cannot choose an obsolete duplicate with the same bundle identifier.
+
+## Expected Permission Observations
+
+| Direct observation and local history | CopyLasso observation |
+| --- | --- |
+| Preflight granted | Granted; record previously observed access |
+| Not granted; never requested in this preferences history | Not granted; first user command may request access |
+| Not granted; a request was recorded | Not granted after a prior request; macOS does not expose denied versus pending |
+| Not granted; access was previously observed | Not granted after previously observed access; access may have been turned off |
+
+Permission history contains only the two booleans needed for these neutral labels. It contains no pixels, recognized text, raw platform error, or definitive copy of macOS authorization state.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -86,9 +86,19 @@ if [[ "$service_management_imports" != "CopyLasso/Services/LaunchAtLoginService.
     exit 1
 fi
 
-readonly retired_runtime_pattern='CGPreflightScreenCaptureAccess|CGRequestScreenCaptureAccess|SCScreenshotManager|SCShareableContent|VNRecognizeTextRequest|SelectionOverlayPanel|--g06-capture-spike|--g07-selection-spike|NSPasteboard'
-if /usr/bin/grep -R -nE "$retired_runtime_pattern" CopyLasso; then
-    echo "A retired experiment or live platform adapter remains in the application target." >&2
+readonly permission_service='CopyLasso/Services/ScreenCapturePermissionService.swift'
+permission_api_files="$({ /usr/bin/grep -R -lE \
+    'CGPreflightScreenCaptureAccess|CGRequestScreenCaptureAccess' CopyLasso || true; })"
+if [[ "$permission_api_files" != "$permission_service" ]] || \
+    ! /usr/bin/grep -q 'CGPreflightScreenCaptureAccess' "$permission_service" || \
+    ! /usr/bin/grep -q 'CGRequestScreenCaptureAccess' "$permission_service"; then
+    echo "Core Graphics Screen Recording permission APIs must remain confined to the production permission service." >&2
+    exit 1
+fi
+
+readonly prohibited_capture_runtime_pattern='import[[:space:]]+(ScreenCaptureKit|Vision)|SCScreenshotManager|SCShareableContent|SCContentSharingPicker|CGWindowListCreateImage|CGDisplayCreateImage|VNRecognizeTextRequest|SelectionOverlayPanel|--g06-capture-spike|--g07-selection-spike|NSPasteboard'
+if /usr/bin/grep -R -nE "$prohibited_capture_runtime_pattern" CopyLasso; then
+    echo "A prohibited capture, OCR, pasteboard, or retired experiment API remains in the application target." >&2
     exit 1
 fi
 
@@ -220,8 +230,8 @@ if [[ ! -x "$release_executable" ]]; then
     exit 1
 fi
 
-if /usr/bin/strings "$release_executable" | /usr/bin/grep -q -- '--g10-g11-'; then
-    echo "Debug-only G10-G11 UI-test controls leaked into Release." >&2
+if /usr/bin/strings "$release_executable" | /usr/bin/grep -qE -- '--g10-g11-|--g12-'; then
+    echo "Debug-only UI-test controls leaked into Release." >&2
     exit 1
 fi
 
@@ -230,6 +240,8 @@ if [[ ! -f "$debug_module" ]] || \
     ! /usr/bin/grep -a -q 'CaptureCoordinator' "$debug_module" || \
     ! /usr/bin/grep -a -q 'DisplayGeometry' "$debug_module" || \
     ! /usr/bin/grep -a -q 'CaptureCommand' "$debug_module" || \
+    ! /usr/bin/grep -a -q 'SystemScreenCapturePermissionService' "$debug_module" || \
+    ! /usr/bin/grep -a -q 'PermissionRecoveryPanelController' "$debug_module" || \
     ! /usr/bin/grep -a -q 'SettingsController' "$debug_module" || \
     ! /usr/bin/grep -a -q 'GlobalShortcutController' "$debug_module"; then
     echo "Debug is missing the production-neutral workflow architecture." >&2
@@ -245,6 +257,8 @@ for release_architecture in arm64 x86_64; do
     if ! /usr/bin/grep -a -q 'CaptureCoordinator' "$release_module" || \
         ! /usr/bin/grep -a -q 'DisplayGeometry' "$release_module" || \
         ! /usr/bin/grep -a -q 'CaptureCommand' "$release_module" || \
+        ! /usr/bin/grep -a -q 'SystemScreenCapturePermissionService' "$release_module" || \
+        ! /usr/bin/grep -a -q 'PermissionRecoveryPanelController' "$release_module" || \
         ! /usr/bin/grep -a -q 'SettingsController' "$release_module" || \
         ! /usr/bin/grep -a -q 'GlobalShortcutController' "$release_module"; then
         echo "Release is missing the production-neutral workflow architecture for $release_architecture." >&2


### PR DESCRIPTION
## Summary
- add the user-initiated Core Graphics Screen Recording permission lifecycle with persistent neutral history
- route the shared capture command through permission handling and a temporary G13-unavailable selection boundary
- add a singleton nonactivating recovery panel with System Settings, retry, cancellation, and explicit relaunch feedback
- strengthen CI API confinement and document architecture, privacy, testing, and live permission evidence

## Verification
- 88 unit tests pass on both arm64 and x86_64 canonical pipelines
- 19 signed UI tests pass, including recovery variants, singleton reuse, retry feedback, keyboard cancellation, and accessibility labels
- Universal 2 Release contains arm64 and x86_64 and excludes Debug permission controls
- live signed matrix passed launch, denial, repeated attempts, deep link, Later, approval, revocation, and full-screen focus preservation

## Scope
No ScreenCaptureKit enumeration, pixels, selection overlay, OCR, clipboard write, feedback workflow, entitlement, or new dependency is included.