### PR TITLE
G28: add protected release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_call:
   pull_request:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Protected Release Candidate
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: copylasso-protected-release
+  cancel-in-progress: false
+
+jobs:
+  quality-gate:
+    name: Complete release quality gate
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ci.yml
+
+  protected-release:
+    name: Build protected draft release
+    needs: quality-gate
+    runs-on: macos-26
+    timeout-minutes: 90
+    environment:
+      name: release
+    permissions:
+      contents: write
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+    steps:
+      - name: Check out exact protected commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify protected source provenance
+        env:
+          COPYLASSO_EXPECTED_REF: ${{ github.ref }}
+          COPYLASSO_EXPECTED_COMMIT: ${{ github.sha }}
+        run: |
+          ./scripts/verify-release-workflow-source.sh \
+            --expected-ref "$COPYLASSO_EXPECTED_REF" \
+            --expected-commit "$COPYLASSO_EXPECTED_COMMIT"
+
+      - name: Initialize ephemeral release paths
+        run: |
+          release_keychain_password="$(/usr/bin/openssl rand -hex 32)"
+          echo "::add-mask::$release_keychain_password"
+          printf 'COPYLASSO_RELEASE_KEYCHAIN_PASSWORD=%s\n' \
+            "$release_keychain_password" >> "$GITHUB_ENV"
+          printf 'COPYLASSO_RELEASE_STATE=%s\n' \
+            "$RUNNER_TEMP/copylasso-release-state" >> "$GITHUB_ENV"
+          printf 'COPYLASSO_RELEASE_KEYCHAIN_PATH=%s\n' \
+            "$RUNNER_TEMP/copylasso-release-state/copylasso-release.keychain-db" \
+            >> "$GITHUB_ENV"
+          printf 'COPYLASSO_RELEASE_HANDOFF=%s\n' \
+            "$RUNNER_TEMP/CopyLasso/G28/$GITHUB_SHA" >> "$GITHUB_ENV"
+          printf 'COPYLASSO_RELEASE_RUN_DIR=%s\n' \
+            "$GITHUB_WORKSPACE/dist/g28/$GITHUB_SHA/run-$GITHUB_RUN_ATTEMPT" \
+            >> "$GITHUB_ENV"
+          printf 'COPYLASSO_RELEASE_DRAFT_TAG=%s\n' \
+            "v0.1.0-g28.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
+          printf 'COPYLASSO_RELEASE_READBACK=%s\n' \
+            "$GITHUB_WORKSPACE/dist/g28/$GITHUB_SHA/draft-release.json" \
+            >> "$GITHUB_ENV"
+
+      - name: Import protected release credentials
+        env:
+          COPYLASSO_DEVELOPER_ID_P12_BASE64: ${{ secrets.COPYLASSO_DEVELOPER_ID_P12_BASE64 }}
+          COPYLASSO_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.COPYLASSO_DEVELOPER_ID_P12_PASSWORD }}
+          COPYLASSO_NOTARY_KEY_BASE64: ${{ secrets.COPYLASSO_NOTARY_KEY_BASE64 }}
+          COPYLASSO_NOTARY_KEY_ID: ${{ secrets.COPYLASSO_NOTARY_KEY_ID }}
+          COPYLASSO_NOTARY_ISSUER_ID: ${{ secrets.COPYLASSO_NOTARY_ISSUER_ID }}
+          COPYLASSO_EXPECTED_TEAM_ID: ${{ secrets.COPYLASSO_EXPECTED_TEAM_ID }}
+        run: |
+          ./scripts/prepare-release-keychain.sh \
+            --state-dir "$COPYLASSO_RELEASE_STATE"
+
+      - name: Build and verify exact release candidate
+        env:
+          COPYLASSO_EXPECTED_TEAM_ID: ${{ secrets.COPYLASSO_EXPECTED_TEAM_ID }}
+        run: |
+          ./scripts/build-release-candidate.sh \
+            --source-commit "$GITHUB_SHA" \
+            --handoff "$COPYLASSO_RELEASE_HANDOFF" \
+            --output-dir "$COPYLASSO_RELEASE_RUN_DIR"
+
+      - name: Remove protected release credentials
+        if: always()
+        run: |
+          ./scripts/cleanup-release-keychain.sh \
+            --state-dir "$COPYLASSO_RELEASE_STATE"
+
+      - name: Create verified GitHub draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./scripts/create-draft-release.sh \
+            --repository "$GITHUB_REPOSITORY" \
+            --commit "$GITHUB_SHA" \
+            --tag "$COPYLASSO_RELEASE_DRAFT_TAG" \
+            --run-dir "$COPYLASSO_RELEASE_RUN_DIR" \
+            --readback "$COPYLASSO_RELEASE_READBACK"

--- a/docs/developer-id-signing.md
+++ b/docs/developer-id-signing.md
@@ -45,7 +45,8 @@ unset COPYLASSO_NOTARY_KEY COPYLASSO_NOTARY_KEY_ID COPYLASSO_NOTARY_ISSUER_ID
 The profile must validate before use. Once validation succeeds, remove the downloaded private-key
 file; the credentials remain in the nonsynchronized login Keychain profile. Do not print or commit
 the account, key identifier, issuer identifier, certificate fingerprint, private key, or profile
-contents. Future protected CI credentials are a separate G28 concern.
+contents. G28's separate protected CI identity export and dedicated Team API key are documented in
+[`release-workflow.md`](release-workflow.md); they do not replace or expose this local profile.
 
 ## Archive and Export
 
@@ -147,3 +148,11 @@ signature slice matches `COPYLASSO_EXPECTED_TEAM_ID`; it never records that valu
 Preserve the exact accepted and stapled CopyLasso.app, its archive, dSYM, source commit, and
 notarization submission record outside the repository. G27 must build its DMG from this qualified
 application without rebuilding or re-signing it.
+
+## G28 Protected CI Boundary
+
+The G26 instruction not to export the private key applies to this local proof and handoff. G28 later
+requires a password-protected identity export so an ephemeral GitHub-hosted Keychain can sign the
+same Release contract. That export is stored only as a protected environment secret and its local
+temporary file is removed immediately. The release workflow also uses a dedicated Team API key
+rather than attempting to recover the one-time private key behind the local Keychain profile.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -38,6 +38,7 @@ Record every command, artifact name, SHA-256 checksum, commit, tag, signing iden
 - [ ] Produce the signed, notarized DMG, checksum, and dSYM from the exact protected commit and run the same verification as G27.
 - [ ] Inspect workflow permissions, secret masking, cleanup, failure behavior, and logs; failed tests or verification must prevent draft creation.
 - [ ] Create and verify a draft GitHub release only. Download its artifacts and rerun local package verification; do not publish it.
+- [ ] Keep the dSYM and verification bundle restricted to the draft and remove both before any G31 public publication.
 
 ## G29 - Clean Installation Test Environment
 

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -92,3 +92,8 @@ Finally, mount the selected verified image in Finder, confirm that it is read-on
 - Keep the dSYM archive private and restricted even though it contains no signing credential.
 
 Do not publish, tag, upload, or create a GitHub release in G27. G28 later introduces protected release CI and a draft-release rehearsal using the exact verified packaging contract.
+
+G28 invokes this same package script only after it has archived, exported, notarized, stapled, and
+verified an application from the exact protected workflow commit. It constructs the same
+commit-addressed handoff layout, uses that commit as both payload and packaging provenance, and does
+not weaken any G27 package check. See [`release-workflow.md`](release-workflow.md).

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,0 +1,130 @@
+# Protected Release Workflow
+
+G28 adds a manually dispatched GitHub Actions workflow that builds one signed, notarized, and
+verified CopyLasso release rehearsal from the exact protected `main` commit. It creates a draft
+prerelease and never publishes it. G29 clean-install testing, G30 immutable release-candidate tags,
+and G31 publication remain later gates.
+
+## Trust Boundary
+
+The workflow file must exist on the default branch before GitHub accepts its `workflow_dispatch`
+event. Run it only by choosing `main` in the Actions interface or by dispatching the workflow with
+`--ref main`.
+The workflow itself rejects every ref except `refs/heads/main`, requires the checked-out `HEAD` to
+equal the dispatched full commit, and requires that commit to equal `origin/main`.
+
+The ordinary pull-request workflow has no release trigger and receives no release credential. The
+protected workflow runs the complete reusable arm64, x86_64, and minimum-macOS gate before it asks
+for access to the `release` environment. The release job uses one reviewed, full-commit-pinned
+checkout action and does not persist Git credentials.
+
+Configure the public repository's `release` environment with:
+
+- protected branches only;
+- the maintainer as required reviewer;
+- self-review allowed while the project has only one release maintainer; and
+- the six environment secrets listed below.
+
+The environment must not expose these values as repository-level secrets:
+
+| Environment secret | Purpose |
+| --- | --- |
+| `COPYLASSO_DEVELOPER_ID_P12_BASE64` | Base64 of the password-protected Developer ID identity export |
+| `COPYLASSO_DEVELOPER_ID_P12_PASSWORD` | Password for that identity export |
+| `COPYLASSO_NOTARY_KEY_BASE64` | Base64 of the dedicated Team API private key |
+| `COPYLASSO_NOTARY_KEY_ID` | Dedicated Team API key identifier |
+| `COPYLASSO_NOTARY_ISSUER_ID` | App Store Connect issuer identifier |
+| `COPYLASSO_EXPECTED_TEAM_ID` | Approved Developer ID team used for independent verification |
+
+Secret names are public configuration; their values are not release evidence. Never enter a value
+in a workflow input, command argument, tracked file, issue, pull request, or release note.
+
+## Initial Credential Setup
+
+Export the existing Developer ID Application identity and private key from the login Keychain once
+as a password-protected PKCS#12 file. Use a newly generated password. Base64-encode the file directly
+into the protected environment secret through standard input, then remove the temporary export. Do
+not retain a `.p12` beside the repository or under `dist/`.
+
+Create a dedicated **Team API key** with the **Developer** role for GitHub Actions. This is separate
+from the local `copylasso-notary` profile established in G26. Store its private-key contents, key
+identifier, and issuer identifier only in the protected environment, then remove the downloaded key
+file. A personal Apple ID password or app-specific password is not used by this workflow.
+
+The workflow decodes both protected blobs only under `RUNNER_TEMP`, imports the identity into a
+randomly protected temporary Keychain, and creates a `copylasso-notary` profile in that Keychain.
+Raw credential files are removed immediately after import. An unconditional cleanup step restores
+the runner's original default and search-list Keychains, deletes the temporary Keychain, and must
+pass before draft creation.
+
+## Run The Rehearsal
+
+After the G28 source pull request is reviewed, green, and separately merged:
+
+1. Open **Actions > Protected Release Candidate > Run workflow** and select `main`.
+2. Confirm the run's commit is the intended protected `main` commit.
+3. Wait for the complete reusable CI gate.
+4. Approve the `release` environment when GitHub requests deployment review.
+5. Allow the protected job to archive, export, notarize, staple, package, verify, clean credentials,
+   and create its draft.
+
+Only one protected release run may execute at a time. A failure is never promoted by rerunning only
+a later step: correct the cause, create a new green commit if tracked code changed, and dispatch the
+complete workflow again.
+
+The workflow uses the G26 application verifier and G27 package process. Its protected commit is both
+the application payload commit and packaging commit. The resulting draft tag uses the nonrelease
+form `v0.1.0-g28.<run>` so it cannot be mistaken for G30's `v0.1.0-rc.N` candidate.
+
+## Draft Assets And Local Readback
+
+The draft prerelease contains exactly:
+
+- `CopyLasso-0.1.0.dmg`;
+- `CopyLasso-0.1.0.dmg.sha256`;
+- `CopyLasso-0.1.0.dSYM.zip`; and
+- `CopyLasso-0.1.0-verification.zip`.
+
+The verification bundle contains the exact stapled source application and the portable records
+needed to reconstruct the release-run directory after downloading the other three assets. Download
+all four assets into an ignored, commit-addressed directory, expand the verification bundle, place
+the DMG, checksum, and dSYM beside its `run` evidence, and invoke `verify-release-package.sh` with
+the bundled `payload/<commit>/export/CopyLasso.app`. The supplied payload and packaging commits are
+both the protected workflow commit.
+
+Read back the draft through GitHub after upload. It must remain `draft: true` and `prerelease: true`,
+target the exact commit, and contain exactly the four assets above. Recompute the public checksum
+and rerun the complete local package verifier. Preserve the downloaded dSYM and verification bundle
+as restricted maintainer evidence.
+
+The dSYM and verification bundle are intentionally draft-only. Remove them from the eventual G31
+public release; only the already-qualified DMG and checksum become public release assets. Never publish the G28 rehearsal.
+
+## Log And Failure Review
+
+The workflow keeps certificate import, Xcode signing, and notarization diagnostics out of the public
+step log. Inspect the completed log and reject the run if it contains private-key or certificate
+blocks, account email, signing authorities, team readback, or app-specific-password-shaped text.
+GitHub masking is defense in depth rather than proof that transformed secrets are safe to print.
+
+Draft creation is transactional. If an asset upload or final API readback fails, the workflow deletes
+the incomplete draft. Failed tests, source validation, credential import, archive/export, signing,
+notarization, stapling, package verification, or credential cleanup prevent draft creation.
+
+## Rotation And Recovery
+
+- **Certificate renewal:** replace both certificate environment secrets from a fresh protected
+  export, then remove the export. Do not change notarization credentials unnecessarily.
+- **Notary key rotation:** revoke only the dedicated CI Team API key, create its replacement with the
+  Developer role, replace its three environment secrets, and remove the downloaded key.
+- **Suspected exposure:** cancel active release runs, revoke the affected Apple credential, delete
+  the protected environment value, inspect workflow history, and create a replacement before
+  another dispatch.
+- **Apple rejection:** retain the private diagnostic evidence, fix the signing or source problem in a
+  reviewed commit, and restart from the complete quality gate. Never staple or draft a rejected
+  artifact.
+- **Stale draft:** delete the incomplete rehearsal through GitHub Releases. Never overwrite assets
+  under an existing draft tag.
+
+G28 stops after one exact workflow run, downloaded local re-verification, log and cleanup inspection,
+and a verified draft release. It does not configure a clean VM or publish a download.

--- a/scripts/audit-release-workflow.sh
+++ b/scripts/audit-release-workflow.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly workflow="$repository_root/.github/workflows/release.yml"
+readonly ci_workflow="$repository_root/.github/workflows/ci.yml"
+readonly source_verifier="$repository_root/scripts/verify-release-workflow-source.sh"
+readonly credential_preparer="$repository_root/scripts/prepare-release-keychain.sh"
+readonly credential_cleanup="$repository_root/scripts/cleanup-release-keychain.sh"
+readonly candidate_builder="$repository_root/scripts/build-release-candidate.sh"
+readonly draft_creator="$repository_root/scripts/create-draft-release.sh"
+readonly verification_library="$repository_root/scripts/lib/release-workflow-verification.sh"
+readonly focused_tests="$repository_root/scripts/test-release-workflow.sh"
+readonly documentation="$repository_root/docs/release-workflow.md"
+readonly release_checklist="$repository_root/docs/release-checklist.md"
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+require_text() {
+    local file="$1"
+    local text="$2"
+
+    /usr/bin/grep -Fq -- "$text" "$file" || \
+        fail "Protected-release contract text is missing: $text"
+}
+
+for executable in \
+    "$source_verifier" \
+    "$credential_preparer" \
+    "$credential_cleanup" \
+    "$candidate_builder" \
+    "$draft_creator" \
+    "$focused_tests"; do
+    [[ -x "$executable" ]] || \
+        fail "Protected-release script is missing or not executable: $(basename "$executable")"
+done
+for readable in \
+    "$workflow" \
+    "$ci_workflow" \
+    "$verification_library" \
+    "$documentation" \
+    "$release_checklist"; do
+    [[ -r "$readable" ]] || \
+        fail "Protected-release contract file is missing: $(basename "$readable")"
+done
+
+require_text "$workflow" 'workflow_dispatch:'
+for prohibited_trigger in pull_request: pull_request_target: push: repository_dispatch: workflow_run:; do
+    if /usr/bin/grep -Eq "^[[:space:]]*${prohibited_trigger}[[:space:]]*$" "$workflow"; then
+        fail "The protected release workflow has a prohibited trigger: $prohibited_trigger"
+    fi
+done
+require_text "$ci_workflow" 'workflow_call:'
+require_text "$workflow" 'uses: ./.github/workflows/ci.yml'
+require_text "$workflow" 'needs: quality-gate'
+require_text "$workflow" 'environment:'
+require_text "$workflow" 'name: release'
+require_text "$workflow" 'cancel-in-progress: false'
+
+contents_write_count="$(/usr/bin/grep -Ec '^[[:space:]]*contents: write[[:space:]]*$' "$workflow")"
+[[ "$contents_write_count" == "1" ]] || \
+    fail "Only the protected draft job may receive contents write permission."
+require_text "$workflow" 'permissions:'
+require_text "$workflow" 'contents: read'
+
+require_text "$workflow" 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0'
+require_text "$workflow" 'ref: ${{ github.sha }}'
+require_text "$workflow" 'fetch-depth: 0'
+require_text "$workflow" 'persist-credentials: false'
+while IFS= read -r action_target; do
+    case "$action_target" in
+        ./*) ;;
+        *@????????????????????????????????????????) ;;
+        *) fail "The privileged release workflow contains a mutable action reference: $action_target" ;;
+    esac
+done < <(/usr/bin/sed -nE 's/^[[:space:]]*uses:[[:space:]]*([^[:space:]]+).*$/\1/p' "$workflow")
+
+for secret in \
+    COPYLASSO_DEVELOPER_ID_P12_BASE64 \
+    COPYLASSO_DEVELOPER_ID_P12_PASSWORD \
+    COPYLASSO_NOTARY_KEY_BASE64 \
+    COPYLASSO_NOTARY_KEY_ID \
+    COPYLASSO_NOTARY_ISSUER_ID \
+    COPYLASSO_EXPECTED_TEAM_ID; do
+    secret_count="$(/usr/bin/grep -Fc 'secrets.'"$secret" "$workflow")"
+    [[ "$secret_count" -ge 1 ]] || \
+        fail "The protected release workflow is missing an environment secret: $secret"
+    if /usr/bin/grep -Fq "secrets.$secret" "$ci_workflow"; then
+        fail "Ordinary CI must never receive protected release secrets: $secret"
+    fi
+done
+
+require_text "$workflow" './scripts/verify-release-workflow-source.sh'
+require_text "$workflow" './scripts/prepare-release-keychain.sh'
+require_text "$workflow" './scripts/build-release-candidate.sh'
+require_text "$workflow" './scripts/cleanup-release-keychain.sh'
+require_text "$workflow" './scripts/create-draft-release.sh'
+require_text "$workflow" 'if: always()'
+
+build_line="$(/usr/bin/grep -n './scripts/build-release-candidate.sh' "$workflow" | /usr/bin/cut -d: -f1)"
+cleanup_line="$(/usr/bin/grep -n './scripts/cleanup-release-keychain.sh' "$workflow" | /usr/bin/cut -d: -f1)"
+draft_line="$(/usr/bin/grep -n './scripts/create-draft-release.sh' "$workflow" | /usr/bin/cut -d: -f1)"
+if ((cleanup_line <= build_line || draft_line <= cleanup_line)); then
+    fail "Credential cleanup must follow packaging and precede draft creation."
+fi
+
+for required_prepare_text in \
+    'assert_release_secret_contract' \
+    'assert_release_state_directory' \
+    'security create-keychain' \
+    'security import' \
+    'security set-key-partition-list' \
+    'notarytool store-credentials copylasso-notary' \
+    'notarytool history' \
+    'cleanup_raw_credentials'; do
+    require_text "$credential_preparer" "$required_prepare_text"
+done
+for required_cleanup_text in \
+    'cleanup_failed=' \
+    'security default-keychain' \
+    'security list-keychains' \
+    'security delete-keychain' \
+    'rm -rf "$state_directory"' \
+    'Temporary release credentials were removed.'; do
+    require_text "$credential_cleanup" "$required_cleanup_text"
+done
+
+for required_build_text in \
+    'xcodebuild archive' \
+    'xcodebuild -exportArchive' \
+    'verify-developer-id-app.sh' \
+    'notarytool submit' \
+    'notarytool log' \
+    'stapler staple' \
+    'package-release.sh' \
+    'assert_release_workflow_assets'; do
+    require_text "$candidate_builder" "$required_build_text"
+done
+
+for required_draft_text in \
+    'draft=true' \
+    'prerelease=true' \
+    'make_latest=false' \
+    'release upload' \
+    '--method DELETE' \
+    'assert_release_draft_record'; do
+    require_text "$draft_creator" "$required_draft_text"
+done
+if /usr/bin/grep -Eiq -- \
+    'release (publish|edit.+--draft=false)|--clobber|make_latest=true' \
+    "$draft_creator" "$workflow"; then
+    fail "The G28 workflow must never publish, overwrite, or promote its draft."
+fi
+
+for required_documentation_text in \
+    'protected branches only' \
+    'required reviewer' \
+    'self-review allowed' \
+    'Team API key' \
+    'password-protected PKCS#12' \
+    'workflow_dispatch' \
+    'refs/heads/main' \
+    'pull-request workflow has no release trigger' \
+    'credential cleanup' \
+    'Draft creation is transactional' \
+    'Never publish the G28 rehearsal' \
+    'G29' \
+    'G30'; do
+    require_text "$documentation" "$required_documentation_text"
+done
+require_text "$release_checklist" 'Keep the dSYM and verification bundle restricted to the draft'
+
+if /usr/bin/grep -Eq 'set -x|TeamIdentifier=[A-Z0-9]{10}|[[:alnum:]._%+-]+@[[:alnum:].-]+\.[A-Za-z]{2,}|[a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4}' \
+    "$workflow" \
+    "$source_verifier" \
+    "$credential_preparer" \
+    "$credential_cleanup" \
+    "$candidate_builder" \
+    "$draft_creator" \
+    "$verification_library" \
+    "$documentation"; then
+    fail "Protected-release public files contain unsafe tracing or credential-like material."
+fi
+
+echo "Protected-release workflow static audit passed."

--- a/scripts/build-release-candidate.sh
+++ b/scripts/build-release-candidate.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 077
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/release-workflow-verification.sh
+source "$repository_root/scripts/lib/release-workflow-verification.sh"
+# shellcheck source=scripts/lib/release-package-verification.sh
+source "$repository_root/scripts/lib/release-package-verification.sh"
+
+usage() {
+    cat >&2 <<'TEXT'
+Usage: build-release-candidate.sh \
+  --source-commit <40-character-commit> \
+  --handoff /path/under/RUNNER_TEMP/<commit> \
+  --output-dir /path/to/repository/dist/g28/<commit>/run
+TEXT
+    exit 64
+}
+
+source_commit=""
+handoff_candidate=""
+output_directory=""
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --source-commit)
+            [[ "$#" -ge 2 ]] || usage
+            source_commit="$2"
+            shift 2
+            ;;
+        --handoff)
+            [[ "$#" -ge 2 ]] || usage
+            handoff_candidate="$2"
+            shift 2
+            ;;
+        --output-dir)
+            [[ "$#" -ge 2 ]] || usage
+            output_directory="$2"
+            shift 2
+            ;;
+        *) usage ;;
+    esac
+done
+[[ -n "$source_commit" && -n "$handoff_candidate" && -n "$output_directory" ]] || usage
+
+assert_full_release_commit "$source_commit"
+assert_release_source_state \
+    "$repository_root" \
+    "${GITHUB_REF:-refs/heads/main}" \
+    "$source_commit"
+assert_release_state_directory "$handoff_candidate"
+[[ "$(basename "$handoff_candidate")" == "$source_commit" ]] || \
+    protected_release_fail "The release handoff must be named for the exact protected commit."
+[[ ! -e "$handoff_candidate" && ! -L "$handoff_candidate" ]] || \
+    protected_release_fail "The protected release handoff already exists."
+
+readonly expected_team_identifier="${COPYLASSO_EXPECTED_TEAM_ID:-}"
+[[ "$expected_team_identifier" =~ ^[A-Z0-9]{10}$ ]] || \
+    protected_release_fail "COPYLASSO_EXPECTED_TEAM_ID must provide the protected release team."
+readonly keychain_path="${COPYLASSO_RELEASE_KEYCHAIN_PATH:-}"
+[[ -f "$keychain_path" && "$keychain_path" == "${RUNNER_TEMP:-}"/* ]] || \
+    protected_release_fail "The temporary protected release Keychain is unavailable."
+
+/bin/mkdir -p "$handoff_candidate"
+readonly archive="$handoff_candidate/CopyLasso.xcarchive"
+readonly export_directory="$handoff_candidate/export"
+readonly application="$export_directory/CopyLasso.app"
+
+cd "$repository_root"
+if ! DEVELOPMENT_TEAM="$expected_team_identifier" \
+    /usr/bin/xcodebuild archive \
+    -project CopyLasso.xcodeproj \
+    -scheme CopyLasso \
+    -configuration Release \
+    -destination 'generic/platform=macOS' \
+    -archivePath "$archive" \
+    > "$handoff_candidate/archive.log" 2>&1; then
+    protected_release_fail "The protected Release archive could not be created."
+fi
+if ! DEVELOPMENT_TEAM="$expected_team_identifier" \
+    /usr/bin/xcodebuild -exportArchive \
+    -archivePath "$archive" \
+    -exportOptionsPlist Configuration/DeveloperIDExportOptions.plist \
+    -exportPath "$export_directory" \
+    > "$handoff_candidate/export.log" 2>&1; then
+    protected_release_fail "The protected Developer ID archive could not be exported."
+fi
+
+COPYLASSO_EXPECTED_TEAM_ID="$expected_team_identifier" \
+    "$repository_root/scripts/verify-developer-id-app.sh" \
+    --pre-notarization "$application" \
+    > "$handoff_candidate/pre-notarization-verification.txt"
+
+readonly application_zip="$handoff_candidate/CopyLasso-notarization.zip"
+if ! /usr/bin/ditto -c -k --keepParent "$application" "$application_zip"; then
+    protected_release_fail "The protected application could not be prepared for notarization."
+fi
+readonly application_submission="$handoff_candidate/notary-submission.json"
+readonly application_log="$handoff_candidate/notary-log.json"
+if ! xcrun notarytool submit "$application_zip" \
+    --keychain-profile copylasso-notary \
+    --keychain "$keychain_path" \
+    --wait \
+    --output-format json > "$application_submission"; then
+    protected_release_fail "The protected application notarization submission did not complete."
+fi
+readonly application_submission_identifier="$(
+    /usr/bin/plutil -extract id raw -o - "$application_submission" 2>/dev/null || true
+)"
+[[ -n "$application_submission_identifier" ]] || \
+    protected_release_fail "The application notarization response has no submission identifier."
+if ! xcrun notarytool log "$application_submission_identifier" \
+    --keychain-profile copylasso-notary \
+    --keychain "$keychain_path" \
+    "$application_log" > "$handoff_candidate/notary-log-fetch.log" 2>&1; then
+    protected_release_fail "The protected application notarization log could not be saved."
+fi
+assert_release_notary_records "$application_submission" "$application_log"
+
+if ! xcrun stapler staple "$application" > "$handoff_candidate/staple.log" 2>&1; then
+    protected_release_fail "The protected application notarization ticket could not be stapled."
+fi
+COPYLASSO_EXPECTED_TEAM_ID="$expected_team_identifier" \
+    "$repository_root/scripts/verify-developer-id-app.sh" \
+    --post-notarization "$application" \
+    > "$handoff_candidate/post-notarization-verification.txt"
+
+COPYLASSO_EXPECTED_TEAM_ID="$expected_team_identifier" \
+    "$repository_root/scripts/package-release.sh" \
+    --handoff "$handoff_candidate" \
+    --payload-commit "$source_commit" \
+    --output-dir "$output_directory"
+
+readonly verification_bundle="$output_directory/$COPYLASSO_G28_VERIFICATION"
+readonly verification_staging="$(mktemp -d "${TMPDIR:-/tmp}/copylasso-g28-verification.XXXXXX")"
+cleanup_verification_staging() {
+    /bin/rm -rf "$verification_staging"
+}
+trap cleanup_verification_staging EXIT
+
+/bin/mkdir -p \
+    "$verification_staging/payload/$source_commit/export" \
+    "$verification_staging/run"
+/usr/bin/ditto \
+    "$application" \
+    "$verification_staging/payload/$source_commit/export/CopyLasso.app"
+for evidence_file in \
+    notary-submission.json \
+    notary-log.json \
+    release-evidence.txt \
+    payload-manifest.txt; do
+    /bin/cp "$output_directory/$evidence_file" "$verification_staging/run/$evidence_file"
+done
+printf 'payload_commit=%s\npackaging_commit=%s\n' \
+    "$source_commit" "$source_commit" \
+    > "$verification_staging/verification-layout.txt"
+if ! /usr/bin/ditto -c -k --norsrc --noextattr \
+    "$verification_staging" "$verification_bundle"; then
+    protected_release_fail "The protected local-verification bundle could not be created."
+fi
+
+assert_release_workflow_assets "$output_directory" "$verification_bundle"
+cleanup_verification_staging
+trap - EXIT
+
+echo "Protected release candidate created and verified for the exact protected commit."

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -58,6 +58,12 @@ echo "Auditing reproducible release packaging"
 echo "Testing reproducible release packaging"
 ./scripts/test-release-package.sh
 
+echo "Auditing protected release workflow"
+./scripts/audit-release-workflow.sh
+
+echo "Testing protected release workflow"
+./scripts/test-release-workflow.sh
+
 readonly committed_development_team_pattern='^[[:space:]]*"?DEVELOPMENT_TEAM(\[[^]]+\])?"?[[:space:]]*=[[:space:]]*[A-Z0-9]{10};'
 
 if /usr/bin/grep -Eq "$committed_development_team_pattern" \

--- a/scripts/cleanup-release-keychain.sh
+++ b/scripts/cleanup-release-keychain.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/release-workflow-verification.sh
+source "$repository_root/scripts/lib/release-workflow-verification.sh"
+
+usage() {
+    echo "Usage: $0 --state-dir /path/under/RUNNER_TEMP" >&2
+    exit 64
+}
+
+state_directory=""
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --state-dir)
+            [[ "$#" -ge 2 ]] || usage
+            state_directory="$2"
+            shift 2
+            ;;
+        *) usage ;;
+    esac
+done
+[[ -n "$state_directory" ]] || usage
+
+assert_release_state_directory "$state_directory"
+if [[ ! -e "$state_directory" ]]; then
+    echo "No temporary release credential state remains."
+    exit 0
+fi
+[[ -d "$state_directory" && ! -L "$state_directory" ]] || \
+    protected_release_fail "The temporary release credential state is not a real directory."
+
+readonly keychain_path="$state_directory/copylasso-release.keychain-db"
+readonly original_keychains="$state_directory/original-keychains.txt"
+readonly original_default="$state_directory/original-default-keychain.txt"
+cleanup_failed="false"
+
+if [[ -s "$original_default" ]]; then
+    original_default_path="$(/bin/cat "$original_default")"
+    if [[ -n "$original_default_path" ]]; then
+        if ! /usr/bin/security default-keychain -d user -s \
+            "$original_default_path" >/dev/null 2>&1; then
+            echo "The original default Keychain could not be restored." >&2
+            cleanup_failed="true"
+        fi
+    fi
+fi
+
+if [[ -f "$original_keychains" ]]; then
+    restored_keychains=()
+    while IFS= read -r keychain; do
+        [[ -n "$keychain" ]] && restored_keychains+=("$keychain")
+    done < "$original_keychains"
+    if [[ "${#restored_keychains[@]}" -gt 0 ]]; then
+        if ! /usr/bin/security list-keychains -d user -s \
+            "${restored_keychains[@]}" >/dev/null 2>&1; then
+            echo "The original Keychain search list could not be restored." >&2
+            cleanup_failed="true"
+        fi
+    fi
+fi
+
+if [[ -e "$keychain_path" ]]; then
+    if ! /usr/bin/security delete-keychain "$keychain_path" >/dev/null 2>&1; then
+        echo "The temporary release Keychain could not be deleted cleanly." >&2
+        cleanup_failed="true"
+    fi
+fi
+/bin/rm -rf "$state_directory"
+[[ ! -e "$state_directory" ]] || \
+    protected_release_fail "Temporary release credential state remains after cleanup."
+
+if [[ "$cleanup_failed" == "true" ]]; then
+    protected_release_fail \
+        "Temporary release material was removed, but the runner Keychain state was not fully restored."
+fi
+
+echo "Temporary release credentials were removed."

--- a/scripts/create-draft-release.sh
+++ b/scripts/create-draft-release.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 077
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/release-workflow-verification.sh
+source "$repository_root/scripts/lib/release-workflow-verification.sh"
+
+usage() {
+    cat >&2 <<'TEXT'
+Usage: create-draft-release.sh \
+  --repository owner/repository \
+  --commit <40-character-commit> \
+  --tag v0.1.0-g28.<run> \
+  --run-dir /path/to/release-run \
+  --readback /path/to/draft-release.json
+TEXT
+    exit 64
+}
+
+repository=""
+commit=""
+tag=""
+run_directory=""
+readback=""
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --repository)
+            [[ "$#" -ge 2 ]] || usage
+            repository="$2"
+            shift 2
+            ;;
+        --commit)
+            [[ "$#" -ge 2 ]] || usage
+            commit="$2"
+            shift 2
+            ;;
+        --tag)
+            [[ "$#" -ge 2 ]] || usage
+            tag="$2"
+            shift 2
+            ;;
+        --run-dir)
+            [[ "$#" -ge 2 ]] || usage
+            run_directory="$2"
+            shift 2
+            ;;
+        --readback)
+            [[ "$#" -ge 2 ]] || usage
+            readback="$2"
+            shift 2
+            ;;
+        *) usage ;;
+    esac
+done
+[[ -n "$repository" && -n "$commit" && -n "$tag" && \
+    -n "$run_directory" && -n "$readback" ]] || usage
+
+[[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || \
+    protected_release_fail "The GitHub repository name is invalid."
+assert_full_release_commit "$commit"
+assert_release_draft_tag "$tag"
+readonly verification_bundle="$run_directory/$COPYLASSO_G28_VERIFICATION"
+assert_release_workflow_assets "$run_directory" "$verification_bundle"
+[[ -n "${GH_TOKEN:-}" ]] || protected_release_fail "The draft-release token is unavailable."
+
+readonly gh_binary="${COPYLASSO_GH_BIN:-gh}"
+readonly temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/copylasso-g28-draft.XXXXXX")"
+readonly creation_record="$temporary_directory/created.json"
+readonly final_record="$temporary_directory/final.json"
+readonly notes="$temporary_directory/notes.md"
+release_identifier=""
+draft_committed="false"
+
+rollback_draft() {
+    if [[ -n "$release_identifier" && "$draft_committed" != "true" ]]; then
+        "$gh_binary" api \
+            --method DELETE \
+            "repos/$repository/releases/$release_identifier" \
+            >/dev/null 2>&1 || true
+    fi
+    /bin/rm -rf "$temporary_directory"
+}
+trap rollback_draft EXIT
+
+if "$gh_binary" api "repos/$repository/releases/tags/$tag" >/dev/null 2>&1; then
+    protected_release_fail "A release already exists for the G28 rehearsal tag."
+fi
+
+printf '%s\n\n%s\n\n%s\n' \
+    'Protected G28 workflow rehearsal for CopyLasso 0.1.0.' \
+    "Exact source commit: $commit" \
+    'Draft only. Do not publish; G29 and G30 remain separate release gates.' \
+    > "$notes"
+
+if ! "$gh_binary" api \
+    --method POST \
+    "repos/$repository/releases" \
+    -f "tag_name=$tag" \
+    -f "target_commitish=$commit" \
+    -f "name=CopyLasso 0.1.0 protected workflow rehearsal" \
+    -F draft=true \
+    -F prerelease=true \
+    -f make_latest=false \
+    -F "body=@$notes" \
+    > "$creation_record"; then
+    protected_release_fail "The protected draft release could not be created."
+fi
+release_identifier="$(/usr/bin/plutil -extract id raw -o - "$creation_record" 2>/dev/null || true)"
+[[ "$release_identifier" =~ ^[0-9]+$ ]] || \
+    protected_release_fail "The protected draft release has no valid identifier."
+
+if ! "$gh_binary" release upload "$tag" \
+    "$run_directory/$COPYLASSO_G28_DMG" \
+    "$run_directory/$COPYLASSO_G28_CHECKSUM" \
+    "$run_directory/$COPYLASSO_G28_DSYM" \
+    "$verification_bundle" \
+    --repo "$repository"; then
+    protected_release_fail "The complete protected draft asset set could not be uploaded."
+fi
+
+if ! "$gh_binary" api "repos/$repository/releases/$release_identifier" > "$final_record"; then
+    protected_release_fail "The protected draft release could not be read back."
+fi
+assert_release_draft_record "$final_record" "$commit" "$tag"
+
+/bin/mkdir -p "$(dirname "$readback")"
+/bin/cp "$final_record" "$readback"
+draft_committed="true"
+rollback_draft
+trap - EXIT
+
+echo "Protected GitHub draft release created and verified."

--- a/scripts/lib/release-workflow-verification.sh
+++ b/scripts/lib/release-workflow-verification.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly COPYLASSO_G28_VERSION="0.1.0"
+readonly COPYLASSO_G28_DMG="CopyLasso-0.1.0.dmg"
+readonly COPYLASSO_G28_CHECKSUM="CopyLasso-0.1.0.dmg.sha256"
+readonly COPYLASSO_G28_DSYM="CopyLasso-0.1.0.dSYM.zip"
+readonly COPYLASSO_G28_VERIFICATION="CopyLasso-0.1.0-verification.zip"
+
+protected_release_fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+assert_full_release_commit() {
+    local g28_commit="$1"
+
+    [[ "$g28_commit" =~ ^[0-9a-f]{40}$ ]] || \
+        protected_release_fail "The protected release commit must be a full lowercase Git object identifier."
+}
+
+assert_protected_release_ref() {
+    local g28_git_ref="$1"
+
+    [[ "$g28_git_ref" == "refs/heads/main" ]] || \
+        protected_release_fail "G28 releases may be dispatched only from protected main."
+}
+
+assert_release_source_state() {
+    local g28_repository="$1"
+    local g28_git_ref="$2"
+    local g28_expected_commit="$3"
+    local g28_actual_commit
+    local g28_protected_main_commit
+
+    [[ -d "$g28_repository/.git" ]] || \
+        protected_release_fail "The protected release checkout is not a Git repository."
+    assert_protected_release_ref "$g28_git_ref"
+    assert_full_release_commit "$g28_expected_commit"
+
+    g28_actual_commit="$(/usr/bin/git -C "$g28_repository" rev-parse HEAD)"
+    [[ "$g28_actual_commit" == "$g28_expected_commit" ]] || \
+        protected_release_fail "The checked-out commit does not match the dispatched commit."
+    /usr/bin/git -C "$g28_repository" cat-file -e "$g28_expected_commit^{commit}" || \
+        protected_release_fail "The dispatched commit is not available in the checkout."
+
+    g28_protected_main_commit="$(/usr/bin/git -C "$g28_repository" \
+        rev-parse refs/remotes/origin/main^{commit} 2>/dev/null || true)"
+    [[ "$g28_protected_main_commit" == "$g28_expected_commit" ]] || \
+        protected_release_fail "The dispatched commit is not the protected origin/main commit."
+
+    if ! /usr/bin/git -C "$g28_repository" diff --quiet || \
+        ! /usr/bin/git -C "$g28_repository" diff --cached --quiet || \
+        [[ -n "$(/usr/bin/git -C "$g28_repository" status --porcelain --untracked-files=no)" ]]; then
+        protected_release_fail "Protected release generation requires a clean tracked checkout."
+    fi
+}
+
+assert_release_secret_contract() {
+    local g28_expected_team_identifier="${COPYLASSO_EXPECTED_TEAM_ID:-}"
+    local g28_key_identifier="${COPYLASSO_NOTARY_KEY_ID:-}"
+    local g28_issuer_identifier="${COPYLASSO_NOTARY_ISSUER_ID:-}"
+
+    [[ -n "${COPYLASSO_DEVELOPER_ID_P12_BASE64:-}" ]] || \
+        protected_release_fail "The protected Developer ID certificate secret is missing."
+    [[ -n "${COPYLASSO_DEVELOPER_ID_P12_PASSWORD:-}" ]] || \
+        protected_release_fail "The protected Developer ID certificate password is missing."
+    [[ -n "${COPYLASSO_NOTARY_KEY_BASE64:-}" ]] || \
+        protected_release_fail "The protected notarization private-key secret is missing."
+    [[ "$g28_expected_team_identifier" =~ ^[A-Z0-9]{10}$ ]] || \
+        protected_release_fail "The protected release team identifier is invalid."
+    [[ "$g28_key_identifier" =~ ^[A-Z0-9]{10}$ ]] || \
+        protected_release_fail "The protected notarization key identifier is invalid."
+    [[ "$g28_issuer_identifier" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]] || \
+        protected_release_fail "The protected notarization issuer identifier is invalid."
+    [[ -n "${COPYLASSO_RELEASE_KEYCHAIN_PASSWORD:-}" ]] || \
+        protected_release_fail "The temporary release Keychain password is missing."
+}
+
+assert_release_state_directory() {
+    local g28_state_candidate="$1"
+    local g28_runner_temporary="${RUNNER_TEMP:-}"
+
+    [[ -n "$g28_runner_temporary" && "$g28_state_candidate" == "$g28_runner_temporary"/* ]] || \
+        protected_release_fail "Release credential state must remain under RUNNER_TEMP."
+    [[ "$g28_state_candidate" != *"/../"* && "$g28_state_candidate" != */.. ]] || \
+        protected_release_fail "Release credential state must not contain parent traversal."
+}
+
+assert_release_draft_tag() {
+    local g28_tag="$1"
+
+    [[ "$g28_tag" =~ ^v0\.1\.0-g28\.[1-9][0-9]*$ ]] || \
+        protected_release_fail "The G28 draft tag name is invalid."
+}
+
+assert_release_workflow_assets() {
+    local g28_asset_run_directory="$1"
+    local g28_asset_verification_bundle="$2"
+
+    [[ -d "$g28_asset_run_directory" ]] || \
+        protected_release_fail "The protected release-package directory is missing."
+    local g28_asset_candidate
+    for g28_asset_candidate in \
+        "$g28_asset_run_directory/$COPYLASSO_G28_DMG" \
+        "$g28_asset_run_directory/$COPYLASSO_G28_CHECKSUM" \
+        "$g28_asset_run_directory/$COPYLASSO_G28_DSYM" \
+        "$g28_asset_verification_bundle"; do
+        [[ -f "$g28_asset_candidate" ]] || \
+            protected_release_fail "A protected release asset is missing: $(basename "$g28_asset_candidate")"
+    done
+    [[ "$(basename "$g28_asset_verification_bundle")" == "$COPYLASSO_G28_VERIFICATION" ]] || \
+        protected_release_fail "The protected verification bundle has the wrong name."
+}
+
+release_draft_asset_names() {
+    local g28_record="$1"
+
+    /usr/bin/plutil -extract assets xml1 -o - "$g28_record" 2>/dev/null | \
+        /usr/bin/awk '
+            /<key>name<\/key>/ {
+                getline
+                gsub(/^[[:space:]]*<string>|<\/string>[[:space:]]*$/, "")
+                print
+            }
+        ' | LC_ALL=C /usr/bin/sort
+}
+
+assert_release_draft_record() {
+    local g28_record="$1"
+    local g28_expected_commit="$2"
+    local g28_expected_tag="$3"
+    local g28_expected_assets
+    local g28_actual_assets
+
+    [[ -f "$g28_record" ]] || protected_release_fail "The draft-release readback is missing."
+    /usr/bin/plutil -p "$g28_record" >/dev/null || \
+        protected_release_fail "The draft-release readback is not valid JSON."
+    assert_full_release_commit "$g28_expected_commit"
+    assert_release_draft_tag "$g28_expected_tag"
+
+    [[ "$(/usr/bin/plutil -extract draft raw -o - "$g28_record" 2>/dev/null || true)" == "true" ]] || \
+        protected_release_fail "The GitHub release is not a draft."
+    [[ "$(/usr/bin/plutil -extract prerelease raw -o - "$g28_record" 2>/dev/null || true)" == "true" ]] || \
+        protected_release_fail "The GitHub release is not marked as a prerelease."
+    [[ "$(/usr/bin/plutil -extract tag_name raw -o - "$g28_record" 2>/dev/null || true)" == "$g28_expected_tag" ]] || \
+        protected_release_fail "The draft release has the wrong tag name."
+    [[ "$(/usr/bin/plutil -extract target_commitish raw -o - "$g28_record" 2>/dev/null || true)" == "$g28_expected_commit" ]] || \
+        protected_release_fail "The draft release targets the wrong commit."
+
+    g28_expected_assets="$(printf '%s\n' \
+        "$COPYLASSO_G28_CHECKSUM" \
+        "$COPYLASSO_G28_DMG" \
+        "$COPYLASSO_G28_DSYM" \
+        "$COPYLASSO_G28_VERIFICATION" | LC_ALL=C /usr/bin/sort)"
+    g28_actual_assets="$(release_draft_asset_names "$g28_record")"
+    [[ "$g28_actual_assets" == "$g28_expected_assets" ]] || \
+        protected_release_fail "The draft release has an incomplete or unexpected asset set."
+}
+
+assert_release_log_is_public_safe() {
+    local g28_log_file="$1"
+
+    [[ -f "$g28_log_file" ]] || protected_release_fail "The release log for inspection is missing."
+    if /usr/bin/grep -Eiq -- \
+        'BEGIN ([A-Z ]+ )?PRIVATE KEY|BEGIN CERTIFICATE|TeamIdentifier=|Authority=Developer ID Application:|[[:alnum:]._%+-]+@[[:alnum:].-]+\.[A-Za-z]{2,}|[a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4}' \
+        "$g28_log_file"; then
+        protected_release_fail "The public release log contains credential or account material."
+    fi
+}

--- a/scripts/lib/release-workflow-verification.sh
+++ b/scripts/lib/release-workflow-verification.sh
@@ -161,11 +161,14 @@ assert_release_draft_record() {
 
 assert_release_log_is_public_safe() {
     local g28_log_file="$1"
+    local g28_sensitive_pattern='BEGIN ([A-Z ]+ )?PRIVATE'
+    g28_sensitive_pattern+=' KEY|BEGIN CERT'
+    g28_sensitive_pattern+='IFICATE|TeamIdentifier=|Authority=Developer ID Application:'
+    g28_sensitive_pattern+='|[[:alnum:]._%+-]+@[[:alnum:].-]+\.[A-Za-z]{2,}'
+    g28_sensitive_pattern+='|[a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4}'
 
     [[ -f "$g28_log_file" ]] || protected_release_fail "The release log for inspection is missing."
-    if /usr/bin/grep -Eiq -- \
-        'BEGIN ([A-Z ]+ )?PRIVATE KEY|BEGIN CERTIFICATE|TeamIdentifier=|Authority=Developer ID Application:|[[:alnum:]._%+-]+@[[:alnum:].-]+\.[A-Za-z]{2,}|[a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4}' \
-        "$g28_log_file"; then
+    if /usr/bin/grep -Eiq -- "$g28_sensitive_pattern" "$g28_log_file"; then
         protected_release_fail "The public release log contains credential or account material."
     fi
 }

--- a/scripts/prepare-release-keychain.sh
+++ b/scripts/prepare-release-keychain.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 077
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/release-workflow-verification.sh
+source "$repository_root/scripts/lib/release-workflow-verification.sh"
+
+usage() {
+    echo "Usage: $0 --state-dir /path/under/RUNNER_TEMP" >&2
+    exit 64
+}
+
+state_directory=""
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --state-dir)
+            [[ "$#" -ge 2 ]] || usage
+            state_directory="$2"
+            shift 2
+            ;;
+        *) usage ;;
+    esac
+done
+[[ -n "$state_directory" ]] || usage
+
+assert_release_secret_contract
+assert_release_state_directory "$state_directory"
+[[ ! -e "$state_directory" && ! -L "$state_directory" ]] || \
+    protected_release_fail "The temporary release credential state already exists."
+/bin/mkdir -m 700 "$state_directory"
+
+readonly keychain_path="$state_directory/copylasso-release.keychain-db"
+readonly certificate_path="$state_directory/developer-id.p12"
+readonly notary_key_path="$state_directory/notary-key.p8"
+readonly original_keychains="$state_directory/original-keychains.txt"
+readonly original_default="$state_directory/original-default-keychain.txt"
+readonly identity_record="$state_directory/identity-record.txt"
+readonly setup_log="$state_directory/setup.log"
+
+cleanup_raw_credentials() {
+    /bin/rm -f "$certificate_path" "$notary_key_path" "$identity_record"
+}
+trap cleanup_raw_credentials EXIT
+
+/usr/bin/security list-keychains -d user | \
+    /usr/bin/sed -E 's/^[[:space:]]*"//; s/"[[:space:]]*$//' > "$original_keychains"
+/usr/bin/security default-keychain -d user | \
+    /usr/bin/sed -E 's/^[[:space:]]*"//; s/"[[:space:]]*$//' > "$original_default"
+
+printf '%s' "$COPYLASSO_DEVELOPER_ID_P12_BASE64" | \
+    /usr/bin/base64 -D > "$certificate_path" || \
+    protected_release_fail "The protected Developer ID certificate could not be decoded."
+printf '%s' "$COPYLASSO_NOTARY_KEY_BASE64" | \
+    /usr/bin/base64 -D > "$notary_key_path" || \
+    protected_release_fail "The protected notarization key could not be decoded."
+/bin/chmod 600 "$certificate_path" "$notary_key_path"
+
+/usr/bin/security create-keychain \
+    -p "$COPYLASSO_RELEASE_KEYCHAIN_PASSWORD" \
+    "$keychain_path" > "$setup_log" 2>&1 || \
+    protected_release_fail "The temporary release Keychain could not be created."
+/usr/bin/security set-keychain-settings \
+    -lut 7200 "$keychain_path" >> "$setup_log" 2>&1 || \
+    protected_release_fail "The temporary release Keychain settings could not be applied."
+/usr/bin/security unlock-keychain \
+    -p "$COPYLASSO_RELEASE_KEYCHAIN_PASSWORD" \
+    "$keychain_path" >> "$setup_log" 2>&1 || \
+    protected_release_fail "The temporary release Keychain could not be unlocked."
+
+existing_keychains=()
+while IFS= read -r keychain; do
+    [[ -n "$keychain" ]] && existing_keychains+=("$keychain")
+done < "$original_keychains"
+/usr/bin/security list-keychains -d user -s \
+    "$keychain_path" "${existing_keychains[@]}" >> "$setup_log" 2>&1 || \
+    protected_release_fail "The temporary release Keychain could not be added to the search list."
+/usr/bin/security default-keychain -d user -s "$keychain_path" >> "$setup_log" 2>&1 || \
+    protected_release_fail "The temporary release Keychain could not become the signing default."
+
+/usr/bin/security import "$certificate_path" \
+    -k "$keychain_path" \
+    -P "$COPYLASSO_DEVELOPER_ID_P12_PASSWORD" \
+    -T /usr/bin/codesign \
+    -T /usr/bin/security \
+    -T /usr/bin/xcodebuild >> "$setup_log" 2>&1 || \
+    protected_release_fail "The protected Developer ID identity could not be imported."
+/usr/bin/security set-key-partition-list \
+    -S apple-tool:,apple:,codesign: \
+    -s \
+    -k "$COPYLASSO_RELEASE_KEYCHAIN_PASSWORD" \
+    "$keychain_path" >> "$setup_log" 2>&1 || \
+    protected_release_fail "The imported Developer ID private key could not be authorized for signing tools."
+
+/usr/bin/security find-identity -v -p codesigning "$keychain_path" \
+    > "$identity_record" 2>/dev/null || true
+identity_count="$(/usr/bin/awk -v team="$COPYLASSO_EXPECTED_TEAM_ID" '
+    index($0, "Developer ID Application:") && index($0, "(" team ")") { count += 1 }
+    END { print count + 0 }
+' "$identity_record")"
+[[ "$identity_count" == "1" ]] || \
+    protected_release_fail "The protected Keychain must contain exactly one matching Developer ID identity."
+
+xcrun notarytool store-credentials copylasso-notary \
+    --key "$notary_key_path" \
+    --key-id "$COPYLASSO_NOTARY_KEY_ID" \
+    --issuer "$COPYLASSO_NOTARY_ISSUER_ID" \
+    --keychain "$keychain_path" >> "$setup_log" 2>&1 || \
+    protected_release_fail "The protected notarization profile could not be stored."
+xcrun notarytool history \
+    --keychain-profile copylasso-notary \
+    --keychain "$keychain_path" >> "$setup_log" 2>&1 || \
+    protected_release_fail "The protected notarization profile could not authenticate."
+
+cleanup_raw_credentials
+trap - EXIT
+echo "Protected release credentials are available only in the temporary Keychain."

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -7,6 +7,7 @@ readonly ci_script="$repository_root/scripts/ci.sh"
 readonly brand_audit_script="$repository_root/scripts/audit-brand-release.sh"
 readonly developer_id_audit_script="$repository_root/scripts/audit-developer-id-release.sh"
 readonly release_package_audit_script="$repository_root/scripts/audit-release-package.sh"
+readonly release_workflow_audit_script="$repository_root/scripts/audit-release-workflow.sh"
 readonly repeatability_script="$repository_root/scripts/test-repeatability.sh"
 readonly workflow="$repository_root/.github/workflows/ci.yml"
 
@@ -71,6 +72,22 @@ if [[ "$release_package_test_invocations" != "1" ]]; then
     fail "Canonical CI must invoke scripts/test-release-package.sh exactly once."
 fi
 
+release_workflow_audit_invocations="$({
+    /usr/bin/grep -Ec '^[[:space:]]*\./scripts/audit-release-workflow\.sh[[:space:]]*$' \
+        "$ci_script" || true
+})"
+if [[ "$release_workflow_audit_invocations" != "1" ]]; then
+    fail "Canonical CI must invoke scripts/audit-release-workflow.sh exactly once."
+fi
+
+release_workflow_test_invocations="$({
+    /usr/bin/grep -Ec '^[[:space:]]*\./scripts/test-release-workflow\.sh[[:space:]]*$' \
+        "$ci_script" || true
+})"
+if [[ "$release_workflow_test_invocations" != "1" ]]; then
+    fail "Canonical CI must invoke scripts/test-release-workflow.sh exactly once."
+fi
+
 if [[ ! -x "$developer_id_audit_script" ]] || \
     [[ ! -x "$repository_root/scripts/verify-developer-id-app.sh" ]] || \
     [[ ! -x "$repository_root/scripts/test-developer-id-release.sh" ]]; then
@@ -83,6 +100,13 @@ if [[ ! -x "$release_package_audit_script" ]] || \
     [[ ! -x "$repository_root/scripts/compare-release-packages.sh" ]] || \
     [[ ! -x "$repository_root/scripts/test-release-package.sh" ]]; then
     fail "Release-package verification scripts must be executable."
+fi
+
+if [[ ! -x "$release_workflow_audit_script" ]] || \
+    [[ ! -x "$repository_root/scripts/test-release-workflow.sh" ]] || \
+    [[ ! -x "$repository_root/scripts/build-release-candidate.sh" ]] || \
+    [[ ! -x "$repository_root/scripts/create-draft-release.sh" ]]; then
+    fail "Protected-release workflow scripts must be executable."
 fi
 
 if ! /usr/bin/grep -Fq \

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -155,7 +155,7 @@ expect_failure "incomplete or unexpected asset set" \
 
 printf 'Fixed content-free release diagnostic.\n' > "$temporary_directory/safe.log"
 assert_release_log_is_public_safe "$temporary_directory/safe.log"
-printf '%s\n' '-----BEGIN PRIVATE KEY-----' > "$temporary_directory/private.log"
+printf '%s%s\n' '-----BEGIN PRIVATE' ' KEY-----' > "$temporary_directory/private.log"
 expect_failure "credential or account material" \
     assert_release_log_is_public_safe "$temporary_directory/private.log"
 

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly audit_script="$repository_root/scripts/audit-release-workflow.sh"
+readonly source_verifier="$repository_root/scripts/verify-release-workflow-source.sh"
+readonly credential_preparer="$repository_root/scripts/prepare-release-keychain.sh"
+readonly credential_cleanup="$repository_root/scripts/cleanup-release-keychain.sh"
+readonly candidate_builder="$repository_root/scripts/build-release-candidate.sh"
+readonly draft_creator="$repository_root/scripts/create-draft-release.sh"
+readonly verifier_library="$repository_root/scripts/lib/release-workflow-verification.sh"
+readonly workflow="$repository_root/.github/workflows/release.yml"
+readonly documentation="$repository_root/docs/release-workflow.md"
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+for executable in \
+    "$audit_script" \
+    "$source_verifier" \
+    "$credential_preparer" \
+    "$credential_cleanup" \
+    "$candidate_builder" \
+    "$draft_creator"; do
+    [[ -x "$executable" ]] || \
+        fail "Protected-release executable is missing: $(basename "$executable")"
+done
+
+for readable in "$verifier_library" "$workflow" "$documentation"; do
+    [[ -r "$readable" ]] || \
+        fail "Protected-release contract file is missing: $(basename "$readable")"
+done
+
+# shellcheck source=scripts/lib/release-workflow-verification.sh
+source "$verifier_library"
+
+expect_failure() {
+    local expected_message="$1"
+    shift
+    local output
+
+    if output="$("$@" 2>&1)"; then
+        fail "Expected command to fail: $*"
+    fi
+    if [[ "$output" != *"$expected_message"* ]]; then
+        fail "Expected failure containing '$expected_message', received '$output'."
+    fi
+}
+
+readonly temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/copylasso-g28-tests.XXXXXX")"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+assert_protected_release_ref "refs/heads/main"
+expect_failure "only from protected main" \
+    assert_protected_release_ref "refs/heads/feature"
+expect_failure "only from protected main" \
+    assert_protected_release_ref "refs/tags/v0.1.0-rc.1"
+assert_full_release_commit "0123456789abcdef0123456789abcdef01234567"
+expect_failure "full lowercase Git object identifier" \
+    assert_full_release_commit "0123456789abcdef"
+expect_failure "full lowercase Git object identifier" \
+    assert_full_release_commit "0123456789ABCDEF0123456789ABCDEF01234567"
+
+(
+    export COPYLASSO_DEVELOPER_ID_P12_BASE64="QQ=="
+    export COPYLASSO_DEVELOPER_ID_P12_PASSWORD="test-only"
+    export COPYLASSO_NOTARY_KEY_BASE64="Qg=="
+    export COPYLASSO_NOTARY_KEY_ID="ABCDEFGHIJ"
+    export COPYLASSO_NOTARY_ISSUER_ID="00000000-0000-0000-0000-000000000000"
+    export COPYLASSO_EXPECTED_TEAM_ID="0123456789"
+    export COPYLASSO_RELEASE_KEYCHAIN_PASSWORD="test-only"
+    assert_release_secret_contract
+)
+expect_failure "Developer ID certificate secret is missing" \
+    assert_release_secret_contract
+
+(
+    export RUNNER_TEMP="$temporary_directory/runner"
+    /bin/mkdir -p "$RUNNER_TEMP"
+    assert_release_state_directory "$RUNNER_TEMP/state"
+    expect_failure "under RUNNER_TEMP" \
+        assert_release_state_directory "$temporary_directory/outside"
+    expect_failure "parent traversal" \
+        assert_release_state_directory "$RUNNER_TEMP/state/../escape"
+)
+
+readonly repository_fixture="$temporary_directory/repository"
+/usr/bin/git init -q "$repository_fixture"
+/usr/bin/git -C "$repository_fixture" config user.name "CopyLasso Tests"
+/usr/bin/git -C "$repository_fixture" config user.email "tests@invalid.local"
+printf 'protected source\n' > "$repository_fixture/source.txt"
+/usr/bin/git -C "$repository_fixture" add source.txt
+/usr/bin/git -C "$repository_fixture" commit -q -m "fixture"
+readonly fixture_commit="$(/usr/bin/git -C "$repository_fixture" rev-parse HEAD)"
+/usr/bin/git -C "$repository_fixture" update-ref refs/remotes/origin/main "$fixture_commit"
+assert_release_source_state "$repository_fixture" "refs/heads/main" "$fixture_commit"
+expect_failure "does not match the dispatched commit" \
+    assert_release_source_state \
+    "$repository_fixture" \
+    "refs/heads/main" \
+    "0123456789abcdef0123456789abcdef01234567"
+printf 'dirty source\n' > "$repository_fixture/source.txt"
+expect_failure "clean tracked checkout" \
+    assert_release_source_state "$repository_fixture" "refs/heads/main" "$fixture_commit"
+/usr/bin/git -C "$repository_fixture" restore source.txt
+printf 'new protected main\n' > "$repository_fixture/main.txt"
+/usr/bin/git -C "$repository_fixture" add main.txt
+/usr/bin/git -C "$repository_fixture" commit -q -m "second fixture"
+readonly second_fixture_commit="$(/usr/bin/git -C "$repository_fixture" rev-parse HEAD)"
+/usr/bin/git -C "$repository_fixture" update-ref refs/remotes/origin/main "$second_fixture_commit"
+/usr/bin/git -C "$repository_fixture" checkout -q --detach "$fixture_commit"
+expect_failure "not the protected origin/main commit" \
+    assert_release_source_state "$repository_fixture" "refs/heads/main" "$fixture_commit"
+
+assert_release_draft_tag "v0.1.0-g28.12345"
+expect_failure "draft tag name is invalid" \
+    assert_release_draft_tag "v0.1.0-rc.1"
+
+readonly valid_draft="$temporary_directory/valid-draft.json"
+printf '%s\n' "{
+  \"id\": 123,
+  \"draft\": true,
+  \"prerelease\": true,
+  \"tag_name\": \"v0.1.0-g28.12345\",
+  \"target_commitish\": \"0123456789abcdef0123456789abcdef01234567\",
+  \"assets\": [
+    {\"name\": \"CopyLasso-0.1.0.dmg\"},
+    {\"name\": \"CopyLasso-0.1.0.dmg.sha256\"},
+    {\"name\": \"CopyLasso-0.1.0.dSYM.zip\"},
+    {\"name\": \"CopyLasso-0.1.0-verification.zip\"}
+  ]
+}" > "$valid_draft"
+assert_release_draft_record \
+    "$valid_draft" \
+    "0123456789abcdef0123456789abcdef01234567" \
+    "v0.1.0-g28.12345"
+
+/usr/bin/sed 's/\"draft\": true/\"draft\": false/' \
+    "$valid_draft" > "$temporary_directory/published.json"
+expect_failure "not a draft" \
+    assert_release_draft_record \
+    "$temporary_directory/published.json" \
+    "0123456789abcdef0123456789abcdef01234567" \
+    "v0.1.0-g28.12345"
+/usr/bin/sed '/CopyLasso-0.1.0.dSYM.zip/d' \
+    "$valid_draft" > "$temporary_directory/missing-asset.json"
+expect_failure "incomplete or unexpected asset set" \
+    assert_release_draft_record \
+    "$temporary_directory/missing-asset.json" \
+    "0123456789abcdef0123456789abcdef01234567" \
+    "v0.1.0-g28.12345"
+
+printf 'Fixed content-free release diagnostic.\n' > "$temporary_directory/safe.log"
+assert_release_log_is_public_safe "$temporary_directory/safe.log"
+printf '%s\n' '-----BEGIN PRIVATE KEY-----' > "$temporary_directory/private.log"
+expect_failure "credential or account material" \
+    assert_release_log_is_public_safe "$temporary_directory/private.log"
+
+readonly release_run="$temporary_directory/release-run"
+/bin/mkdir "$release_run"
+for asset in \
+    CopyLasso-0.1.0.dmg \
+    CopyLasso-0.1.0.dmg.sha256 \
+    CopyLasso-0.1.0.dSYM.zip \
+    CopyLasso-0.1.0-verification.zip; do
+    : > "$release_run/$asset"
+done
+assert_release_workflow_assets \
+    "$release_run" \
+    "$release_run/CopyLasso-0.1.0-verification.zip"
+/bin/rm "$release_run/CopyLasso-0.1.0.dSYM.zip"
+expect_failure "protected release asset is missing" \
+    assert_release_workflow_assets \
+    "$release_run" \
+    "$release_run/CopyLasso-0.1.0-verification.zip"
+: > "$release_run/CopyLasso-0.1.0.dSYM.zip"
+
+readonly fake_gh="$temporary_directory/gh"
+readonly fake_gh_log="$temporary_directory/gh.log"
+cat > "$fake_gh" <<'SCRIPT'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+if [[ "$1" == "api" && "$*" == *"releases/tags/"* ]]; then
+    exit 1
+fi
+if [[ "$1" == "api" && "$*" == *"--method POST"* ]]; then
+    printf '{"id":123}\n'
+    exit 0
+fi
+if [[ "$1" == "release" && "$2" == "upload" ]]; then
+    [[ "${FAKE_GH_MODE:-success}" != "upload-fail" ]]
+    exit
+fi
+if [[ "$1" == "api" && "$*" == *"--method DELETE"* ]]; then
+    exit 0
+fi
+if [[ "$1" == "api" && "$*" == *"releases/123"* ]]; then
+    /bin/cat "$FAKE_GH_RECORD"
+    exit 0
+fi
+exit 1
+SCRIPT
+/bin/chmod +x "$fake_gh"
+
+export GH_TOKEN="test-only"
+export COPYLASSO_GH_BIN="$fake_gh"
+export FAKE_GH_LOG="$fake_gh_log"
+export FAKE_GH_RECORD="$valid_draft"
+export FAKE_GH_MODE="success"
+"$draft_creator" \
+    --repository owner/repository \
+    --commit 0123456789abcdef0123456789abcdef01234567 \
+    --tag v0.1.0-g28.12345 \
+    --run-dir "$release_run" \
+    --readback "$temporary_directory/readback.json"
+assert_release_draft_record \
+    "$temporary_directory/readback.json" \
+    "0123456789abcdef0123456789abcdef01234567" \
+    "v0.1.0-g28.12345"
+if /usr/bin/grep -Fq -- '--method DELETE' "$fake_gh_log"; then
+    fail "A successful draft must not be rolled back."
+fi
+
+: > "$fake_gh_log"
+export FAKE_GH_MODE="upload-fail"
+expect_failure "asset set could not be uploaded" \
+    "$draft_creator" \
+    --repository owner/repository \
+    --commit 0123456789abcdef0123456789abcdef01234567 \
+    --tag v0.1.0-g28.12345 \
+    --run-dir "$release_run" \
+    --readback "$temporary_directory/failed-readback.json"
+/usr/bin/grep -Fq -- '--method DELETE' "$fake_gh_log" || \
+    fail "A partial draft upload must delete the incomplete draft."
+
+unset GH_TOKEN COPYLASSO_GH_BIN FAKE_GH_LOG FAKE_GH_RECORD FAKE_GH_MODE
+
+echo "Protected-release workflow tests passed."

--- a/scripts/verify-release-workflow-source.sh
+++ b/scripts/verify-release-workflow-source.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/release-workflow-verification.sh
+source "$repository_root/scripts/lib/release-workflow-verification.sh"
+
+usage() {
+    echo "Usage: $0 --expected-ref refs/heads/main --expected-commit <full-commit>" >&2
+    exit 64
+}
+
+expected_ref=""
+expected_commit=""
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --expected-ref)
+            [[ "$#" -ge 2 ]] || usage
+            expected_ref="$2"
+            shift 2
+            ;;
+        --expected-commit)
+            [[ "$#" -ge 2 ]] || usage
+            expected_commit="$2"
+            shift 2
+            ;;
+        *) usage ;;
+    esac
+done
+
+[[ -n "$expected_ref" && -n "$expected_commit" ]] || usage
+assert_release_source_state "$repository_root" "$expected_ref" "$expected_commit"
+echo "Protected release source matches the exact protected main commit."


### PR DESCRIPTION
## Summary

- add a manually dispatched, protected release workflow gated by the complete reusable CI matrix
- import Developer ID and notarization credentials into an ephemeral Keychain, then remove them before draft creation
- build, notarize, staple, package, and verify the exact protected `main` commit
- create a transactional draft prerelease with the DMG, checksum, restricted dSYM, and local-verification bundle
- document environment setup, credential rotation, failure recovery, and the G29/G30/G31 boundaries

## Verification

- `COPYLASSO_CI_ARCH=arm64 ./scripts/ci.sh`
- `COPYLASSO_CI_ARCH=x86_64 ./scripts/ci.sh`
- 243 unit tests per ordinary and repeatability pass on both architectures
- focused protected-workflow audit and contract tests, including partial-upload rollback
- YAML syntax, shell syntax, secret/placeholder scan, and `git diff --check`

## Rollout boundary

GitHub only exposes a new `workflow_dispatch` workflow after it reaches the default branch. This pull request delivers and validates the source contract. After separate maintainer merge approval, G28 will configure the protected `release` environment and run the real draft-only rehearsal. It does not publish a release.