### PR TITLE
G28: fix hosted Developer ID export

### DIFF
--- a/Configuration/DeveloperIDCIExportOptions.plist
+++ b/Configuration/DeveloperIDCIExportOptions.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>destination</key>
+    <string>export</string>
+    <key>manageAppVersionAndBuildNumber</key>
+    <false/>
+    <key>method</key>
+    <string>developer-id</string>
+    <key>signingCertificate</key>
+    <string>Developer ID Application</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+</dict>
+</plist>

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -57,6 +57,11 @@ Raw credential files are removed immediately after import. An unconditional clea
 the runner's original default and search-list Keychains, deletes the temporary Keychain, and must
 pass before draft creation.
 
+The hosted runner exports with `Configuration/DeveloperIDCIExportOptions.plist`. That contract uses
+manual signing only for the CI export step and selects the already imported Developer ID
+Application identity, so export does not depend on an interactive Xcode account or ask Xcode to
+create signing assets. The local G26 export contract remains automatic and separate.
+
 ## Run The Rehearsal
 
 After the G28 source pull request is reviewed, green, and separately merged:

--- a/scripts/audit-release-workflow.sh
+++ b/scripts/audit-release-workflow.sh
@@ -9,6 +9,7 @@ readonly source_verifier="$repository_root/scripts/verify-release-workflow-sourc
 readonly credential_preparer="$repository_root/scripts/prepare-release-keychain.sh"
 readonly credential_cleanup="$repository_root/scripts/cleanup-release-keychain.sh"
 readonly candidate_builder="$repository_root/scripts/build-release-candidate.sh"
+readonly ci_export_options="$repository_root/Configuration/DeveloperIDCIExportOptions.plist"
 readonly draft_creator="$repository_root/scripts/create-draft-release.sh"
 readonly verification_library="$repository_root/scripts/lib/release-workflow-verification.sh"
 readonly focused_tests="$repository_root/scripts/test-release-workflow.sh"
@@ -41,11 +42,28 @@ done
 for readable in \
     "$workflow" \
     "$ci_workflow" \
+    "$ci_export_options" \
     "$verification_library" \
     "$documentation" \
     "$release_checklist"; do
     [[ -r "$readable" ]] || \
         fail "Protected-release contract file is missing: $(basename "$readable")"
+done
+
+/usr/bin/plutil -lint "$ci_export_options" >/dev/null
+[[ "$(/usr/bin/plutil -extract method raw -o - "$ci_export_options")" == "developer-id" ]] || \
+    fail "The hosted release export method must be developer-id."
+[[ "$(/usr/bin/plutil -extract destination raw -o - "$ci_export_options")" == "export" ]] || \
+    fail "The hosted release destination must be export."
+[[ "$(/usr/bin/plutil -extract signingStyle raw -o - "$ci_export_options")" == "manual" ]] || \
+    fail "The hosted release export must use the imported identity without an Xcode account."
+[[ "$(/usr/bin/plutil -extract signingCertificate raw -o - "$ci_export_options")" == \
+    "Developer ID Application" ]] || \
+    fail "The hosted release export must select Developer ID Application."
+for prohibited_key in teamID provisioningProfiles installerSigningCertificate; do
+    if /usr/bin/plutil -extract "$prohibited_key" raw -o - "$ci_export_options" >/dev/null 2>&1; then
+        fail "Hosted release export options must not commit $prohibited_key."
+    fi
 done
 
 require_text "$workflow" 'workflow_dispatch:'
@@ -132,6 +150,7 @@ done
 for required_build_text in \
     'xcodebuild archive' \
     'xcodebuild -exportArchive' \
+    'Configuration/DeveloperIDCIExportOptions.plist' \
     'verify-developer-id-app.sh' \
     'notarytool submit' \
     'notarytool log' \

--- a/scripts/build-release-candidate.sh
+++ b/scripts/build-release-candidate.sh
@@ -81,7 +81,7 @@ fi
 if ! DEVELOPMENT_TEAM="$expected_team_identifier" \
     /usr/bin/xcodebuild -exportArchive \
     -archivePath "$archive" \
-    -exportOptionsPlist Configuration/DeveloperIDExportOptions.plist \
+    -exportOptionsPlist Configuration/DeveloperIDCIExportOptions.plist \
     -exportPath "$export_directory" \
     > "$handoff_candidate/export.log" 2>&1; then
     protected_release_fail "The protected Developer ID archive could not be exported."


### PR DESCRIPTION
## Summary
- add a CI-only manual Developer ID export contract that selects the imported Developer ID Application identity
- keep the established G26 local automatic export contract unchanged
- enforce the hosted export contract in the canonical release-workflow audit and document the account-free trust boundary

## Evidence
- protected rehearsal 29551067068 passed arm64, x86_64, macOS 14, credential import, and credential cleanup, then failed only at automatic archive export
- focused release-workflow audit first failed because the CI export plist was absent, then passed with the new contract
- real Xcode 26.6 export of the qualified G26 archive succeeded with the new plist and passed the full pre-notarization verifier
- canonical arm64 and x86_64 pipelines passed and produced Universal 2 Release executables

## Boundary
This PR does not rerun or publish a release. After merge, the complete protected G28 rehearsal must be dispatched again from main.