### PR TITLE
G27: create reproducible release package

### DIFF
--- a/CopyLasso.xcodeproj/project.pbxproj
+++ b/CopyLasso.xcodeproj/project.pbxproj
@@ -436,7 +436,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Configuration/CopyLasso-Info.plist";
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Bennett Hilberg. All rights reserved.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Created by Bennett Hilberg. Open source under the MIT License.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -469,7 +469,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Configuration/CopyLasso-Info.plist";
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Bennett Hilberg. All rights reserved.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Created by Bennett Hilberg. Open source under the MIT License.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/CopyLasso/App/CopyLassoApp.swift
+++ b/CopyLasso/App/CopyLassoApp.swift
@@ -138,6 +138,9 @@ struct CopyLassoApp: App {
       )
     }
     .menuBarExtraStyle(.menu)
+    .commands {
+      CopyLassoApplicationCommands()
+    }
 
     Settings {
       SettingsView(
@@ -183,4 +186,16 @@ struct CopyLassoApp: App {
       }
     }
   #endif
+}
+
+private struct CopyLassoApplicationCommands: Commands {
+  @Environment(\.openWindow) private var openWindow
+
+  var body: some Commands {
+    CommandGroup(replacing: .appInfo) {
+      Button("About CopyLasso") {
+        openWindow(id: "about")
+      }
+    }
+  }
 }

--- a/CopyLasso/Models/AboutMetadata.swift
+++ b/CopyLasso/Models/AboutMetadata.swift
@@ -11,7 +11,7 @@ struct AboutMetadata: Equatable, Sendable {
   let applicationName = "CopyLasso"
   let version: String
   let build: String
-  let copyright = "Copyright © 2026 Bennett Hilberg"
+  let creatorDescription = "Created by Bennett Hilberg"
   let licenseName = "MIT License"
   let summary = "Free and open source. Private, offline, and local."
   let repositoryURL = URL(string: "https://github.com/bennetthilberg/copylasso")!

--- a/CopyLasso/SharedUI/AboutView.swift
+++ b/CopyLasso/SharedUI/AboutView.swift
@@ -44,11 +44,11 @@ struct AboutView: View {
         .foregroundStyle(.secondary)
         .multilineTextAlignment(.center)
 
-      Text(metadata.copyright)
+      Text(metadata.creatorDescription)
         .font(.caption)
         .foregroundStyle(.secondary)
-        .accessibilityLabel(metadata.copyright)
-        .accessibilityIdentifier("copylasso.about.copyright")
+        .accessibilityLabel(metadata.creatorDescription)
+        .accessibilityIdentifier("copylasso.about.creator")
 
       HStack(spacing: 16) {
         Link("Project Repository", destination: metadata.repositoryURL)

--- a/CopyLassoTests/App/MenuBarShellTests.swift
+++ b/CopyLassoTests/App/MenuBarShellTests.swift
@@ -43,7 +43,7 @@ final class MenuBarShellTests: XCTestCase {
     )
 
     XCTAssertEqual(metadata.applicationName, "CopyLasso")
-    XCTAssertEqual(metadata.copyright, "Copyright © 2026 Bennett Hilberg")
+    XCTAssertEqual(metadata.creatorDescription, "Created by Bennett Hilberg")
     XCTAssertEqual(metadata.licenseName, "MIT License")
     XCTAssertEqual(
       metadata.summary,

--- a/CopyLassoUITests/CopyLassoUITests.swift
+++ b/CopyLassoUITests/CopyLassoUITests.swift
@@ -202,8 +202,8 @@ final class CopyLassoUITests: XCTestCase {
         app.staticTexts["copylasso.about.version"], equals: "Version 0.1.0 (1)"
       )
       assertAccessibleText(
-        app.staticTexts["copylasso.about.copyright"],
-        equals: "Copyright © 2026 Bennett Hilberg"
+        app.staticTexts["copylasso.about.creator"],
+        equals: "Created by Bennett Hilberg"
       )
       XCTAssertTrue(app.links["copylasso.about.repository"].exists)
       XCTAssertTrue(app.links["copylasso.about.license"].exists)

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -24,6 +24,7 @@ Record every command, artifact name, SHA-256 checksum, commit, tag, signing iden
 
 ## G27 - Reproducible Release Package
 
+- [ ] Follow the version-controlled process in [`release-packaging.md`](release-packaging.md) from a clean, exact packaging commit.
 - [ ] Build the final disk image from the exact stapled application without rebuilding the app; include CopyLasso and an Applications-folder alias only.
 - [ ] Verify the read-only DMG mount, drag-to-Applications layout, production identity, Universal 2 architectures, version/build, strict signature, Gatekeeper assessment, and stapled ticket.
 - [ ] Record the DMG SHA-256 checksum, file size, embedded-app checksum, source commit, version/build, and notarization linkage.

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -1,0 +1,92 @@
+# Release Packaging
+
+This document defines the local G27 process that turns the exact G26 Developer ID handoff into the disk image intended for later release qualification. It creates no public release and uploads nothing except the signed disk image submitted privately to Apple's notarization service.
+
+## Immutable inputs
+
+G27 must reuse the exact G26 application, archive dSYM, accepted notarization records, and payload commit. It must not archive, export, rebuild, modify, or re-sign `CopyLasso.app`.
+
+The payload commit identifies the application contents. The packaging commit separately identifies the version-controlled scripts that create and verify the disk image. Both full commit identifiers are recorded in ignored local evidence.
+
+Before packaging:
+
+1. Confirm G26 is merged and the packaging branch descends from its qualified payload commit.
+2. Confirm the tracked worktree is clean.
+3. Confirm the G26 handoff directory is named with the full payload commit and still contains `export/CopyLasso.app`, `CopyLasso.xcarchive/dSYMs/CopyLasso.app.dSYM`, and matching accepted notarization records.
+4. Unlock the login Keychain if needed. The valid Developer ID Application private key remains there.
+5. Load the approved team identifier into `COPYLASSO_EXPECTED_TEAM_ID` without writing it to a command, file, or log. Authentication continues to use the `copylasso-notary` Keychain profile established in G26.
+
+The packaging script refuses a dirty tracked tree, a handoff/commit mismatch, more than one matching signing identity, an output outside ignored `dist/`, or application-input changes after the payload commit.
+
+## Create two local packages
+
+Set local shell variables without committing their values:
+
+```bash
+PAYLOAD_COMMIT="<full G26 payload commit>"
+PACKAGING_COMMIT="$(git rev-parse HEAD)"
+G26_HANDOFF="$HOME/Library/Developer/CopyLasso/G26/$PAYLOAD_COMMIT"
+read -r -s COPYLASSO_EXPECTED_TEAM_ID
+export COPYLASSO_EXPECTED_TEAM_ID
+```
+
+Run the complete process twice from that same clean source state. Each run creates, signs, notarizes, staples, and verifies its own disk image, so each has a distinct Apple submission:
+
+```bash
+./scripts/package-release.sh \
+  --handoff "$G26_HANDOFF" \
+  --payload-commit "$PAYLOAD_COMMIT" \
+  --output-dir "$PWD/dist/g27/$PACKAGING_COMMIT/run-1"
+
+./scripts/package-release.sh \
+  --handoff "$G26_HANDOFF" \
+  --payload-commit "$PAYLOAD_COMMIT" \
+  --output-dir "$PWD/dist/g27/$PACKAGING_COMMIT/run-2"
+```
+
+The script deliberately uses the saved `copylasso-notary` profile. It never accepts an Apple ID or app-specific password. A Keychain or Touch ID confirmation may still appear when signing the disk image.
+
+Each run produces:
+
+- `CopyLasso-0.1.0.dmg`, a signed, notarized, stapled, read-only UDZO image;
+- `CopyLasso-0.1.0.dmg.sha256`, the public-form SHA-256 checksum record;
+- `CopyLasso-0.1.0.dSYM.zip`, the matching private symbol archive;
+- the accepted submission record and complete Apple diagnostic log;
+- payload, UUID, signature, stapling, and final-verification evidence; and
+- `release-evidence.txt`, containing only portable metadata rather than local paths or account values.
+
+The mounted image must contain exactly `CopyLasso.app` and an `Applications` link that resolves to `/Applications`. It contains no installer, helper, README, background, or hidden layout metadata.
+
+## Verify and compare
+
+The package script calls the verifier before it reports success. It can also be run directly:
+
+```bash
+./scripts/verify-release-package.sh \
+  --payload-app "$G26_HANDOFF/export/CopyLasso.app" \
+  "$PWD/dist/g27/$PACKAGING_COMMIT/run-1"
+```
+
+Verification covers the checksum, Developer ID disk-image signature and timestamp, accepted notarization records, stapled ticket, Gatekeeper disk-image assessment, UDZO format, read-only mount, exact volume layout, embedded application identity and signatures, payload manifest, version `0.1.0`, build `1`, production bundle identifier, both architectures, and dSYM UUIDs.
+
+Compare the two complete runs:
+
+```bash
+./scripts/compare-release-packages.sh \
+  "$PWD/dist/g27/$PACKAGING_COMMIT/run-1" \
+  "$PWD/dist/g27/$PACKAGING_COMMIT/run-2"
+```
+
+The comparison requires identical mounted application manifests and normalized provenance. The DMG byte streams, checksums, sizes, filesystem metadata, signatures, tickets, and submission identifiers may differ because each run is independently signed and notarized.
+
+Finally, mount the selected verified image in Finder, confirm that it is read-only, drag CopyLasso through its Applications link only if no existing installation would be overwritten, launch that installed copy, verify `Version 0.1.0 (1)`, then quit it. Preserve the selected DMG, checksum, dSYM archive, and evidence under ignored `dist/`.
+
+## Recovery and handoff
+
+- If a run fails, preserve its directory for diagnosis and start a fresh run directory after correcting the cause.
+- If Apple rejects a submission, inspect the saved diagnostic log. Do not use `--force`, bypass validation, or staple a rejected image.
+- If the payload fails verification, stop. Repairing or regenerating the G26 application is outside G27.
+- If any tracked commit changes after qualification, rerun both complete packages at the new packaging commit.
+- Keep the dSYM archive private and restricted even though it contains no signing credential.
+
+Do not publish, tag, upload, or create a GitHub release in G27. G28 later introduces protected release CI and a draft-release rehearsal using the exact verified packaging contract.

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -64,6 +64,8 @@ The package script calls the verifier before it reports success. It can also be 
 ```bash
 ./scripts/verify-release-package.sh \
   --payload-app "$G26_HANDOFF/export/CopyLasso.app" \
+  --payload-commit "$PAYLOAD_COMMIT" \
+  --packaging-commit "$PACKAGING_COMMIT" \
   "$PWD/dist/g27/$PACKAGING_COMMIT/run-1"
 ```
 

--- a/scripts/audit-brand-release.sh
+++ b/scripts/audit-brand-release.sh
@@ -119,9 +119,22 @@ require_text CopyLasso/SharedUI/AboutView.swift 'NSApp.applicationIconImage'
 if /usr/bin/grep -Fq 'NSApp.applicationIconImage' CopyLasso/App/CopyLassoApp.swift; then
     fail "The About scene must defer loading the application icon until its view is presented."
 fi
-require_text CopyLasso/Models/AboutMetadata.swift 'Copyright © 2026 Bennett Hilberg'
+require_text CopyLasso/Models/AboutMetadata.swift 'Created by Bennett Hilberg'
 require_text CopyLasso/Models/AboutMetadata.swift 'https://github.com/bennetthilberg/copylasso'
 require_text CopyLasso/Models/AboutMetadata.swift 'KeyboardShortcuts 3.0.1'
+require_text CopyLasso/App/CopyLassoApp.swift 'CopyLassoApplicationCommands()'
+require_text CopyLasso/App/CopyLassoApp.swift 'CommandGroup(replacing: .appInfo)'
+
+if /usr/bin/grep -R -n -F 'All rights reserved' \
+    CopyLasso CopyLasso.xcodeproj/project.pbxproj; then
+    fail "The application must not claim all rights reserved for MIT-licensed CopyLasso."
+fi
+
+if [[ "$(/usr/bin/grep -c \
+    'INFOPLIST_KEY_NSHumanReadableCopyright = "Created by Bennett Hilberg. Open source under the MIT License.";' \
+    CopyLasso.xcodeproj/project.pbxproj)" != 2 ]]; then
+    fail "Every application configuration must embed the open-source creator description."
+fi
 
 if [[ "$(/usr/bin/grep -c 'MARKETING_VERSION = 0.1.0;' CopyLasso.xcodeproj/project.pbxproj)" != 6 ]] || \
     [[ "$(/usr/bin/grep -c 'CURRENT_PROJECT_VERSION = 1;' CopyLasso.xcodeproj/project.pbxproj)" != 6 ]] || \

--- a/scripts/audit-release-package.sh
+++ b/scripts/audit-release-package.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly package_script="$repository_root/scripts/package-release.sh"
+readonly verifier_script="$repository_root/scripts/verify-release-package.sh"
+readonly comparator_script="$repository_root/scripts/compare-release-packages.sh"
+readonly test_script="$repository_root/scripts/test-release-package.sh"
+readonly verifier_library="$repository_root/scripts/lib/release-package-verification.sh"
+readonly packaging_documentation="$repository_root/docs/release-packaging.md"
+readonly release_checklist="$repository_root/docs/release-checklist.md"
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+for executable in "$package_script" "$verifier_script" "$comparator_script" "$test_script"; do
+    [[ -x "$executable" ]] || fail "Release-package script is missing or not executable: $(basename "$executable")"
+done
+for readable in "$verifier_library" "$packaging_documentation" "$release_checklist"; do
+    [[ -r "$readable" ]] || fail "Release-package contract file is missing: $(basename "$readable")"
+done
+
+if ! /usr/bin/grep -Fxq '/dist/' "$repository_root/.gitignore" || \
+    ! /usr/bin/grep -Fxq '*.dmg' "$repository_root/.gitignore" || \
+    ! /usr/bin/grep -Fxq '*.dSYM' "$repository_root/.gitignore"; then
+    fail "Generated release packages and symbols must remain ignored."
+fi
+
+for required_pattern in \
+    'verify-developer-id-app.sh' \
+    'git diff --quiet' \
+    'Application inputs changed after the qualified G26 payload commit' \
+    'dist/*' \
+    '/usr/bin/ditto' \
+    '/bin/ln -s /Applications' \
+    'assert_release_volume_layout' \
+    '-format UDZO' \
+    '--timestamp' \
+    'io.github.bennetthilberg.copylasso.dmg' \
+    '--keychain-profile' \
+    '--wait' \
+    'notarytool log' \
+    'stapler staple' \
+    'stapler validate' \
+    'CopyLasso-0.1.0.dmg.sha256' \
+    'CopyLasso-0.1.0.dSYM.zip' \
+    'release-evidence.txt'; do
+    /usr/bin/grep -Fq -- "$required_pattern" "$package_script" "$verifier_library" || \
+        fail "The package script is missing a required release step: $required_pattern"
+done
+
+if /usr/bin/grep -Eq 'xcodebuild|exportArchive|archivePath' "$package_script"; then
+    fail "G27 must package the exact G26 application without rebuilding or exporting it."
+fi
+if /usr/bin/grep -Eq -- '--password|--apple-id|AC_PASSWORD|APPLE_ID' \
+    "$package_script" "$verifier_script" "$packaging_documentation"; then
+    fail "Release packaging must authenticate only through the saved Keychain profile."
+fi
+
+for required_pattern in \
+    'assert_release_checksum' \
+    'assert_release_notary_records' \
+    'codesign --verify --strict' \
+    'assert_release_dmg_signature' \
+    'stapler validate' \
+    'spctl --assess --type open --context context:primary-signature' \
+    'hdiutil imageinfo' \
+    'hdiutil attach -readonly -nobrowse' \
+    'diskutil info' \
+    'assert_release_volume_layout' \
+    'verify-developer-id-app.sh' \
+    'assert_release_payload_manifests_match' \
+    'dwarfdump --uuid' \
+    'assert_release_uuid_sets_match'; do
+    /usr/bin/grep -Fq -- "$required_pattern" "$verifier_script" || \
+        fail "The release verifier is missing a required check: $required_pattern"
+done
+
+for required_phrase in \
+    'exact G26' \
+    'copylasso-notary' \
+    'CopyLasso-0.1.0.dmg' \
+    'CopyLasso-0.1.0.dmg.sha256' \
+    'CopyLasso-0.1.0.dSYM.zip' \
+    'two complete runs' \
+    'payload commit' \
+    'packaging commit' \
+    'Applications' \
+    'G28' \
+    'Do not publish'; do
+    /usr/bin/grep -Fiq -- "$required_phrase" "$packaging_documentation" || \
+        fail "Release-packaging documentation is missing required guidance: $required_phrase"
+done
+
+readonly maintainer_home_pattern="/Users/${USER:-maintainer}/"
+if /usr/bin/grep -Eq "$maintainer_home_pattern|TeamIdentifier=[A-Z0-9]{10}|[[:alnum:]._%+-]+@[[:alnum:].-]+\.[A-Za-z]{2,}|[a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4}" \
+    "$package_script" \
+    "$verifier_script" \
+    "$comparator_script" \
+    "$verifier_library" \
+    "$packaging_documentation"; then
+    fail "Release-package public files contain a local path, account value, team value, or credential-like text."
+fi
+
+echo "Release-package static audit passed."

--- a/scripts/audit-release-package.sh
+++ b/scripts/audit-release-package.sh
@@ -95,14 +95,13 @@ for required_phrase in \
         fail "Release-packaging documentation is missing required guidance: $required_phrase"
 done
 
-readonly maintainer_home_pattern="/Users/${USER:-maintainer}/"
-if /usr/bin/grep -Eq "$maintainer_home_pattern|TeamIdentifier=[A-Z0-9]{10}|[[:alnum:]._%+-]+@[[:alnum:].-]+\.[A-Za-z]{2,}|[a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4}" \
+if /usr/bin/grep -Eq "TeamIdentifier=[A-Z0-9]{10}|[[:alnum:]._%+-]+@[[:alnum:].-]+\.[A-Za-z]{2,}|[a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4}" \
     "$package_script" \
     "$verifier_script" \
     "$comparator_script" \
     "$verifier_library" \
     "$packaging_documentation"; then
-    fail "Release-package public files contain a local path, account value, team value, or credential-like text."
+    fail "Release-package public files contain an account value, team value, or credential-like text."
 fi
 
 echo "Release-package static audit passed."

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -52,6 +52,12 @@ echo "Auditing Developer ID release configuration"
 echo "Testing Developer ID release verification"
 ./scripts/test-developer-id-release.sh
 
+echo "Auditing reproducible release packaging"
+./scripts/audit-release-package.sh
+
+echo "Testing reproducible release packaging"
+./scripts/test-release-package.sh
+
 readonly committed_development_team_pattern='^[[:space:]]*"?DEVELOPMENT_TEAM(\[[^]]+\])?"?[[:space:]]*=[[:space:]]*[A-Z0-9]{10};'
 
 if /usr/bin/grep -Eq "$committed_development_team_pattern" \

--- a/scripts/compare-release-packages.sh
+++ b/scripts/compare-release-packages.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/release-package-verification.sh
+source "$repository_root/scripts/lib/release-package-verification.sh"
+
+usage() {
+    echo "Usage: $0 /path/to/first-run /path/to/second-run" >&2
+    exit 64
+}
+
+[[ "$#" == 2 ]] || usage
+readonly first_run="$1"
+readonly second_run="$2"
+
+for run in "$first_run" "$second_run"; do
+    [[ -d "$run" ]] || release_package_fail "A release-package run directory is missing."
+    [[ -f "$run/payload-manifest.txt" ]] || \
+        release_package_fail "A release-package payload manifest is missing."
+    [[ -f "$run/release-evidence.txt" ]] || \
+        release_package_fail "A release-package evidence record is missing."
+    for artifact in \
+        "$run/$COPYLASSO_RELEASE_DMG" \
+        "$run/$COPYLASSO_RELEASE_CHECKSUM" \
+        "$run/$COPYLASSO_RELEASE_DSYM"; do
+        [[ -f "$artifact" ]] || \
+            release_package_fail "A release-package artifact is missing: $(basename "$artifact")"
+    done
+    assert_release_artifact_names \
+        "$(basename "$run/$COPYLASSO_RELEASE_DMG")" \
+        "$(basename "$run/$COPYLASSO_RELEASE_CHECKSUM")" \
+        "$(basename "$run/$COPYLASSO_RELEASE_DSYM")"
+    assert_release_checksum \
+        "$run/$COPYLASSO_RELEASE_DMG" \
+        "$run/$COPYLASSO_RELEASE_CHECKSUM"
+done
+
+assert_release_payload_manifests_match \
+    "$first_run/payload-manifest.txt" \
+    "$second_run/payload-manifest.txt"
+
+for key in \
+    version \
+    build \
+    payload_commit \
+    packaging_commit \
+    dmg_identifier \
+    dmg_filename \
+    app_manifest_sha256 \
+    dsym_uuid_manifest_sha256; do
+    first_value="$(/usr/bin/sed -n "s/^${key}=//p" "$first_run/release-evidence.txt")"
+    second_value="$(/usr/bin/sed -n "s/^${key}=//p" "$second_run/release-evidence.txt")"
+    if [[ -z "$first_value" ]] || [[ "$first_value" != "$second_value" ]]; then
+        release_package_fail "Release-package runs differ in normalized evidence: $key."
+    fi
+done
+
+echo "Release-package runs are functionally equivalent."

--- a/scripts/compare-release-packages.sh
+++ b/scripts/compare-release-packages.sh
@@ -14,8 +14,12 @@ usage() {
 [[ "$#" == 2 ]] || usage
 readonly first_run="$1"
 readonly second_run="$2"
+readonly temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/copylasso-release-compare.XXXXXX")"
+trap 'rm -rf "$temporary_directory"' EXIT
 
+comparison_run_number=0
 for run in "$first_run" "$second_run"; do
+    comparison_run_number=$((comparison_run_number + 1))
     [[ -d "$run" ]] || release_package_fail "A release-package run directory is missing."
     [[ -f "$run/payload-manifest.txt" ]] || \
         release_package_fail "A release-package payload manifest is missing."
@@ -35,6 +39,39 @@ for run in "$first_run" "$second_run"; do
     assert_release_checksum \
         "$run/$COPYLASSO_RELEASE_DMG" \
         "$run/$COPYLASSO_RELEASE_CHECKSUM"
+
+    dsym_directory="$temporary_directory/dsym-$comparison_run_number"
+    /bin/mkdir "$dsym_directory"
+    if ! /usr/bin/ditto -x -k "$run/$COPYLASSO_RELEASE_DSYM" "$dsym_directory" \
+        > "$temporary_directory/dsym-$comparison_run_number-expand.log" 2>&1; then
+        release_package_fail "The release dSYM archive could not be expanded."
+    fi
+    dsym="$dsym_directory/CopyLasso.app.dSYM"
+    if [[ ! -d "$dsym" || -L "$dsym" ]]; then
+        release_package_fail "The release dSYM archive has an unexpected layout."
+    fi
+    if [[ "$(/usr/bin/find "$dsym_directory" -mindepth 1 -maxdepth 1 -print | \
+        /usr/bin/wc -l | /usr/bin/tr -d ' ')" != "1" ]]; then
+        release_package_fail "The release dSYM archive must contain only CopyLasso.app.dSYM."
+    fi
+    if ! /usr/bin/dwarfdump --uuid "$dsym" \
+        > "$temporary_directory/dsym-$comparison_run_number-uuids.txt"; then
+        release_package_fail "The release dSYM archive UUIDs could not be inspected."
+    fi
+    normalized_release_uuids "$temporary_directory/dsym-$comparison_run_number-uuids.txt" \
+        > "$temporary_directory/dsym-$comparison_run_number-normalized-uuids.txt"
+    if [[ ! -s "$temporary_directory/dsym-$comparison_run_number-normalized-uuids.txt" ]]; then
+        release_package_fail "The release dSYM archive contains no UUID records."
+    fi
+    actual_dsym_uuid_hash="$(/usr/bin/shasum -a 256 \
+        "$temporary_directory/dsym-$comparison_run_number-normalized-uuids.txt" | \
+        /usr/bin/awk '{print $1}')"
+    recorded_dsym_uuid_hash="$(/usr/bin/sed -n 's/^dsym_uuid_manifest_sha256=//p' \
+        "$run/release-evidence.txt")"
+    if [[ -z "$recorded_dsym_uuid_hash" ]] || \
+        [[ "$recorded_dsym_uuid_hash" != "$actual_dsym_uuid_hash" ]]; then
+        release_package_fail "The release evidence records the wrong dSYM UUID manifest."
+    fi
 done
 
 assert_release_payload_manifests_match \

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -243,3 +243,16 @@ assert_release_evidence_is_portable() {
         release_package_fail "The release evidence must not contain local absolute paths."
     fi
 }
+
+assert_release_commit_matches() {
+    local label="$1"
+    local expected_commit="$2"
+    local evidence_commit="$3"
+
+    [[ "$expected_commit" =~ ^[0-9a-f]{40}$ ]] || \
+        release_package_fail "The expected $label commit is invalid."
+    [[ "$evidence_commit" =~ ^[0-9a-f]{40}$ ]] || \
+        release_package_fail "The release evidence $label commit is invalid."
+    [[ "$evidence_commit" == "$expected_commit" ]] || \
+        release_package_fail "The release evidence $label commit does not match the expected commit."
+}

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -231,3 +231,13 @@ assert_release_uuid_sets_match() {
         release_package_fail "The dSYM UUIDs do not match the release application."
     fi
 }
+
+assert_release_evidence_is_portable() {
+    local evidence_record_path="$1"
+
+    [[ -f "$evidence_record_path" ]] || \
+        release_package_fail "The release evidence record is missing."
+    if /usr/bin/grep -Eq '^[^=]+=/.*$' "$evidence_record_path"; then
+        release_package_fail "The release evidence must not contain local absolute paths."
+    fi
+}

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -179,7 +179,7 @@ assert_release_notary_records() {
     local diagnostic_log_path="$2"
     local submission_status
     local log_status
-    local submission_identifier
+    local observed_submission_identifier
     local log_identifier
     local issues
 
@@ -190,9 +190,10 @@ assert_release_notary_records() {
     if [[ "$submission_status" != "Accepted" ]] || [[ "$log_status" != "Accepted" ]]; then
         release_package_fail "The disk-image notarization submission was not accepted."
     fi
-    submission_identifier="$(/usr/bin/plutil -extract id raw "$submission_record_path" 2>/dev/null || true)"
+    observed_submission_identifier="$(/usr/bin/plutil -extract id raw "$submission_record_path" 2>/dev/null || true)"
     log_identifier="$(/usr/bin/plutil -extract jobId raw "$diagnostic_log_path" 2>/dev/null || true)"
-    if [[ -z "$submission_identifier" ]] || [[ "$submission_identifier" != "$log_identifier" ]]; then
+    if [[ -z "$observed_submission_identifier" ]] || \
+        [[ "$observed_submission_identifier" != "$log_identifier" ]]; then
         release_package_fail "The notarization submission and diagnostic log do not match."
     fi
     issues="$(/usr/bin/plutil -extract issues json -o - "$diagnostic_log_path" 2>/dev/null || true)"

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -197,7 +197,7 @@ assert_release_notary_records() {
     fi
     issues="$(/usr/bin/plutil -extract issues json -o - "$diagnostic_log_path" 2>/dev/null || true)"
     if [[ "$issues" != "[]" ]] && \
-        ! /usr/bin/grep -Eq '"issues"[[:space:]]*:[[:space:]]*null([[:space:]]*[,}])' \
+        ! /usr/bin/grep -Eq '"issues"[[:space:]]*:[[:space:]]*null([[:space:]]*[,}]|[[:space:]]*$)' \
             "$diagnostic_log_path"; then
         release_package_fail "The accepted notarization diagnostic log contains issues."
     fi

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -41,8 +41,8 @@ assert_release_volume_layout() {
     if [[ "$actual_entries" != "$expected_entries" ]]; then
         release_package_fail "The release volume must contain exactly CopyLasso.app and Applications."
     fi
-    [[ -d "$volume_root/CopyLasso.app" ]] || \
-        release_package_fail "CopyLasso.app is missing from the release volume."
+    [[ -d "$volume_root/CopyLasso.app" && ! -L "$volume_root/CopyLasso.app" ]] || \
+        release_package_fail "CopyLasso.app must be a real directory in the release volume."
     [[ -L "$volume_root/Applications" ]] || \
         release_package_fail "Applications must be a symbolic link."
     if [[ "$(/usr/bin/readlink "$volume_root/Applications")" != "/Applications" ]]; then
@@ -196,7 +196,9 @@ assert_release_notary_records() {
         release_package_fail "The notarization submission and diagnostic log do not match."
     fi
     issues="$(/usr/bin/plutil -extract issues json -o - "$diagnostic_log_path" 2>/dev/null || true)"
-    if [[ "$issues" != "[]" ]]; then
+    if [[ "$issues" != "[]" ]] && \
+        ! /usr/bin/grep -Eq '"issues"[[:space:]]*:[[:space:]]*null([[:space:]]*[,}])' \
+            "$diagnostic_log_path"; then
         release_package_fail "The accepted notarization diagnostic log contains issues."
     fi
 }

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -257,3 +257,22 @@ assert_release_commit_matches() {
     [[ "$evidence_commit" == "$expected_commit" ]] || \
         release_package_fail "The release evidence $label commit does not match the expected commit."
 }
+
+assert_release_commit_relationship() {
+    local commit_repository_path="$1"
+    local payload_commit_value="$2"
+    local packaging_commit_value="$3"
+
+    if ! /usr/bin/git -C "$commit_repository_path" cat-file -e \
+        "$payload_commit_value^{commit}" 2>/dev/null; then
+        release_package_fail "The payload commit is not available in this repository."
+    fi
+    if ! /usr/bin/git -C "$commit_repository_path" cat-file -e \
+        "$packaging_commit_value^{commit}" 2>/dev/null; then
+        release_package_fail "The packaging commit is not available in this repository."
+    fi
+    if ! /usr/bin/git -C "$commit_repository_path" merge-base --is-ancestor \
+        "$payload_commit_value" "$packaging_commit_value"; then
+        release_package_fail "The payload commit is not an ancestor of the packaging commit."
+    fi
+}

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly COPYLASSO_RELEASE_VERSION="0.1.0"
+readonly COPYLASSO_RELEASE_BUILD="1"
+readonly COPYLASSO_RELEASE_DMG="CopyLasso-0.1.0.dmg"
+readonly COPYLASSO_RELEASE_CHECKSUM="CopyLasso-0.1.0.dmg.sha256"
+readonly COPYLASSO_RELEASE_DSYM="CopyLasso-0.1.0.dSYM.zip"
+readonly COPYLASSO_RELEASE_DMG_IDENTIFIER="io.github.bennetthilberg.copylasso.dmg"
+
+release_package_fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+assert_release_artifact_names() {
+    local dmg_name="$1"
+    local checksum_name="$2"
+    local dsym_name="$3"
+
+    if [[ "$dmg_name" != "$COPYLASSO_RELEASE_DMG" ]] || \
+        [[ "$checksum_name" != "$COPYLASSO_RELEASE_CHECKSUM" ]] || \
+        [[ "$dsym_name" != "$COPYLASSO_RELEASE_DSYM" ]]; then
+        release_package_fail "The release artifact names must be versioned exactly for CopyLasso 0.1.0."
+    fi
+}
+
+assert_release_volume_layout() {
+    local volume_root="$1"
+    local actual_entries
+    local expected_entries
+
+    [[ -d "$volume_root" ]] || release_package_fail "The release volume root is missing."
+    actual_entries="$({
+        /usr/bin/find "$volume_root" -mindepth 1 -maxdepth 1 -print | \
+            while IFS= read -r entry; do /usr/bin/basename "$entry"; done | \
+            LC_ALL=C /usr/bin/sort
+    })"
+    expected_entries="$(printf '%s\n%s' Applications CopyLasso.app)"
+    if [[ "$actual_entries" != "$expected_entries" ]]; then
+        release_package_fail "The release volume must contain exactly CopyLasso.app and Applications."
+    fi
+    [[ -d "$volume_root/CopyLasso.app" ]] || \
+        release_package_fail "CopyLasso.app is missing from the release volume."
+    [[ -L "$volume_root/Applications" ]] || \
+        release_package_fail "Applications must be a symbolic link."
+    if [[ "$(/usr/bin/readlink "$volume_root/Applications")" != "/Applications" ]]; then
+        release_package_fail "The Applications link must resolve to /Applications."
+    fi
+}
+
+create_release_payload_manifest() {
+    local application="$1"
+    local output="$2"
+    local canonical_parent
+    local canonical_application
+
+    [[ -d "$application" ]] || release_package_fail "The application for the payload manifest is missing."
+    canonical_parent="$(cd "$(dirname "$application")" && /bin/pwd -P)"
+    canonical_application="$canonical_parent/$(basename "$application")"
+
+    : > "$output"
+    while IFS= read -r candidate; do
+        local relative_path
+        local mode
+
+        if [[ "$candidate" == "$canonical_application" ]]; then
+            relative_path="."
+        else
+            relative_path="${candidate#"$canonical_application"/}"
+        fi
+        mode="$(/usr/bin/stat -f '%Lp' "$candidate")"
+        if [[ -L "$candidate" ]]; then
+            printf 'link\t%s\t%s\t%s\n' \
+                "$mode" "$relative_path" "$(/usr/bin/readlink "$candidate")" >> "$output"
+        elif [[ -d "$candidate" ]]; then
+            printf 'directory\t%s\t%s\n' "$mode" "$relative_path" >> "$output"
+        elif [[ -f "$candidate" ]]; then
+            local size
+            local digest
+            size="$(/usr/bin/stat -f '%z' "$candidate")"
+            digest="$(/usr/bin/shasum -a 256 "$candidate" | /usr/bin/awk '{print $1}')"
+            printf 'file\t%s\t%s\t%s\t%s\n' \
+                "$mode" "$size" "$digest" "$relative_path" >> "$output"
+        else
+            release_package_fail "The application payload contains an unsupported file type."
+        fi
+    done < <(/usr/bin/find "$canonical_application" -print | LC_ALL=C /usr/bin/sort)
+}
+
+assert_release_payload_manifests_match() {
+    local expected_manifest="$1"
+    local actual_manifest="$2"
+
+    [[ -f "$expected_manifest" && -f "$actual_manifest" ]] || \
+        release_package_fail "A release payload manifest is missing."
+    if ! /usr/bin/cmp -s "$expected_manifest" "$actual_manifest"; then
+        release_package_fail "The packaged payload differs from the qualified G26 application."
+    fi
+}
+
+assert_release_checksum() {
+    local image_path="$1"
+    local checksum_path="$2"
+    local expected_hash
+    local expected_line
+    local actual_line
+
+    [[ -f "$image_path" ]] || release_package_fail "The release disk image is missing."
+    [[ -f "$checksum_path" ]] || release_package_fail "The release checksum is missing."
+    if [[ "$(basename "$image_path")" != "$COPYLASSO_RELEASE_DMG" ]]; then
+        release_package_fail "The checksum target must be CopyLasso-0.1.0.dmg."
+    fi
+    expected_hash="$(/usr/bin/shasum -a 256 "$image_path" | /usr/bin/awk '{print $1}')"
+    expected_line="$expected_hash  $COPYLASSO_RELEASE_DMG"
+    actual_line="$(/bin/cat "$checksum_path")"
+    if [[ "$actual_line" != *"  $COPYLASSO_RELEASE_DMG" ]]; then
+        release_package_fail "The checksum record must name CopyLasso-0.1.0.dmg."
+    fi
+    if [[ "$actual_line" != "$expected_line" ]]; then
+        release_package_fail "The release disk-image checksum does not match."
+    fi
+}
+
+assert_release_dmg_signature() {
+    local signature_record_path="$1"
+    local required_team_identifier="$2"
+
+    [[ -f "$signature_record_path" ]] || release_package_fail "The disk-image signature record is missing."
+    /usr/bin/grep -Fxq "Identifier=$COPYLASSO_RELEASE_DMG_IDENTIFIER" "$signature_record_path" || \
+        release_package_fail "The release disk-image identifier is incorrect."
+    /usr/bin/grep -Fq 'Authority=Developer ID Application:' "$signature_record_path" || \
+        release_package_fail "The disk image is not signed with Developer ID Application."
+    /usr/bin/grep -Eq '^Timestamp=.+$' "$signature_record_path" || \
+        release_package_fail "The disk-image signature is missing a secure timestamp."
+    /usr/bin/grep -Fxq "TeamIdentifier=$required_team_identifier" "$signature_record_path" || \
+        release_package_fail "The disk-image signature does not match the approved release team."
+}
+
+assert_release_dmg_gatekeeper() {
+    local gatekeeper_record_path="$1"
+
+    [[ -f "$gatekeeper_record_path" ]] || release_package_fail "The disk-image Gatekeeper record is missing."
+    /usr/bin/grep -Eq ': accepted$' "$gatekeeper_record_path" || \
+        release_package_fail "Gatekeeper did not accept the release disk image."
+    /usr/bin/grep -Eq '^source=(Notarized )?Developer ID$' "$gatekeeper_record_path" || \
+        release_package_fail "Gatekeeper did not identify the disk image as Developer ID software."
+    if /usr/bin/grep -q '^origin=' "$gatekeeper_record_path" && \
+        /usr/bin/grep '^origin=' "$gatekeeper_record_path" | \
+            /usr/bin/grep -Fqv 'origin=Developer ID Application:'; then
+        release_package_fail "Gatekeeper reported an unexpected origin for the disk image."
+    fi
+}
+
+assert_release_dmg_imageinfo() {
+    local imageinfo_record_path="$1"
+
+    [[ -f "$imageinfo_record_path" ]] || \
+        release_package_fail "The disk-image format record is missing."
+    /usr/bin/grep -Eq '^[[:space:]]*Format:[[:space:]]+UDZO[[:space:]]*$' \
+        "$imageinfo_record_path" || \
+        release_package_fail "The release disk image must use read-only UDZO format."
+}
+
+assert_release_read_only_mount() {
+    local disk_record_path="$1"
+
+    [[ -f "$disk_record_path" ]] || \
+        release_package_fail "The mounted-volume record is missing."
+    /usr/bin/grep -Eq 'Media Read-Only:[[:space:]]+Yes' "$disk_record_path" || \
+        release_package_fail "The release disk-image media is not read-only."
+    /usr/bin/grep -Eq 'Volume Read-Only:[[:space:]]+Yes' "$disk_record_path" || \
+        release_package_fail "The mounted release volume is not read-only."
+}
+
+assert_release_notary_records() {
+    local submission_record_path="$1"
+    local diagnostic_log_path="$2"
+    local submission_status
+    local log_status
+    local submission_identifier
+    local log_identifier
+    local issues
+
+    [[ -f "$submission_record_path" && -f "$diagnostic_log_path" ]] || \
+        release_package_fail "The notarization submission record or diagnostic log is missing."
+    submission_status="$(/usr/bin/plutil -extract status raw "$submission_record_path" 2>/dev/null || true)"
+    log_status="$(/usr/bin/plutil -extract status raw "$diagnostic_log_path" 2>/dev/null || true)"
+    if [[ "$submission_status" != "Accepted" ]] || [[ "$log_status" != "Accepted" ]]; then
+        release_package_fail "The disk-image notarization submission was not accepted."
+    fi
+    submission_identifier="$(/usr/bin/plutil -extract id raw "$submission_record_path" 2>/dev/null || true)"
+    log_identifier="$(/usr/bin/plutil -extract jobId raw "$diagnostic_log_path" 2>/dev/null || true)"
+    if [[ -z "$submission_identifier" ]] || [[ "$submission_identifier" != "$log_identifier" ]]; then
+        release_package_fail "The notarization submission and diagnostic log do not match."
+    fi
+    issues="$(/usr/bin/plutil -extract issues json -o - "$diagnostic_log_path" 2>/dev/null || true)"
+    if [[ "$issues" != "[]" ]]; then
+        release_package_fail "The accepted notarization diagnostic log contains issues."
+    fi
+}
+
+normalized_release_uuids() {
+    local uuid_record="$1"
+
+    /usr/bin/awk '
+        /^UUID:/ {
+            architecture = $3
+            gsub(/[()]/, "", architecture)
+            print architecture " " toupper($2)
+        }
+    ' "$uuid_record" | LC_ALL=C /usr/bin/sort
+}
+
+assert_release_uuid_sets_match() {
+    local application_record="$1"
+    local dsym_record="$2"
+    local application_uuids
+    local dsym_uuids
+
+    [[ -f "$application_record" && -f "$dsym_record" ]] || \
+        release_package_fail "The application or dSYM UUID record is missing."
+    application_uuids="$(normalized_release_uuids "$application_record")"
+    dsym_uuids="$(normalized_release_uuids "$dsym_record")"
+    if [[ "$(printf '%s\n' "$application_uuids" | /usr/bin/awk '{print $1}')" != \
+        "$(printf '%s\n%s' arm64 x86_64)" ]]; then
+        release_package_fail "The release UUID record must contain exactly arm64 and x86_64."
+    fi
+    if [[ "$application_uuids" != "$dsym_uuids" ]]; then
+        release_package_fail "The dSYM UUIDs do not match the release application."
+    fi
+}

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -12,8 +12,7 @@ usage() {
 Usage: package-release.sh \
   --handoff /path/to/G26/<commit> \
   --payload-commit <40-character-commit> \
-  --output-dir /path/to/repository/dist/<run> \
-  [--notary-profile copylasso-notary]
+  --output-dir /path/to/repository/dist/<run>
 TEXT
     exit 64
 }
@@ -21,7 +20,7 @@ TEXT
 handoff_candidate=""
 payload_commit=""
 output_candidate=""
-notary_profile="copylasso-notary"
+readonly notary_profile="copylasso-notary"
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
         --handoff)
@@ -39,11 +38,6 @@ while [[ "$#" -gt 0 ]]; do
             output_candidate="$2"
             shift 2
             ;;
-        --notary-profile)
-            [[ "$#" -ge 2 ]] || usage
-            notary_profile="$2"
-            shift 2
-            ;;
         *) usage ;;
     esac
 done
@@ -51,8 +45,6 @@ done
 [[ -n "$handoff_candidate" && -n "$payload_commit" && -n "$output_candidate" ]] || usage
 [[ "$payload_commit" =~ ^[0-9a-f]{40}$ ]] || \
     release_package_fail "The payload commit must be a full lowercase Git object identifier."
-[[ "$notary_profile" =~ ^[A-Za-z0-9._-]+$ ]] || \
-    release_package_fail "The notary profile name contains unsupported characters."
 readonly expected_team_identifier="${COPYLASSO_EXPECTED_TEAM_ID:-}"
 if [[ ! "$expected_team_identifier" =~ ^[A-Z0-9]{10}$ ]]; then
     release_package_fail \
@@ -247,6 +239,8 @@ readonly dsym_uuid_hash="$(/usr/bin/shasum -a 256 \
 COPYLASSO_EXPECTED_TEAM_ID="$expected_team_identifier" \
     "$repository_root/scripts/verify-release-package.sh" \
     --payload-app "$payload_app" \
+    --payload-commit "$payload_commit" \
+    --packaging-commit "$packaging_commit" \
     "$output_directory" > "$output_directory/release-verification.txt"
 
 echo "CopyLasso release package created and verified in $output_directory."

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 077
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/release-package-verification.sh
+source "$repository_root/scripts/lib/release-package-verification.sh"
+
+usage() {
+    cat >&2 <<'TEXT'
+Usage: package-release.sh \
+  --handoff /path/to/G26/<commit> \
+  --payload-commit <40-character-commit> \
+  --output-dir /path/to/repository/dist/<run> \
+  [--notary-profile copylasso-notary]
+TEXT
+    exit 64
+}
+
+handoff_candidate=""
+payload_commit=""
+output_candidate=""
+notary_profile="copylasso-notary"
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --handoff)
+            [[ "$#" -ge 2 ]] || usage
+            handoff_candidate="$2"
+            shift 2
+            ;;
+        --payload-commit)
+            [[ "$#" -ge 2 ]] || usage
+            payload_commit="$2"
+            shift 2
+            ;;
+        --output-dir)
+            [[ "$#" -ge 2 ]] || usage
+            output_candidate="$2"
+            shift 2
+            ;;
+        --notary-profile)
+            [[ "$#" -ge 2 ]] || usage
+            notary_profile="$2"
+            shift 2
+            ;;
+        *) usage ;;
+    esac
+done
+
+[[ -n "$handoff_candidate" && -n "$payload_commit" && -n "$output_candidate" ]] || usage
+[[ "$payload_commit" =~ ^[0-9a-f]{40}$ ]] || \
+    release_package_fail "The payload commit must be a full lowercase Git object identifier."
+[[ "$notary_profile" =~ ^[A-Za-z0-9._-]+$ ]] || \
+    release_package_fail "The notary profile name contains unsupported characters."
+readonly expected_team_identifier="${COPYLASSO_EXPECTED_TEAM_ID:-}"
+if [[ ! "$expected_team_identifier" =~ ^[A-Z0-9]{10}$ ]]; then
+    release_package_fail \
+        "COPYLASSO_EXPECTED_TEAM_ID must provide the approved release team outside the repository."
+fi
+
+[[ -d "$handoff_candidate" ]] || release_package_fail "The G26 handoff directory is missing."
+readonly handoff_parent="$(cd "$(dirname "$handoff_candidate")" && /bin/pwd -P)"
+readonly handoff="$handoff_parent/$(basename "$handoff_candidate")"
+if [[ "$(basename "$handoff")" != "$payload_commit" ]]; then
+    release_package_fail "The G26 handoff directory must be named for the payload commit."
+fi
+readonly payload_app="$handoff/export/CopyLasso.app"
+readonly payload_dsym="$handoff/CopyLasso.xcarchive/dSYMs/CopyLasso.app.dSYM"
+readonly payload_submission="$handoff/notary-submission.json"
+readonly payload_log="$handoff/notary-log.json"
+[[ -d "$payload_app" ]] || release_package_fail "The G26 handoff application is missing."
+[[ -d "$payload_dsym" ]] || release_package_fail "The matching G26 dSYM is missing."
+assert_release_notary_records "$payload_submission" "$payload_log"
+
+cd "$repository_root"
+readonly packaging_commit="$(/usr/bin/git rev-parse HEAD)"
+[[ "$packaging_commit" =~ ^[0-9a-f]{40}$ ]] || \
+    release_package_fail "The packaging source must be an exact Git commit."
+/usr/bin/git cat-file -e "$payload_commit^{commit}" || \
+    release_package_fail "The payload commit is not available in this repository."
+/usr/bin/git merge-base --is-ancestor "$payload_commit" "$packaging_commit" || \
+    release_package_fail "The payload commit is not an ancestor of the packaging commit."
+if ! /usr/bin/git diff --quiet || ! /usr/bin/git diff --cached --quiet || \
+    [[ -n "$(/usr/bin/git status --porcelain --untracked-files=no)" ]]; then
+    release_package_fail "Release packaging requires a clean tracked worktree."
+fi
+if ! /usr/bin/git diff --quiet "$payload_commit..$packaging_commit" -- \
+    BrandAssets \
+    Configuration/CopyLasso-Info.plist \
+    Configuration/Shared.xcconfig \
+    CopyLasso \
+    CopyLasso.xcodeproj \
+    THIRD_PARTY_NOTICES.md; then
+    release_package_fail \
+        "Application inputs changed after the qualified G26 payload commit; rebuild is outside G27."
+fi
+
+case "$output_candidate" in
+    /*) ;;
+    *) output_candidate="$PWD/$output_candidate" ;;
+esac
+if [[ "$output_candidate" == *"/../"* ]] || [[ "$output_candidate" == */.. ]]; then
+    release_package_fail "The release output path must not contain parent traversal."
+fi
+case "$output_candidate" in
+    "$repository_root"/dist/*) ;;
+    *) release_package_fail "Release output must remain under the repository's ignored dist directory." ;;
+esac
+readonly output_parent_candidate="$(dirname "$output_candidate")"
+/bin/mkdir -p "$output_parent_candidate"
+readonly output_parent="$(cd "$output_parent_candidate" && /bin/pwd -P)"
+case "$output_parent" in
+    "$repository_root"/dist | "$repository_root"/dist/*) ;;
+    *) release_package_fail "The canonical release output escapes the ignored dist directory." ;;
+esac
+readonly output_directory="$output_parent/$(basename "$output_candidate")"
+[[ ! -e "$output_directory" ]] || \
+    release_package_fail "The release output directory already exists; use a fresh run directory."
+/bin/mkdir "$output_directory"
+
+readonly temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/copylasso-release-package.XXXXXX")"
+cleanup() {
+    /bin/rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+if ! COPYLASSO_EXPECTED_TEAM_ID="$expected_team_identifier" \
+    "$repository_root/scripts/verify-developer-id-app.sh" --post-notarization "$payload_app" \
+    > "$output_directory/payload-verification.txt"; then
+    release_package_fail "The exact G26 application no longer passes final verification."
+fi
+
+readonly staging_directory="$temporary_directory/volume"
+/bin/mkdir "$staging_directory"
+/usr/bin/ditto "$payload_app" "$staging_directory/CopyLasso.app"
+/bin/ln -s /Applications "$staging_directory/Applications"
+assert_release_volume_layout "$staging_directory"
+create_release_payload_manifest "$payload_app" "$output_directory/payload-manifest.txt"
+create_release_payload_manifest \
+    "$staging_directory/CopyLasso.app" \
+    "$temporary_directory/staged-payload.manifest"
+assert_release_payload_manifests_match \
+    "$output_directory/payload-manifest.txt" \
+    "$temporary_directory/staged-payload.manifest"
+
+readonly dmg="$output_directory/$COPYLASSO_RELEASE_DMG"
+if ! /usr/bin/hdiutil create \
+    -srcfolder "$staging_directory" \
+    -volname "CopyLasso $COPYLASSO_RELEASE_VERSION" \
+    -fs HFS+ \
+    -format UDZO \
+    -imagekey zlib-level=9 \
+    "$dmg" > "$output_directory/hdiutil-create.log" 2>&1; then
+    release_package_fail "The release disk image could not be created."
+fi
+
+identity_records="$(/usr/bin/security find-identity -v -p codesigning 2>/dev/null || true)"
+matching_identities="$(printf '%s\n' "$identity_records" | \
+    /usr/bin/awk -v team="$expected_team_identifier" '
+        $0 ~ /"Developer ID Application:/ && $0 ~ "\\(" team "\\)\"$" { print $2 }
+    ')"
+identity_count="$(printf '%s\n' "$matching_identities" | /usr/bin/awk 'NF { count += 1 } END { print count + 0 }')"
+if [[ "$identity_count" != "1" ]]; then
+    release_package_fail "Exactly one valid Developer ID Application identity must match the approved team."
+fi
+readonly signing_identity="$(printf '%s\n' "$matching_identities" | /usr/bin/head -n 1)"
+unset identity_records matching_identities
+
+if ! /usr/bin/codesign \
+    --sign "$signing_identity" \
+    --timestamp \
+    --identifier "$COPYLASSO_RELEASE_DMG_IDENTIFIER" \
+    "$dmg" > "$output_directory/dmg-signing.log" 2>&1; then
+    release_package_fail "The release disk image could not be signed."
+fi
+if ! /usr/bin/codesign --verify --strict --verbose=2 "$dmg" \
+    > "$output_directory/dmg-signature-verification.log" 2>&1; then
+    release_package_fail "The signed release disk image failed strict verification."
+fi
+
+readonly submission_record="$output_directory/notary-submission.json"
+readonly diagnostic_log="$output_directory/notary-log.json"
+if ! xcrun notarytool submit "$dmg" \
+    --keychain-profile "$notary_profile" \
+    --wait \
+    --output-format json > "$submission_record"; then
+    release_package_fail "The disk-image notarization submission did not complete."
+fi
+readonly submission_identifier="$(/usr/bin/plutil -extract id raw "$submission_record" 2>/dev/null || true)"
+[[ -n "$submission_identifier" ]] || \
+    release_package_fail "The notarization response did not include a submission identifier."
+if ! xcrun notarytool log "$submission_identifier" \
+    --keychain-profile "$notary_profile" \
+    "$diagnostic_log" > "$output_directory/notary-log-fetch.log" 2>&1; then
+    release_package_fail "The disk-image notarization diagnostic log could not be saved."
+fi
+assert_release_notary_records "$submission_record" "$diagnostic_log"
+
+if ! xcrun stapler staple "$dmg" > "$output_directory/staple.log" 2>&1; then
+    release_package_fail "The notarization ticket could not be stapled to the disk image."
+fi
+if ! xcrun stapler validate "$dmg" > "$output_directory/stapler-validation.log" 2>&1; then
+    release_package_fail "The stapled disk-image ticket did not validate."
+fi
+
+(
+    cd "$output_directory"
+    /usr/bin/shasum -a 256 "$COPYLASSO_RELEASE_DMG" > "$COPYLASSO_RELEASE_CHECKSUM"
+)
+if ! /usr/bin/ditto -c -k --norsrc --noextattr --keepParent \
+    "$payload_dsym" "$output_directory/$COPYLASSO_RELEASE_DSYM"; then
+    release_package_fail "The matching release dSYM could not be archived."
+fi
+
+readonly executable_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' \
+    "$payload_app/Contents/Info.plist")"
+/usr/bin/dwarfdump --uuid "$payload_app/Contents/MacOS/$executable_name" \
+    > "$output_directory/application-uuids.txt"
+/usr/bin/dwarfdump --uuid "$payload_dsym" > "$output_directory/dsym-uuids.txt"
+assert_release_uuid_sets_match \
+    "$output_directory/application-uuids.txt" \
+    "$output_directory/dsym-uuids.txt"
+normalized_release_uuids "$output_directory/dsym-uuids.txt" \
+    > "$temporary_directory/normalized-dsym-uuids.txt"
+
+readonly dmg_hash="$(/usr/bin/shasum -a 256 "$dmg" | /usr/bin/awk '{print $1}')"
+readonly dmg_size="$(/usr/bin/stat -f '%z' "$dmg")"
+readonly app_manifest_hash="$(/usr/bin/shasum -a 256 \
+    "$output_directory/payload-manifest.txt" | /usr/bin/awk '{print $1}')"
+readonly dsym_uuid_hash="$(/usr/bin/shasum -a 256 \
+    "$temporary_directory/normalized-dsym-uuids.txt" | /usr/bin/awk '{print $1}')"
+{
+    printf 'version=%s\n' "$COPYLASSO_RELEASE_VERSION"
+    printf 'build=%s\n' "$COPYLASSO_RELEASE_BUILD"
+    printf 'payload_commit=%s\n' "$payload_commit"
+    printf 'packaging_commit=%s\n' "$packaging_commit"
+    printf 'dmg_identifier=%s\n' "$COPYLASSO_RELEASE_DMG_IDENTIFIER"
+    printf 'dmg_filename=%s\n' "$COPYLASSO_RELEASE_DMG"
+    printf 'dmg_sha256=%s\n' "$dmg_hash"
+    printf 'dmg_size_bytes=%s\n' "$dmg_size"
+    printf 'app_manifest_sha256=%s\n' "$app_manifest_hash"
+    printf 'dsym_uuid_manifest_sha256=%s\n' "$dsym_uuid_hash"
+    printf 'notary_submission_id=%s\n' "$submission_identifier"
+} > "$output_directory/release-evidence.txt"
+
+COPYLASSO_EXPECTED_TEAM_ID="$expected_team_identifier" \
+    "$repository_root/scripts/verify-release-package.sh" \
+    --payload-app "$payload_app" \
+    "$output_directory" > "$output_directory/release-verification.txt"
+
+echo "CopyLasso release package created and verified in $output_directory."

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -6,6 +6,7 @@ readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly ci_script="$repository_root/scripts/ci.sh"
 readonly brand_audit_script="$repository_root/scripts/audit-brand-release.sh"
 readonly developer_id_audit_script="$repository_root/scripts/audit-developer-id-release.sh"
+readonly release_package_audit_script="$repository_root/scripts/audit-release-package.sh"
 readonly repeatability_script="$repository_root/scripts/test-repeatability.sh"
 readonly workflow="$repository_root/.github/workflows/ci.yml"
 
@@ -54,10 +55,34 @@ if [[ "$developer_id_test_invocations" != "1" ]]; then
     fail "Canonical CI must invoke scripts/test-developer-id-release.sh exactly once."
 fi
 
+release_package_audit_invocations="$({
+    /usr/bin/grep -Ec '^[[:space:]]*\./scripts/audit-release-package\.sh[[:space:]]*$' \
+        "$ci_script" || true
+})"
+if [[ "$release_package_audit_invocations" != "1" ]]; then
+    fail "Canonical CI must invoke scripts/audit-release-package.sh exactly once."
+fi
+
+release_package_test_invocations="$({
+    /usr/bin/grep -Ec '^[[:space:]]*\./scripts/test-release-package\.sh[[:space:]]*$' \
+        "$ci_script" || true
+})"
+if [[ "$release_package_test_invocations" != "1" ]]; then
+    fail "Canonical CI must invoke scripts/test-release-package.sh exactly once."
+fi
+
 if [[ ! -x "$developer_id_audit_script" ]] || \
     [[ ! -x "$repository_root/scripts/verify-developer-id-app.sh" ]] || \
     [[ ! -x "$repository_root/scripts/test-developer-id-release.sh" ]]; then
     fail "Developer ID release verification scripts must be executable."
+fi
+
+if [[ ! -x "$release_package_audit_script" ]] || \
+    [[ ! -x "$repository_root/scripts/package-release.sh" ]] || \
+    [[ ! -x "$repository_root/scripts/verify-release-package.sh" ]] || \
+    [[ ! -x "$repository_root/scripts/compare-release-packages.sh" ]] || \
+    [[ ! -x "$repository_root/scripts/test-release-package.sh" ]]; then
+    fail "Release-package verification scripts must be executable."
 fi
 
 if ! /usr/bin/grep -Fq \

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -20,6 +20,15 @@ for executable in "$audit_script" "$package_script" "$verifier_script" "$compara
 done
 [[ -r "$verifier_library" ]] || fail "Release-package verification library is missing."
 [[ -r "$packaging_documentation" ]] || fail "Release-packaging documentation is missing."
+if /usr/bin/grep -q -- '--notary-profile' "$package_script"; then
+    fail "Release packaging must use only the G26 copylasso-notary profile."
+fi
+for required_commit_option in --payload-commit --packaging-commit; do
+    /usr/bin/grep -Fq -- "$required_commit_option" "$verifier_script" || \
+        fail "Release verification must require $required_commit_option."
+    /usr/bin/grep -Fq -- "$required_commit_option" "$package_script" || \
+        fail "Release packaging must pass $required_commit_option to verification."
+done
 
 # shellcheck source=scripts/lib/release-package-verification.sh
 source "$verifier_library"
@@ -247,6 +256,18 @@ local_artifact=/local/build/output
 TEXT
 expect_failure "must not contain local absolute paths" \
     assert_release_evidence_is_portable "$absolute_path_evidence"
+
+assert_release_commit_matches \
+    "payload" \
+    "1111111111111111111111111111111111111111" \
+    "1111111111111111111111111111111111111111"
+expect_failure "payload commit does not match" \
+    assert_release_commit_matches \
+    "payload" \
+    "1111111111111111111111111111111111111111" \
+    "2222222222222222222222222222222222222222"
+expect_failure "expected payload commit is invalid" \
+    assert_release_commit_matches "payload" "not-a-commit" "not-a-commit"
 
 assert_release_artifact_names \
     "CopyLasso-0.1.0.dmg" \

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly audit_script="$repository_root/scripts/audit-release-package.sh"
+readonly package_script="$repository_root/scripts/package-release.sh"
+readonly verifier_script="$repository_root/scripts/verify-release-package.sh"
+readonly comparator_script="$repository_root/scripts/compare-release-packages.sh"
+readonly verifier_library="$repository_root/scripts/lib/release-package-verification.sh"
+readonly packaging_documentation="$repository_root/docs/release-packaging.md"
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+for executable in "$audit_script" "$package_script" "$verifier_script" "$comparator_script"; do
+    [[ -x "$executable" ]] || fail "Release-package executable is missing: $(basename "$executable")"
+done
+[[ -r "$verifier_library" ]] || fail "Release-package verification library is missing."
+[[ -r "$packaging_documentation" ]] || fail "Release-packaging documentation is missing."
+
+# shellcheck source=scripts/lib/release-package-verification.sh
+source "$verifier_library"
+
+expect_failure() {
+    local expected_message="$1"
+    shift
+    local output
+
+    if output="$("$@" 2>&1)"; then
+        fail "Expected command to fail: $*"
+    fi
+    if [[ "$output" != *"$expected_message"* ]]; then
+        fail "Expected failure containing '$expected_message', received '$output'."
+    fi
+}
+
+readonly temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/copylasso-g27-tests.XXXXXX")"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+valid_layout="$temporary_directory/valid-layout"
+mkdir -p "$valid_layout/CopyLasso.app/Contents/MacOS"
+echo 'fixture executable' > "$valid_layout/CopyLasso.app/Contents/MacOS/CopyLasso"
+ln -s /Applications "$valid_layout/Applications"
+assert_release_volume_layout "$valid_layout"
+
+cp -R "$valid_layout" "$temporary_directory/extra-layout"
+echo 'unexpected' > "$temporary_directory/extra-layout/README.txt"
+expect_failure "exactly CopyLasso.app and Applications" \
+    assert_release_volume_layout "$temporary_directory/extra-layout"
+
+cp -R "$valid_layout" "$temporary_directory/wrong-link-layout"
+rm "$temporary_directory/wrong-link-layout/Applications"
+ln -s /tmp "$temporary_directory/wrong-link-layout/Applications"
+expect_failure "must resolve to /Applications" \
+    assert_release_volume_layout "$temporary_directory/wrong-link-layout"
+
+mkdir -p "$temporary_directory/missing-app-layout"
+ln -s /Applications "$temporary_directory/missing-app-layout/Applications"
+expect_failure "exactly CopyLasso.app and Applications" \
+    assert_release_volume_layout "$temporary_directory/missing-app-layout"
+
+source_app="$temporary_directory/source/CopyLasso.app"
+mkdir -p "$source_app/Contents/MacOS" "$source_app/Contents/Resources"
+printf 'binary fixture\n' > "$source_app/Contents/MacOS/CopyLasso"
+printf 'resource fixture\n' > "$source_app/Contents/Resources/content.txt"
+ln -s content.txt "$source_app/Contents/Resources/current.txt"
+chmod 755 "$source_app/Contents/MacOS/CopyLasso"
+
+source_manifest="$temporary_directory/source.manifest"
+same_manifest="$temporary_directory/same.manifest"
+changed_manifest="$temporary_directory/changed.manifest"
+create_release_payload_manifest "$source_app" "$source_manifest"
+create_release_payload_manifest "$source_app" "$same_manifest"
+assert_release_payload_manifests_match "$source_manifest" "$same_manifest"
+printf 'changed\n' >> "$source_app/Contents/Resources/content.txt"
+create_release_payload_manifest "$source_app" "$changed_manifest"
+expect_failure "payload differs from the qualified G26 application" \
+    assert_release_payload_manifests_match "$source_manifest" "$changed_manifest"
+
+dmg_fixture="$temporary_directory/CopyLasso-0.1.0.dmg"
+printf 'disk image fixture\n' > "$dmg_fixture"
+checksum_fixture="$temporary_directory/CopyLasso-0.1.0.dmg.sha256"
+(
+    cd "$temporary_directory"
+    /usr/bin/shasum -a 256 "$(basename "$dmg_fixture")" > "$(basename "$checksum_fixture")"
+)
+assert_release_checksum "$dmg_fixture" "$checksum_fixture"
+(
+    readonly dmg="$dmg_fixture"
+    readonly checksum_file="$checksum_fixture"
+    assert_release_checksum "$dmg_fixture" "$checksum_fixture"
+)
+
+wrong_checksum="$temporary_directory/wrong.sha256"
+printf '%064d  CopyLasso-0.1.0.dmg\n' 0 > "$wrong_checksum"
+expect_failure "checksum does not match" assert_release_checksum "$dmg_fixture" "$wrong_checksum"
+
+wrong_name_checksum="$temporary_directory/wrong-name.sha256"
+checksum_value="$(/usr/bin/shasum -a 256 "$dmg_fixture" | /usr/bin/awk '{print $1}')"
+printf '%s  Other.dmg\n' "$checksum_value" > "$wrong_name_checksum"
+expect_failure "must name CopyLasso-0.1.0.dmg" \
+    assert_release_checksum "$dmg_fixture" "$wrong_name_checksum"
+
+valid_signature="$temporary_directory/valid-dmg-signature.txt"
+cat > "$valid_signature" <<'TEXT'
+Identifier=io.github.bennetthilberg.copylasso.dmg
+Signature size=9000
+Authority=Developer ID Application: Redacted
+Authority=Developer ID Certification Authority
+Authority=Apple Root CA
+Timestamp=Jul 16, 2026 at 12:00:00 PM
+TeamIdentifier=REDACTED
+TEXT
+assert_release_dmg_signature "$valid_signature" "REDACTED"
+(
+    readonly expected_team_identifier="REDACTED"
+    readonly signature_record="$valid_signature"
+    assert_release_dmg_signature "$valid_signature" "REDACTED"
+)
+
+sed '/Developer ID Application/d' "$valid_signature" > "$temporary_directory/development-signature.txt"
+expect_failure "Developer ID Application" assert_release_dmg_signature \
+    "$temporary_directory/development-signature.txt" "REDACTED"
+sed '/Timestamp=/d' "$valid_signature" > "$temporary_directory/no-timestamp-signature.txt"
+expect_failure "secure timestamp" assert_release_dmg_signature \
+    "$temporary_directory/no-timestamp-signature.txt" "REDACTED"
+sed 's/io.github.bennetthilberg.copylasso.dmg/io.github.bennetthilberg.copylasso.debug.dmg/' \
+    "$valid_signature" > "$temporary_directory/wrong-identifier-signature.txt"
+expect_failure "release disk-image identifier" assert_release_dmg_signature \
+    "$temporary_directory/wrong-identifier-signature.txt" "REDACTED"
+sed 's/TeamIdentifier=REDACTED/TeamIdentifier=DIFFERENT/' \
+    "$valid_signature" > "$temporary_directory/wrong-team-signature.txt"
+expect_failure "approved release team" assert_release_dmg_signature \
+    "$temporary_directory/wrong-team-signature.txt" "REDACTED"
+
+valid_gatekeeper="$temporary_directory/valid-dmg-gatekeeper.txt"
+cat > "$valid_gatekeeper" <<'TEXT'
+/private/example/CopyLasso-0.1.0.dmg: accepted
+source=Notarized Developer ID
+origin=Developer ID Application: Redacted
+TEXT
+assert_release_dmg_gatekeeper "$valid_gatekeeper"
+sed 's/Notarized Developer ID/Developer ID/' "$valid_gatekeeper" > \
+    "$temporary_directory/developer-id-gatekeeper.txt"
+assert_release_dmg_gatekeeper "$temporary_directory/developer-id-gatekeeper.txt"
+sed 's/: accepted/: rejected/' "$valid_gatekeeper" > "$temporary_directory/rejected-gatekeeper.txt"
+expect_failure "did not accept" assert_release_dmg_gatekeeper \
+    "$temporary_directory/rejected-gatekeeper.txt"
+sed 's/Developer ID Application: Redacted/Apple Development: Redacted/' \
+    "$valid_gatekeeper" > "$temporary_directory/wrong-origin-gatekeeper.txt"
+expect_failure "unexpected origin" assert_release_dmg_gatekeeper \
+    "$temporary_directory/wrong-origin-gatekeeper.txt"
+
+valid_imageinfo="$temporary_directory/valid-imageinfo.txt"
+cat > "$valid_imageinfo" <<'TEXT'
+Format Description: UDIF read-only compressed (zlib)
+Format: UDZO
+TEXT
+assert_release_dmg_imageinfo "$valid_imageinfo"
+sed 's/Format: UDZO/Format: UDRW/' "$valid_imageinfo" > "$temporary_directory/writable-imageinfo.txt"
+expect_failure "read-only UDZO" assert_release_dmg_imageinfo \
+    "$temporary_directory/writable-imageinfo.txt"
+
+valid_diskutil="$temporary_directory/valid-diskutil.txt"
+cat > "$valid_diskutil" <<'TEXT'
+   Media Read-Only:           Yes
+   Volume Read-Only:          Yes (read-only mount flag set)
+TEXT
+assert_release_read_only_mount "$valid_diskutil"
+sed 's/Media Read-Only:           Yes/Media Read-Only:           No/' \
+    "$valid_diskutil" > "$temporary_directory/writable-media.txt"
+expect_failure "media is not read-only" assert_release_read_only_mount \
+    "$temporary_directory/writable-media.txt"
+sed 's/Volume Read-Only:          Yes/Volume Read-Only:          No/' \
+    "$valid_diskutil" > "$temporary_directory/writable-volume.txt"
+expect_failure "volume is not read-only" assert_release_read_only_mount \
+    "$temporary_directory/writable-volume.txt"
+
+valid_submission="$temporary_directory/valid-submission.json"
+cat > "$valid_submission" <<'JSON'
+{"id":"00000000-0000-0000-0000-000000000000","status":"Accepted"}
+JSON
+valid_log="$temporary_directory/valid-notary-log.json"
+cat > "$valid_log" <<'JSON'
+{"jobId":"00000000-0000-0000-0000-000000000000","status":"Accepted","issues":[]}
+JSON
+assert_release_notary_records "$valid_submission" "$valid_log"
+(
+    readonly submission_record="$valid_submission"
+    readonly diagnostic_log="$valid_log"
+    assert_release_notary_records "$valid_submission" "$valid_log"
+)
+
+sed 's/Accepted/Invalid/' "$valid_submission" > "$temporary_directory/invalid-submission.json"
+expect_failure "submission was not accepted" assert_release_notary_records \
+    "$temporary_directory/invalid-submission.json" "$valid_log"
+cat > "$temporary_directory/warning-log.json" <<'JSON'
+{"jobId":"00000000-0000-0000-0000-000000000000","status":"Accepted","issues":[{"severity":"warning"}]}
+JSON
+expect_failure "contains issues" assert_release_notary_records \
+    "$valid_submission" "$temporary_directory/warning-log.json"
+
+valid_app_uuids="$temporary_directory/app-uuids.txt"
+valid_dsym_uuids="$temporary_directory/dsym-uuids.txt"
+cat > "$valid_app_uuids" <<'TEXT'
+UUID: AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA (arm64) CopyLasso
+UUID: BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB (x86_64) CopyLasso
+TEXT
+cat > "$valid_dsym_uuids" <<'TEXT'
+UUID: BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB (x86_64) CopyLasso
+UUID: AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA (arm64) CopyLasso
+TEXT
+assert_release_uuid_sets_match "$valid_app_uuids" "$valid_dsym_uuids"
+sed 's/BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB/CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC/' \
+    "$valid_dsym_uuids" > "$temporary_directory/wrong-dsym-uuids.txt"
+expect_failure "dSYM UUIDs do not match" assert_release_uuid_sets_match \
+    "$valid_app_uuids" "$temporary_directory/wrong-dsym-uuids.txt"
+
+assert_release_artifact_names \
+    "CopyLasso-0.1.0.dmg" \
+    "CopyLasso-0.1.0.dmg.sha256" \
+    "CopyLasso-0.1.0.dSYM.zip"
+expect_failure "release artifact names" assert_release_artifact_names \
+    "CopyLasso-latest.dmg" \
+    "CopyLasso-0.1.0.dmg.sha256" \
+    "CopyLasso-0.1.0.dSYM.zip"
+
+for run_name in comparison-1 comparison-2; do
+    run="$temporary_directory/$run_name"
+    mkdir "$run"
+    printf 'equivalent image fixture\n' > "$run/CopyLasso-0.1.0.dmg"
+    printf 'symbol fixture\n' > "$run/CopyLasso-0.1.0.dSYM.zip"
+    cp "$source_manifest" "$run/payload-manifest.txt"
+    (
+        cd "$run"
+        /usr/bin/shasum -a 256 CopyLasso-0.1.0.dmg > CopyLasso-0.1.0.dmg.sha256
+    )
+    cat > "$run/release-evidence.txt" <<'TEXT'
+version=0.1.0
+build=1
+payload_commit=1111111111111111111111111111111111111111
+packaging_commit=2222222222222222222222222222222222222222
+dmg_identifier=io.github.bennetthilberg.copylasso.dmg
+dmg_filename=CopyLasso-0.1.0.dmg
+app_manifest_sha256=3333333333333333333333333333333333333333333333333333333333333333
+dsym_uuid_manifest_sha256=4444444444444444444444444444444444444444444444444444444444444444
+TEXT
+done
+"$comparator_script" \
+    "$temporary_directory/comparison-1" \
+    "$temporary_directory/comparison-2" >/dev/null
+sed -i '' 's/build=1/build=2/' "$temporary_directory/comparison-2/release-evidence.txt"
+expect_failure "normalized evidence: build" "$comparator_script" \
+    "$temporary_directory/comparison-1" \
+    "$temporary_directory/comparison-2"
+
+echo "Release-package contract tests passed."

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -214,7 +214,11 @@ assert_release_notary_records "$valid_submission" "$valid_log"
 
 null_issues_log="$temporary_directory/null-issues-log.json"
 cat > "$null_issues_log" <<'JSON'
-{"jobId":"00000000-0000-0000-0000-000000000000","status":"Accepted","issues":null}
+{
+  "jobId": "00000000-0000-0000-0000-000000000000",
+  "status": "Accepted",
+  "issues": null
+}
 JSON
 assert_release_notary_records "$valid_submission" "$null_issues_log"
 

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -277,6 +277,29 @@ expect_failure "payload commit does not match" \
 expect_failure "expected payload commit is invalid" \
     assert_release_commit_matches "payload" "not-a-commit" "not-a-commit"
 
+commit_repository="$temporary_directory/commit-repository"
+/usr/bin/git init -q "$commit_repository"
+/usr/bin/git -C "$commit_repository" \
+    -c user.name=CopyLasso \
+    -c user.email=release-test.invalid \
+    commit -q --allow-empty -m payload
+fixture_payload_commit="$(/usr/bin/git -C "$commit_repository" rev-parse HEAD)"
+/usr/bin/git -C "$commit_repository" \
+    -c user.name=CopyLasso \
+    -c user.email=release-test.invalid \
+    commit -q --allow-empty -m packaging
+fixture_packaging_commit="$(/usr/bin/git -C "$commit_repository" rev-parse HEAD)"
+assert_release_commit_relationship \
+    "$commit_repository" "$fixture_payload_commit" "$fixture_packaging_commit"
+expect_failure "payload commit is not available" \
+    assert_release_commit_relationship \
+    "$commit_repository" \
+    "1111111111111111111111111111111111111111" \
+    "$fixture_packaging_commit"
+expect_failure "payload commit is not an ancestor" \
+    assert_release_commit_relationship \
+    "$commit_repository" "$fixture_packaging_commit" "$fixture_payload_commit"
+
 assert_release_artifact_names \
     "CopyLasso-0.1.0.dmg" \
     "CopyLasso-0.1.0.dmg.sha256" \

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -62,6 +62,15 @@ ln -s /Applications "$temporary_directory/missing-app-layout/Applications"
 expect_failure "exactly CopyLasso.app and Applications" \
     assert_release_volume_layout "$temporary_directory/missing-app-layout"
 
+external_app="$temporary_directory/external/CopyLasso.app"
+mkdir -p "$external_app"
+symlink_app_layout="$temporary_directory/symlink-app-layout"
+mkdir -p "$symlink_app_layout"
+ln -s "$external_app" "$symlink_app_layout/CopyLasso.app"
+ln -s /Applications "$symlink_app_layout/Applications"
+expect_failure "must be a real directory" \
+    assert_release_volume_layout "$symlink_app_layout"
+
 source_app="$temporary_directory/source/CopyLasso.app"
 mkdir -p "$source_app/Contents/MacOS" "$source_app/Contents/Resources"
 printf 'binary fixture\n' > "$source_app/Contents/MacOS/CopyLasso"
@@ -193,6 +202,12 @@ assert_release_notary_records "$valid_submission" "$valid_log"
     readonly diagnostic_log="$valid_log"
     assert_release_notary_records "$valid_submission" "$valid_log"
 )
+
+null_issues_log="$temporary_directory/null-issues-log.json"
+cat > "$null_issues_log" <<'JSON'
+{"jobId":"00000000-0000-0000-0000-000000000000","status":"Accepted","issues":null}
+JSON
+assert_release_notary_records "$valid_submission" "$null_issues_log"
 
 sed 's/Accepted/Invalid/' "$valid_submission" > "$temporary_directory/invalid-submission.json"
 expect_failure "submission was not accepted" assert_release_notary_records \

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -211,6 +211,10 @@ assert_release_notary_records "$valid_submission" "$valid_log"
     readonly diagnostic_log="$valid_log"
     assert_release_notary_records "$valid_submission" "$valid_log"
 )
+(
+    readonly submission_identifier="fixture-submission"
+    assert_release_notary_records "$valid_submission" "$valid_log"
+)
 
 null_issues_log="$temporary_directory/null-issues-log.json"
 cat > "$null_issues_log" <<'JSON'

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -309,11 +309,21 @@ expect_failure "release artifact names" assert_release_artifact_names \
     "CopyLasso-0.1.0.dmg.sha256" \
     "CopyLasso-0.1.0.dSYM.zip"
 
+comparison_dsym="$temporary_directory/comparison-dsym/CopyLasso.app.dSYM"
+mkdir -p "$comparison_dsym/Contents/Resources/DWARF"
+cp /usr/bin/true "$comparison_dsym/Contents/Resources/DWARF/CopyLasso"
+/usr/bin/dwarfdump --uuid "$comparison_dsym" > "$temporary_directory/comparison-dsym-uuids.txt"
+normalized_release_uuids "$temporary_directory/comparison-dsym-uuids.txt" \
+    > "$temporary_directory/comparison-normalized-dsym-uuids.txt"
+comparison_dsym_uuid_hash="$(/usr/bin/shasum -a 256 \
+    "$temporary_directory/comparison-normalized-dsym-uuids.txt" | /usr/bin/awk '{print $1}')"
+
 for run_name in comparison-1 comparison-2; do
     run="$temporary_directory/$run_name"
     mkdir "$run"
     printf 'equivalent image fixture\n' > "$run/CopyLasso-0.1.0.dmg"
-    printf 'symbol fixture\n' > "$run/CopyLasso-0.1.0.dSYM.zip"
+    /usr/bin/ditto -c -k --norsrc --noextattr --keepParent \
+        "$comparison_dsym" "$run/CopyLasso-0.1.0.dSYM.zip"
     cp "$source_manifest" "$run/payload-manifest.txt"
     (
         cd "$run"
@@ -327,14 +337,28 @@ packaging_commit=2222222222222222222222222222222222222222
 dmg_identifier=io.github.bennetthilberg.copylasso.dmg
 dmg_filename=CopyLasso-0.1.0.dmg
 app_manifest_sha256=3333333333333333333333333333333333333333333333333333333333333333
-dsym_uuid_manifest_sha256=4444444444444444444444444444444444444444444444444444444444444444
 TEXT
+    printf 'dsym_uuid_manifest_sha256=%s\n' "$comparison_dsym_uuid_hash" >> \
+        "$run/release-evidence.txt"
 done
 "$comparator_script" \
     "$temporary_directory/comparison-1" \
     "$temporary_directory/comparison-2" >/dev/null
 sed -i '' 's/build=1/build=2/' "$temporary_directory/comparison-2/release-evidence.txt"
 expect_failure "normalized evidence: build" "$comparator_script" \
+    "$temporary_directory/comparison-1" \
+    "$temporary_directory/comparison-2"
+sed -i '' 's/build=2/build=1/' "$temporary_directory/comparison-2/release-evidence.txt"
+cp /usr/bin/false "$comparison_dsym/Contents/Resources/DWARF/CopyLasso"
+rm "$temporary_directory/comparison-2/CopyLasso-0.1.0.dSYM.zip"
+/usr/bin/ditto -c -k --norsrc --noextattr --keepParent \
+    "$comparison_dsym" "$temporary_directory/comparison-2/CopyLasso-0.1.0.dSYM.zip"
+expect_failure "wrong dSYM UUID manifest" "$comparator_script" \
+    "$temporary_directory/comparison-1" \
+    "$temporary_directory/comparison-2"
+printf 'corrupted dSYM archive\n' > \
+    "$temporary_directory/comparison-2/CopyLasso-0.1.0.dSYM.zip"
+expect_failure "release dSYM archive could not be expanded" "$comparator_script" \
     "$temporary_directory/comparison-1" \
     "$temporary_directory/comparison-2"
 

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -219,6 +219,20 @@ sed 's/BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB/CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC
 expect_failure "dSYM UUIDs do not match" assert_release_uuid_sets_match \
     "$valid_app_uuids" "$temporary_directory/wrong-dsym-uuids.txt"
 
+portable_evidence="$temporary_directory/portable-evidence.txt"
+cat > "$portable_evidence" <<'TEXT'
+version=0.1.0
+build=1
+TEXT
+assert_release_evidence_is_portable "$portable_evidence"
+absolute_path_evidence="$temporary_directory/absolute-path-evidence.txt"
+cat > "$absolute_path_evidence" <<'TEXT'
+version=0.1.0
+local_artifact=/local/build/output
+TEXT
+expect_failure "must not contain local absolute paths" \
+    assert_release_evidence_is_portable "$absolute_path_evidence"
+
 assert_release_artifact_names \
     "CopyLasso-0.1.0.dmg" \
     "CopyLasso-0.1.0.dmg.sha256" \

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -185,8 +185,6 @@ readonly actual_submission_identifier="$(/usr/bin/plutil -extract id raw "$submi
     release_package_fail "The release evidence has no exact payload commit."
 [[ "$(evidence_value packaging_commit)" =~ ^[0-9a-f]{40}$ ]] || \
     release_package_fail "The release evidence has no exact packaging commit."
-if /usr/bin/grep -Eq '=(/Users/|/private/|/tmp/)' "$evidence_record"; then
-    release_package_fail "The release evidence must not contain local absolute paths."
-fi
+assert_release_evidence_is_portable "$evidence_record"
 
 echo "CopyLasso release-package verification passed."

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -7,25 +7,61 @@ readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$repository_root/scripts/lib/release-package-verification.sh"
 
 usage() {
-    echo "Usage: $0 --payload-app /path/to/CopyLasso.app /path/to/release-run" >&2
+    cat >&2 <<'TEXT'
+Usage: verify-release-package.sh \
+  --payload-app /path/to/G26/<commit>/export/CopyLasso.app \
+  --payload-commit <40-character-commit> \
+  --packaging-commit <40-character-commit> \
+  /path/to/release-run
+TEXT
     exit 64
 }
 
 payload_app=""
-if [[ "${1:-}" == "--payload-app" ]]; then
-    [[ "$#" == 3 ]] || usage
-    payload_app="$2"
-    shift 2
-fi
-[[ "$#" == 1 && -n "$payload_app" ]] || usage
+expected_payload_commit=""
+expected_packaging_commit=""
+run_candidate=""
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --payload-app)
+            [[ "$#" -ge 2 ]] || usage
+            payload_app="$2"
+            shift 2
+            ;;
+        --payload-commit)
+            [[ "$#" -ge 2 ]] || usage
+            expected_payload_commit="$2"
+            shift 2
+            ;;
+        --packaging-commit)
+            [[ "$#" -ge 2 ]] || usage
+            expected_packaging_commit="$2"
+            shift 2
+            ;;
+        --*) usage ;;
+        *)
+            [[ -z "$run_candidate" ]] || usage
+            run_candidate="$1"
+            shift
+            ;;
+    esac
+done
+[[ -n "$payload_app" && -n "$expected_payload_commit" && \
+    -n "$expected_packaging_commit" && -n "$run_candidate" ]] || usage
+assert_release_commit_matches \
+    "payload" "$expected_payload_commit" "$expected_payload_commit"
+assert_release_commit_matches \
+    "packaging" "$expected_packaging_commit" "$expected_packaging_commit"
 
-readonly run_candidate="$1"
 [[ -d "$run_candidate" ]] || release_package_fail "The release-package run directory is missing."
 readonly run_parent="$(cd "$(dirname "$run_candidate")" && /bin/pwd -P)"
 readonly run_directory="$run_parent/$(basename "$run_candidate")"
 [[ -d "$payload_app" ]] || release_package_fail "The qualified G26 payload application is missing."
 readonly payload_parent="$(cd "$(dirname "$payload_app")" && /bin/pwd -P)"
 readonly qualified_payload="$payload_parent/$(basename "$payload_app")"
+if [[ "$(basename "$(dirname "$payload_parent")")" != "$expected_payload_commit" ]]; then
+    release_package_fail "The qualified G26 payload path does not match the expected payload commit."
+fi
 readonly expected_team_identifier="${COPYLASSO_EXPECTED_TEAM_ID:-}"
 if [[ ! "$expected_team_identifier" =~ ^[A-Z0-9]{10}$ ]]; then
     release_package_fail \
@@ -181,10 +217,10 @@ readonly actual_submission_identifier="$(/usr/bin/plutil -extract id raw "$submi
     release_package_fail "The release evidence records the wrong dSYM UUID manifest."
 [[ "$(evidence_value notary_submission_id)" == "$actual_submission_identifier" ]] || \
     release_package_fail "The release evidence records the wrong notarization submission."
-[[ "$(evidence_value payload_commit)" =~ ^[0-9a-f]{40}$ ]] || \
-    release_package_fail "The release evidence has no exact payload commit."
-[[ "$(evidence_value packaging_commit)" =~ ^[0-9a-f]{40}$ ]] || \
-    release_package_fail "The release evidence has no exact packaging commit."
+assert_release_commit_matches \
+    "payload" "$expected_payload_commit" "$(evidence_value payload_commit)"
+assert_release_commit_matches \
+    "packaging" "$expected_packaging_commit" "$(evidence_value packaging_commit)"
 assert_release_evidence_is_portable "$evidence_record"
 
 echo "CopyLasso release-package verification passed."

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -52,6 +52,8 @@ assert_release_commit_matches \
     "payload" "$expected_payload_commit" "$expected_payload_commit"
 assert_release_commit_matches \
     "packaging" "$expected_packaging_commit" "$expected_packaging_commit"
+assert_release_commit_relationship \
+    "$repository_root" "$expected_payload_commit" "$expected_packaging_commit"
 
 [[ -d "$run_candidate" ]] || release_package_fail "The release-package run directory is missing."
 readonly run_parent="$(cd "$(dirname "$run_candidate")" && /bin/pwd -P)"

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/release-package-verification.sh
+source "$repository_root/scripts/lib/release-package-verification.sh"
+
+usage() {
+    echo "Usage: $0 --payload-app /path/to/CopyLasso.app /path/to/release-run" >&2
+    exit 64
+}
+
+payload_app=""
+if [[ "${1:-}" == "--payload-app" ]]; then
+    [[ "$#" == 3 ]] || usage
+    payload_app="$2"
+    shift 2
+fi
+[[ "$#" == 1 && -n "$payload_app" ]] || usage
+
+readonly run_candidate="$1"
+[[ -d "$run_candidate" ]] || release_package_fail "The release-package run directory is missing."
+readonly run_parent="$(cd "$(dirname "$run_candidate")" && /bin/pwd -P)"
+readonly run_directory="$run_parent/$(basename "$run_candidate")"
+[[ -d "$payload_app" ]] || release_package_fail "The qualified G26 payload application is missing."
+readonly payload_parent="$(cd "$(dirname "$payload_app")" && /bin/pwd -P)"
+readonly qualified_payload="$payload_parent/$(basename "$payload_app")"
+readonly expected_team_identifier="${COPYLASSO_EXPECTED_TEAM_ID:-}"
+if [[ ! "$expected_team_identifier" =~ ^[A-Z0-9]{10}$ ]]; then
+    release_package_fail \
+        "COPYLASSO_EXPECTED_TEAM_ID must provide the approved release team outside the repository."
+fi
+
+readonly dmg="$run_directory/$COPYLASSO_RELEASE_DMG"
+readonly checksum="$run_directory/$COPYLASSO_RELEASE_CHECKSUM"
+readonly dsym_zip="$run_directory/$COPYLASSO_RELEASE_DSYM"
+readonly submission_record="$run_directory/notary-submission.json"
+readonly diagnostic_log="$run_directory/notary-log.json"
+readonly evidence_record="$run_directory/release-evidence.txt"
+readonly expected_payload_manifest="$run_directory/payload-manifest.txt"
+
+for required_file in \
+    "$dmg" \
+    "$checksum" \
+    "$dsym_zip" \
+    "$submission_record" \
+    "$diagnostic_log" \
+    "$evidence_record" \
+    "$expected_payload_manifest"; do
+    [[ -f "$required_file" ]] || \
+        release_package_fail "A required release-package artifact is missing: $(basename "$required_file")"
+done
+
+assert_release_artifact_names \
+    "$(basename "$dmg")" \
+    "$(basename "$checksum")" \
+    "$(basename "$dsym_zip")"
+assert_release_checksum "$dmg" "$checksum"
+assert_release_notary_records "$submission_record" "$diagnostic_log"
+
+readonly temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/copylasso-release-verify.XXXXXX")"
+readonly mount_point="$temporary_directory/mount"
+mounted="false"
+cleanup() {
+    if [[ "$mounted" == "true" ]]; then
+        /usr/bin/hdiutil detach "$mount_point" >/dev/null 2>&1 || true
+    fi
+    /bin/rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+if ! "$repository_root/scripts/verify-developer-id-app.sh" --post-notarization \
+    "$qualified_payload" > "$temporary_directory/payload-verification.txt"; then
+    release_package_fail "The qualified G26 payload no longer passes final Developer ID verification."
+fi
+
+if ! /usr/bin/codesign --verify --strict --verbose=2 "$dmg" \
+    > "$temporary_directory/dmg-codesign-verification.txt" 2>&1; then
+    release_package_fail "The release disk-image signature is invalid."
+fi
+if ! /usr/bin/codesign --display --verbose=4 "$dmg" \
+    > /dev/null 2> "$temporary_directory/dmg-signature.txt"; then
+    release_package_fail "The release disk-image signature cannot be inspected."
+fi
+assert_release_dmg_signature \
+    "$temporary_directory/dmg-signature.txt" \
+    "$expected_team_identifier"
+
+if ! xcrun stapler validate "$dmg" > "$temporary_directory/dmg-stapler.txt" 2>&1; then
+    release_package_fail "The release disk image has no valid stapled notarization ticket."
+fi
+if ! /usr/sbin/spctl --assess --type open --context context:primary-signature \
+    --verbose=4 "$dmg" > "$temporary_directory/dmg-gatekeeper.txt" 2>&1; then
+    release_package_fail "Gatekeeper assessment failed for the release disk image."
+fi
+assert_release_dmg_gatekeeper "$temporary_directory/dmg-gatekeeper.txt"
+
+if ! /usr/bin/hdiutil imageinfo "$dmg" > "$temporary_directory/dmg-imageinfo.txt" 2>&1; then
+    release_package_fail "The release disk image cannot be inspected."
+fi
+assert_release_dmg_imageinfo "$temporary_directory/dmg-imageinfo.txt"
+
+/bin/mkdir "$mount_point"
+if ! /usr/bin/hdiutil attach -readonly -nobrowse -mountpoint "$mount_point" "$dmg" \
+    > "$temporary_directory/dmg-attach.txt" 2>&1; then
+    release_package_fail "The release disk image could not be mounted read-only."
+fi
+mounted="true"
+if ! /usr/sbin/diskutil info "$mount_point" > "$temporary_directory/dmg-diskutil.txt" 2>&1; then
+    release_package_fail "The mounted release volume could not be inspected."
+fi
+assert_release_read_only_mount "$temporary_directory/dmg-diskutil.txt"
+
+assert_release_volume_layout "$mount_point"
+readonly mounted_application="$mount_point/CopyLasso.app"
+if ! "$repository_root/scripts/verify-developer-id-app.sh" --post-notarization \
+    "$mounted_application" > "$temporary_directory/mounted-app-verification.txt"; then
+    release_package_fail "The application inside the disk image failed final verification."
+fi
+
+create_release_payload_manifest "$qualified_payload" "$temporary_directory/source-payload.manifest"
+create_release_payload_manifest "$mounted_application" "$temporary_directory/mounted-payload.manifest"
+assert_release_payload_manifests_match \
+    "$temporary_directory/source-payload.manifest" \
+    "$expected_payload_manifest"
+assert_release_payload_manifests_match \
+    "$temporary_directory/source-payload.manifest" \
+    "$temporary_directory/mounted-payload.manifest"
+
+/usr/bin/hdiutil detach "$mount_point" > "$temporary_directory/dmg-detach.txt"
+mounted="false"
+
+/bin/mkdir "$temporary_directory/dsym"
+if ! /usr/bin/ditto -x -k "$dsym_zip" "$temporary_directory/dsym"; then
+    release_package_fail "The release dSYM archive could not be expanded."
+fi
+readonly dsym="$temporary_directory/dsym/CopyLasso.app.dSYM"
+[[ -d "$dsym" ]] || release_package_fail "The release dSYM archive has an unexpected layout."
+if [[ "$(/usr/bin/find "$temporary_directory/dsym" -mindepth 1 -maxdepth 1 -print | /usr/bin/wc -l | /usr/bin/tr -d ' ')" != "1" ]]; then
+    release_package_fail "The release dSYM archive must contain only CopyLasso.app.dSYM."
+fi
+readonly executable_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' \
+    "$qualified_payload/Contents/Info.plist")"
+/usr/bin/dwarfdump --uuid "$qualified_payload/Contents/MacOS/$executable_name" \
+    > "$temporary_directory/application-uuids.txt"
+/usr/bin/dwarfdump --uuid "$dsym" > "$temporary_directory/dsym-uuids.txt"
+assert_release_uuid_sets_match \
+    "$temporary_directory/application-uuids.txt" \
+    "$temporary_directory/dsym-uuids.txt"
+
+evidence_value() {
+    local key="$1"
+    /usr/bin/sed -n "s/^${key}=//p" "$evidence_record"
+}
+
+readonly actual_dmg_hash="$(/usr/bin/shasum -a 256 "$dmg" | /usr/bin/awk '{print $1}')"
+readonly actual_dmg_size="$(/usr/bin/stat -f '%z' "$dmg")"
+readonly actual_manifest_hash="$(/usr/bin/shasum -a 256 "$expected_payload_manifest" | /usr/bin/awk '{print $1}')"
+normalized_release_uuids "$temporary_directory/dsym-uuids.txt" \
+    > "$temporary_directory/normalized-dsym-uuids.txt"
+readonly actual_dsym_uuid_hash="$(/usr/bin/shasum -a 256 \
+    "$temporary_directory/normalized-dsym-uuids.txt" | /usr/bin/awk '{print $1}')"
+readonly actual_submission_identifier="$(/usr/bin/plutil -extract id raw "$submission_record")"
+
+[[ "$(evidence_value version)" == "$COPYLASSO_RELEASE_VERSION" ]] || \
+    release_package_fail "The release evidence records the wrong version."
+[[ "$(evidence_value build)" == "$COPYLASSO_RELEASE_BUILD" ]] || \
+    release_package_fail "The release evidence records the wrong build."
+[[ "$(evidence_value dmg_identifier)" == "$COPYLASSO_RELEASE_DMG_IDENTIFIER" ]] || \
+    release_package_fail "The release evidence records the wrong disk-image identifier."
+[[ "$(evidence_value dmg_filename)" == "$COPYLASSO_RELEASE_DMG" ]] || \
+    release_package_fail "The release evidence records the wrong disk-image filename."
+[[ "$(evidence_value dmg_sha256)" == "$actual_dmg_hash" ]] || \
+    release_package_fail "The release evidence records the wrong disk-image checksum."
+[[ "$(evidence_value dmg_size_bytes)" == "$actual_dmg_size" ]] || \
+    release_package_fail "The release evidence records the wrong disk-image size."
+[[ "$(evidence_value app_manifest_sha256)" == "$actual_manifest_hash" ]] || \
+    release_package_fail "The release evidence records the wrong application manifest."
+[[ "$(evidence_value dsym_uuid_manifest_sha256)" == "$actual_dsym_uuid_hash" ]] || \
+    release_package_fail "The release evidence records the wrong dSYM UUID manifest."
+[[ "$(evidence_value notary_submission_id)" == "$actual_submission_identifier" ]] || \
+    release_package_fail "The release evidence records the wrong notarization submission."
+[[ "$(evidence_value payload_commit)" =~ ^[0-9a-f]{40}$ ]] || \
+    release_package_fail "The release evidence has no exact payload commit."
+[[ "$(evidence_value packaging_commit)" =~ ^[0-9a-f]{40}$ ]] || \
+    release_package_fail "The release evidence has no exact packaging commit."
+if /usr/bin/grep -Eq '=(/Users/|/private/|/tmp/)' "$evidence_record"; then
+    release_package_fail "The release evidence must not contain local absolute paths."
+fi
+
+echo "CopyLasso release-package verification passed."


### PR DESCRIPTION
## Summary

- add a version-controlled local DMG packaging process that reuses an exact qualified release app and matching dSYM
- add strict disk-image, checksum, notarization, mounted-layout, payload-equivalence, provenance, and dSYM verification
- add deterministic two-run comparison, canonical CI enforcement, and release-packaging documentation
- replace the standard About command with CopyLasso's accessible MIT and repository About window so the shipped app does not claim "All rights reserved"
- make the two-run comparator independently expand each dSYM archive and bind its actual UUID manifest to release evidence

## Verification

- complete local arm64 and x86_64 pipelines passed with 243 tests, offline checks, three repeatability passes per architecture, and a Universal 2 Release build
- hosted arm64, x86_64, and macOS 14 checks passed on exact head `7587756`
- focused release-package tests, static audit, CI contract, brand audit, privacy audit, shell syntax, and formatting passed
- qualified payload `8b0ee5f` was freshly archived, Developer ID exported, accepted by Apple's notarization service, stapled, and fully reverified after the About correction
- two fresh DMGs at packaging head `7587756` were independently signed, accepted, stapled, and fully verified
- both checksums validate and the strengthened two-run comparator reports functional equivalence after inspecting both real dSYM archives
- the corrected custom About window was inspected in the exact qualified Release app and shows the creator, open-source description, repository, and MIT license

## Release boundary

The qualified app, DMGs, checksums, dSYM archive, and notarization evidence remain local ignored outputs. No package, tag, or public release is published by G27.