### PR TITLE
G28: fix hosted archive signing

### DIFF
--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -57,10 +57,13 @@ Raw credential files are removed immediately after import. An unconditional clea
 the runner's original default and search-list Keychains, deletes the temporary Keychain, and must
 pass before draft creation.
 
-The hosted runner exports with `Configuration/DeveloperIDCIExportOptions.plist`. That contract uses
-manual signing only for the CI export step and selects the already imported Developer ID
-Application identity, so export does not depend on an interactive Xcode account or ask Xcode to
-create signing assets. The local G26 export contract remains automatic and separate.
+The hosted runner archives with manual signing, the imported Developer ID Application identity,
+the protected team, and the temporary Keychain selected explicitly. It then copies
+`Configuration/DeveloperIDCIExportOptions.plist` into the private handoff, adds the protected team
+to that runtime-only copy, and removes the copy immediately after export. The tracked contract has
+no account identifier. Archive and export therefore use the same protected identity without an
+interactive Xcode account or permission to create signing assets. The local G26 automatic export
+contract remains separate.
 
 ## Run The Rehearsal
 

--- a/scripts/audit-release-workflow.sh
+++ b/scripts/audit-release-workflow.sh
@@ -149,8 +149,14 @@ done
 
 for required_build_text in \
     'xcodebuild archive' \
+    'CODE_SIGN_STYLE=Manual' \
+    'CODE_SIGN_IDENTITY=Developer ID Application' \
+    'DEVELOPMENT_TEAM="$expected_team_identifier"' \
+    'OTHER_CODE_SIGN_FLAGS=--keychain $keychain_path' \
     'xcodebuild -exportArchive' \
     'Configuration/DeveloperIDCIExportOptions.plist' \
+    'plutil -insert teamID -string "$expected_team_identifier"' \
+    'rm -f "$runtime_export_options"' \
     'verify-developer-id-app.sh' \
     'notarytool submit' \
     'notarytool log' \

--- a/scripts/build-release-candidate.sh
+++ b/scripts/build-release-candidate.sh
@@ -68,24 +68,37 @@ readonly export_directory="$handoff_candidate/export"
 readonly application="$export_directory/CopyLasso.app"
 
 cd "$repository_root"
-if ! DEVELOPMENT_TEAM="$expected_team_identifier" \
-    /usr/bin/xcodebuild archive \
+if ! /usr/bin/xcodebuild archive \
     -project CopyLasso.xcodeproj \
     -scheme CopyLasso \
     -configuration Release \
     -destination 'generic/platform=macOS' \
     -archivePath "$archive" \
+    DEVELOPMENT_TEAM="$expected_team_identifier" \
+    CODE_SIGN_STYLE=Manual \
+    "CODE_SIGN_IDENTITY=Developer ID Application" \
+    "OTHER_CODE_SIGN_FLAGS=--keychain $keychain_path" \
     > "$handoff_candidate/archive.log" 2>&1; then
     protected_release_fail "The protected Release archive could not be created."
 fi
-if ! DEVELOPMENT_TEAM="$expected_team_identifier" \
-    /usr/bin/xcodebuild -exportArchive \
+
+readonly runtime_export_options="$handoff_candidate/DeveloperIDCIExportOptions.plist"
+cleanup_runtime_export_options() {
+    /bin/rm -f "$runtime_export_options"
+}
+trap cleanup_runtime_export_options EXIT
+/bin/cp Configuration/DeveloperIDCIExportOptions.plist "$runtime_export_options"
+/usr/bin/plutil -insert teamID -string "$expected_team_identifier" \
+    "$runtime_export_options"
+if ! /usr/bin/xcodebuild -exportArchive \
     -archivePath "$archive" \
-    -exportOptionsPlist Configuration/DeveloperIDCIExportOptions.plist \
+    -exportOptionsPlist "$runtime_export_options" \
     -exportPath "$export_directory" \
     > "$handoff_candidate/export.log" 2>&1; then
     protected_release_fail "The protected Developer ID archive could not be exported."
 fi
+cleanup_runtime_export_options
+trap - EXIT
 
 COPYLASSO_EXPECTED_TEAM_ID="$expected_team_identifier" \
     "$repository_root/scripts/verify-developer-id-app.sh" \


### PR DESCRIPTION
## Summary

- sign the hosted archive manually with the imported Developer ID identity, protected team, and temporary Keychain
- add the protected team only to a private runtime export plist and remove it immediately after export
- enforce and document the hosted archive and export signing contract

## Verification

- focused protected release audit and workflow tests
- Developer ID archive and export proof with full pre-notarization verification
- complete canonical arm64 and x86_64 pipelines, including 243 tests per ordinary and repeatability pass and Universal 2 Release output
- privacy audit and whitespace validation