### PR TITLE
G30: qualify the v0.1 release candidate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Protected Release Candidate
 
 on:
   workflow_dispatch:
+    inputs:
+      candidate_number:
+        description: Positive G30 candidate number; leave blank only for a G28 rehearsal
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -28,6 +33,7 @@ jobs:
       contents: write
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+      COPYLASSO_CANDIDATE_NUMBER: ${{ inputs.candidate_number }}
     steps:
       - name: Check out exact protected commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -47,6 +53,18 @@ jobs:
 
       - name: Initialize ephemeral release paths
         run: |
+          source ./scripts/lib/release-workflow-verification.sh
+          release_goal=G28
+          release_subdirectory=g28
+          release_mode=rehearsal
+          release_tag="v0.1.0-g28.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}"
+          if [[ -n "$COPYLASSO_CANDIDATE_NUMBER" ]]; then
+            assert_release_candidate_number "$COPYLASSO_CANDIDATE_NUMBER"
+            release_tag="$(release_candidate_tag "$COPYLASSO_CANDIDATE_NUMBER")"
+            release_goal=G30
+            release_subdirectory=g30
+            release_mode=candidate
+          fi
           release_keychain_password="$(/usr/bin/openssl rand -hex 32)"
           echo "::add-mask::$release_keychain_password"
           printf 'COPYLASSO_RELEASE_KEYCHAIN_PASSWORD=%s\n' \
@@ -57,14 +75,14 @@ jobs:
             "$RUNNER_TEMP/copylasso-release-state/copylasso-release.keychain-db" \
             >> "$GITHUB_ENV"
           printf 'COPYLASSO_RELEASE_HANDOFF=%s\n' \
-            "$RUNNER_TEMP/CopyLasso/G28/$GITHUB_SHA" >> "$GITHUB_ENV"
+            "$RUNNER_TEMP/CopyLasso/$release_goal/$GITHUB_SHA" >> "$GITHUB_ENV"
           printf 'COPYLASSO_RELEASE_RUN_DIR=%s\n' \
-            "$GITHUB_WORKSPACE/dist/g28/$GITHUB_SHA/run-$GITHUB_RUN_ATTEMPT" \
+            "$GITHUB_WORKSPACE/dist/$release_subdirectory/$GITHUB_SHA/run-$GITHUB_RUN_ATTEMPT" \
             >> "$GITHUB_ENV"
-          printf 'COPYLASSO_RELEASE_DRAFT_TAG=%s\n' \
-            "v0.1.0-g28.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
+          printf 'COPYLASSO_RELEASE_DRAFT_TAG=%s\n' "$release_tag" >> "$GITHUB_ENV"
+          printf 'COPYLASSO_RELEASE_MODE=%s\n' "$release_mode" >> "$GITHUB_ENV"
           printf 'COPYLASSO_RELEASE_READBACK=%s\n' \
-            "$GITHUB_WORKSPACE/dist/g28/$GITHUB_SHA/draft-release.json" \
+            "$GITHUB_WORKSPACE/dist/$release_subdirectory/$GITHUB_SHA/draft-release.json" \
             >> "$GITHUB_ENV"
 
       - name: Import protected release credentials
@@ -98,9 +116,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          ./scripts/create-draft-release.sh \
-            --repository "$GITHUB_REPOSITORY" \
-            --commit "$GITHUB_SHA" \
-            --tag "$COPYLASSO_RELEASE_DRAFT_TAG" \
-            --run-dir "$COPYLASSO_RELEASE_RUN_DIR" \
-            --readback "$COPYLASSO_RELEASE_READBACK"
+          if [[ "$COPYLASSO_RELEASE_MODE" == "candidate" ]]; then
+            ./scripts/create-draft-release.sh \
+              --repository "$GITHUB_REPOSITORY" \
+              --commit "$GITHUB_SHA" \
+              --candidate-number "$COPYLASSO_CANDIDATE_NUMBER" \
+              --run-dir "$COPYLASSO_RELEASE_RUN_DIR" \
+              --readback "$COPYLASSO_RELEASE_READBACK"
+          else
+            ./scripts/create-draft-release.sh \
+              --repository "$GITHUB_REPOSITORY" \
+              --commit "$GITHUB_SHA" \
+              --tag "$COPYLASSO_RELEASE_DRAFT_TAG" \
+              --run-dir "$COPYLASSO_RELEASE_RUN_DIR" \
+              --readback "$COPYLASSO_RELEASE_READBACK"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,6 @@ All notable changes to CopyLasso will be documented in this file.
 - OCR targets ordinary horizontal single-column U.S. English text; complex layouts, handwriting, and strongly rotated text are outside the initial release target.
 - Selection is confined to the display where the drag begins, and protected content can be blank or unavailable under macOS capture restrictions.
 - Immediate stationary-pointer reuse can briefly delay the visible crosshair until movement or mouse-down.
-- Locking during an active drag can require quitting and reopening CopyLasso after unlock.
+- Locking during an active drag can leave selection pending after unlock. Quit and reopen CopyLasso before another pointer action; if the retained selection completes, the clipboard may change.
 - A rare pasteboard clear-success followed by text-write rejection can leave the clipboard empty; CopyLasso does not read or restore prior contents.
 - Updates are manual.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See the [privacy policy](PRIVACY.md), [security and privacy review](docs/securit
 - A selection belongs to the display where the drag begins and clamps at that display's edge. Start another capture to select text on a different display.
 - Protected or DRM-restricted content can appear blank or unavailable to screen capture. CopyLasso follows macOS capture restrictions and does not bypass them.
 - Immediately reusing capture without moving the pointer can briefly leave the ordinary pointer visible. Moving the pointer or pressing the mouse button restores the crosshair; selection remains functional.
-- Locking the Mac during an active drag is a narrow recovery edge case. After unlocking, quit and reopen CopyLasso before the next capture if selection does not return to idle.
+- Locking the Mac during an active drag can leave selection pending after unlock. Quit and reopen CopyLasso before another pointer action; if the retained selection is allowed to complete, the clipboard may change.
 - In the rare event that macOS accepts clearing the pasteboard but rejects the subsequent text write, the previous clipboard contents have already been cleared. CopyLasso reports failure and does not read or reconstruct the prior contents.
 - Updates are manual in version 0.1.
 

--- a/docs/clean-install-testing.md
+++ b/docs/clean-install-testing.md
@@ -11,6 +11,18 @@ account has no CopyLasso application, production preferences, production
 container, login item, or Screen Recording approval. This document does not
 publish a release.
 
+## G30 Host Account Substitution
+
+G30 follows the bounded
+[`release-candidate-qualification.md`](release-candidate-qualification.md)
+procedure instead of this document's VM bridge steps. The maintainer account
+downloads and verifies all four private draft assets, then serves only the DMG
+and checksum on `127.0.0.1`. Safari in the disposable local account performs
+the genuine quarantined download after the system-wide Applications directory
+and that account's CopyLasso-owned state have been proved clean. The account is
+not signed in to GitHub, quarantine is not fabricated, and the accepted G29 VM
+gaps remain blocked. Do not resume VirtualBuddy for v0.1.
+
 ## Qualified Tool And Candidate
 
 The G29 host uses VirtualBuddy 2.1 build 325 from the project's official

--- a/docs/release-candidate-qualification.md
+++ b/docs/release-candidate-qualification.md
@@ -1,0 +1,140 @@
+# Release Candidate Qualification
+
+This procedure qualifies one immutable CopyLasso 0.1.0 release candidate. It
+supplements the partial Sonoma rehearsal retained by G29 and replaces further
+VirtualBuddy execution with one exact-candidate smoke test in a disposable
+local macOS account on the maintainer's latest-stable host. Do not resume VirtualBuddy
+for the v0.1 release.
+
+The protected workflow must create the candidate from the exact protected
+`main` commit. Every automated result, private asset, manual observation, and
+risk entry must identify that commit, the derived `v0.1.0-rc.N` tag, and the
+DMG SHA-256. Any tracked correction abandons the candidate and requires a new
+positive candidate number plus the complete gate.
+
+## Evidence And Immutability
+
+Before dispatch, finalize the tracked release notes, product contract,
+checklist, and this procedure. After dispatch, retain content-free evidence
+outside the repository under a commit-addressed
+`~/Library/Developer/CopyLasso/G30/<commit>/` directory and record the concise
+result in ignored `roadmap.md`. Do not commit account names, passwords, local
+account identifiers, signing subjects, Team IDs, private host paths, raw TCC
+or login-item databases, captured pixels, recognized text, or clipboard data.
+
+The candidate helper accepts only a positive canonical `candidate_number` and
+derives the tag internally. It refuses an existing release or tag, uploads the
+four reviewed private assets without replacement, verifies their GitHub
+`sha256:` asset digests, and creates the tag last. A failed transaction removes
+only the draft and tag created by that invocation. It never patches, moves,
+force-updates, or overwrites an existing release or ref.
+
+The final candidate remains a draft prerelease. G30 does not publish it, create
+the final `v0.1.0` tag, date the changelog, or add a public download link.
+
+## Disposable Local Account Preflight
+
+The application in `/Applications` is visible to every local account. Before
+creating or entering the disposable account, quit any existing CopyLasso
+process and reversibly stage an existing `/Applications/CopyLasso.app` outside
+Applications. Do not delete the maintainer's production preferences or
+container.
+
+Create the disposable account through macOS Users & Groups without recording
+its password. Before downloading the candidate, verify all of the following:
+
+- `/Applications/CopyLasso.app` is absent.
+- `defaults read io.github.bennetthilberg.copylasso` reports no domain for the
+  disposable account.
+- `$HOME/Library/Containers/io.github.bennetthilberg.copylasso` is absent.
+- CopyLasso is absent from Login Items & Extensions.
+- CopyLasso is absent from Screen & System Audio Recording.
+
+Do not inspect or copy raw TCC or login-item databases. A stale application,
+preference, container, login item, or Screen Recording approval invalidates the
+clean-account run.
+
+## Private Staging And Browser Download
+
+Authenticated maintainer tooling downloads all four draft assets for private
+verification. After the complete package verifier passes, place only
+`CopyLasso-0.1.0.dmg` and `CopyLasso-0.1.0.dmg.sha256` in a temporary external
+serve directory. Start a server bound only to `127.0.0.1` on an unused high
+port. Do not bind to every interface, sign the disposable account in to GitHub,
+use a shared folder, copy the app between accounts, or add quarantine manually.
+
+In Safari from the disposable account, download the DMG and checksum from the
+loopback server. Stop the server immediately afterward. Require a nonempty
+`com.apple.quarantine` value and verify both the trusted candidate digest and
+the downloaded checksum file before mounting the DMG. Missing quarantine or a
+checksum mismatch blocks the candidate.
+
+Because the reviewed release notes are already part of the tagged commit and
+draft body, this one fresh Safari download is the final G30 browser readback;
+no second download is inferred from older G28 or G29 assets.
+
+## Exact Candidate Smoke Matrix
+
+Record Pass, Fail, or Blocked for every row. This is a bounded release smoke,
+not a repetition of the complete G24 performance and accessibility matrix.
+
+1. Confirm the quarantined DMG mounts read-only and contains only CopyLasso and
+   the Applications alias.
+2. Drag CopyLasso to Applications and open it normally. Do not use Open Anyway,
+   remove quarantine, or bypass Gatekeeper.
+3. Confirm onboarding appears once, no Dock icon appears, no privacy prompt is
+   shown before capture, and the suggested shortcut is `⇧⌘2`.
+4. Complete onboarding with an explicitly recorded Launch at Login choice and
+   verify the presented state without reopening the accepted restart matrix.
+5. Start capture, deny the native Screen Recording request, and confirm one
+   recovery window, no downstream work, and no automatic retry.
+6. Enable only CopyLasso through its System Settings route, follow the actual
+   Later or Quit & Reopen transition, and start a fresh capture.
+7. Complete one configured-shortcut capture and one menu capture. Confirm the
+   crosshair, initiating-display dim, bounded outline, OCR, plain-text
+   clipboard output, success HUD, originating-application restoration, and
+   immediate command reuse.
+8. Read back production bundle `io.github.bennetthilberg.copylasso`, version
+   `0.1.0`, build `1`, and both `arm64` and `x86_64` from the installed app.
+9. Quit normally and confirm the process, status item, active selection, and
+   HUD disappear.
+
+Admin authentication, privacy approval, and physical drag observations may
+require the maintainer. Computer Use should perform every faithful read-only
+inspection and UI action that does not require the maintainer's direct input.
+
+## Accepted Evidence Gaps
+
+The following remain explicit accepted gaps rather than release passes:
+
+- the Sonoma enabled-Launch-at-Login restart;
+- ordinary reinstall with preferences retained;
+- complete uninstall and reinstall;
+- disposable-clone discard and recreation;
+- every unexecuted latest-stable guest-VM row;
+- G24's incomplete cold native-status-item timing, exact capture-dimension
+  record, remaining permission repeats, complete active-phase lifecycle and
+  clipboard sweep, reboot persistence, complete assistive-state sampling,
+  pre-run temporary inventory, and private-memory checkpoint series.
+
+The accepted stationary immediate-reuse crosshair delay and lock-during-drag
+recovery behavior remain Known limitation entries. The disposable-account
+smoke supplements these records but does not retroactively convert them to
+passes.
+
+## Issue Classification And Approval
+
+- **Release-blocking:** signing, notarization, Gatekeeper, quarantine,
+  checksum, installation, permission recovery, menu or shortcut capture, OCR,
+  clipboard output, privacy, crash, or data-handling failure that violates the
+  reviewed contract. Abandon the candidate.
+- **Known limitation:** an explicitly accepted and accurately documented v0.1
+  boundary that does not invalidate the core smoke.
+- **Deferred:** a non-goal or accepted evidence gap whose automation or
+  procedure remains intact for later work.
+
+Compare the classification record with the reviewed release notes and G24/G29
+evidence. The maintainer must explicitly approve the exact tag, commit,
+checksum, notes, and risk record. Stop with the draft unpublished and the
+binary unchanged. Keep the disposable account until separately approved
+cleanup; deleting it is not part of G30.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -50,15 +50,21 @@ Record every command, artifact name, SHA-256 checksum, commit, tag, signing iden
 
 ## G30 - Release Candidate Qualification
 
+For G30, "remaining" means the rows in this section plus exact-candidate revalidation of the
+applicable automated G25-G29 gates. Earlier unchecked template boxes retain their recorded goal
+evidence and are not silently reclassified. Use
+[`release-candidate-qualification.md`](release-candidate-qualification.md) for the bounded host
+matrix and accepted-risk record.
+
 - [ ] Phase 1: add reviewed RC mode support to the protected workflow, draft helper, static audit, and regression tests, then obtain separate approval to merge that source-enablement pull request to protected `main`.
 - [ ] Phase 2: dispatch the post-merge protected workflow from that exact `main` commit with a new positive `candidate_number`; require it to derive and create the immutable `v0.1.0-rc.N` tag and corresponding draft prerelease without accepting an arbitrary tag.
-- [ ] Read back the RC draft as `draft: true` and `prerelease: true`; verify its exact target commit, four required assets, DMG checksum, and refusal to overwrite an existing tag or release.
+- [ ] Read back the RC draft as `draft: true` and `prerelease: true`; verify its reviewed notes, exact target commit, four required assets, GitHub asset digests, DMG checksum, and refusal to overwrite an existing tag or release. Collision and rollback behavior is proven through focused fake-GitHub regressions rather than a second privileged live dispatch.
 - [ ] Download the private draft DMG and checksum with authenticated maintainer tooling, verify them, then expose only those files through a temporary loopback-only server for the disposable account's Safari download. Do not sign the disposable account in to GitHub or add quarantine manually.
 - [ ] Confirm canonical and hosted CI, package verification, host manual QA, Intel automated checks, and a fresh browser-download/Gatekeeper/install/core-capture smoke in a disposable local macOS user account on the maintainer's latest-stable host all identify that same commit and artifact checksum.
 - [ ] Before downloading the candidate in that account, verify CopyLasso's application, production preferences, production container, login item, and Screen Recording approval are absent so stale state cannot satisfy first-launch or permission-recovery checks.
 - [ ] Carry the G29 partial rehearsal and every accepted VM/reinstall evidence gap into the candidate risk record; do not describe a Blocked row as qualified.
 - [ ] Classify every issue as release-blocking, known limitation, or deferred; any fix creates a new candidate and reruns the complete gate.
-- [ ] Prepare final release notes from the qualified implementation and evidence, then verify the draft-release artifacts through a fresh browser download.
+- [ ] Land final release notes and the risk template before candidate creation, then use the disposable account's one fresh Safari download after draft creation as the candidate qualification and final browser readback.
 - [ ] Confirm the release remains unpublished and the candidate tag, artifacts, notes, changelog, and documentation identify the same version/build and commit.
 
 ## G31 - Final Tag And Publication

--- a/docs/release-notes/0.1.0.md
+++ b/docs/release-notes/0.1.0.md
@@ -1,0 +1,50 @@
+# CopyLasso 0.1.0
+
+CopyLasso is a macOS menu-bar utility for copying text from any capturable
+region of the screen. Free and open source. Private, offline, and local:
+screen pixels and recognized text are processed on this Mac without accounts,
+cloud OCR, analytics, telemetry, or capture history.
+
+## Highlights
+
+- Capture screen text with the suggested `⇧⌘2` shortcut or the status-menu
+  command.
+- Select text from ordinary applications, browsers, PDFs, images, paused
+  video, system UI, and desktop pixels.
+- Use local Apple Vision OCR and receive plain text on the clipboard with a
+  brief nonactivating confirmation HUD.
+- Configure the shortcut and Launch at Login behavior through native,
+  accessible Settings.
+- Run on macOS 14 or newer as a Universal 2 application for Apple Silicon and
+  Intel Macs.
+- Inspect and build the complete MIT-licensed source from the project
+  repository.
+
+## Privacy
+
+CopyLasso requests Screen Recording only when capture is first used. Captured
+images and recognized strings remain in memory for the active operation and
+are never logged, persisted, or transmitted. The app has no network client,
+automatic updater, account system, analytics, or telemetry.
+
+## Known Limitations
+
+- OCR targets ordinary, approximately horizontal, single-column U.S. English
+  text. Complex layouts, handwriting, strongly rotated text, and difficult
+  source pixels may be incomplete or reordered.
+- A selection belongs to the display where its drag begins and stops at that
+  display's edge.
+- Protected or DRM-restricted content may be blank or unavailable because
+  CopyLasso follows macOS capture restrictions.
+- Immediately starting another capture without moving the pointer can briefly
+  leave the ordinary pointer visible. Pointer movement or mouse-down restores
+  the crosshair while selection remains functional.
+- Locking the Mac during an active drag can leave selection pending after
+  unlock. Quit and reopen CopyLasso before another pointer action; if the
+  retained selection is allowed to complete, the clipboard may change.
+- CopyLasso never reads the prior clipboard. In the rare event that AppKit
+  accepts clearing it but rejects the following text write, the prior contents
+  may already be lost.
+- Updates are manual in version 0.1.
+
+CopyLasso is released under the MIT License and created by Bennett Hilberg.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -100,8 +100,23 @@ G28-only and reject release-candidate tags. G30 therefore has two ordered phases
    `main` commit through the complete quality gate and `release` environment. The job must sign,
    notarize, staple, package, clean credentials, and transactionally create a draft prerelease with
    the same four-asset contract. Readback must prove the exact target commit, tag, draft/prerelease
-   state, asset names, and DMG checksum. Any later tracked change abandons that candidate and uses a
-   new number.
+   state, asset names, GitHub asset digests, and DMG checksum. Any later tracked change abandons that
+   candidate and uses a new number.
+
+`candidate_number` is the workflow's sole input. Leaving it blank preserves the completed G28
+rehearsal path; a positive canonical integer selects G30. Values with a sign, leading zero, decimal,
+whitespace, or tag text are rejected before they influence a tag or path. No arbitrary tag, ref, or
+mode input exists.
+
+The G30 helper derives the RC tag independently, refuses both an existing release and an existing
+Git ref, and uploads without replacement. It reads back the draft body from the reviewed
+[`release-notes/0.1.0.md`](release-notes/0.1.0.md), the exact four asset names, and every available
+`sha256:` asset digest. The checksum record must agree with both the local DMG and its uploaded
+digest. Only after those checks pass is the lightweight tag created directly on the exact commit;
+the tag is created last so an upload or validation failure cannot strand an RC ref. Final tag and
+release readback completes the transaction. On a later failure, cleanup deletes only the draft and
+tag created by that invocation. The helper never patches, force-updates, moves, or overwrites a ref
+or release.
 
 The G28 rehearsal draft and its assets cannot serve as G30 evidence. Only the RC draft created by
 the post-merge protected run supplies G30's DMG and checksum.
@@ -112,6 +127,13 @@ then serve only those two files temporarily on `127.0.0.1`. Download them throug
 disposable local test account so macOS creates genuine browser quarantine without signing that
 account in to GitHub. Stop the server and remove the staging copy after qualification; never add a
 quarantine attribute manually.
+
+The reviewed release notes and qualification procedure land before candidate creation. Therefore
+the Safari qualification download occurs after the final draft body exists and also serves as the
+fresh browser readback required by G30; an older G28/G29 download or a second inferred download does
+not count. Follow [`release-candidate-qualification.md`](release-candidate-qualification.md) for the
+clean-account preflight, exact smoke matrix, accepted gaps, risk classification, and evidence
+boundary.
 
 ## Draft Assets And Local Readback
 

--- a/docs/v0.1-product-contract.md
+++ b/docs/v0.1-product-contract.md
@@ -2,7 +2,7 @@
 
 - **Status:** Approved scope for the first public release
 - **Approved:** July 9, 2026
-- **Implementation status:** Pre-development
+- **Implementation status:** Release-candidate qualification
 
 This document defines CopyLasso's user-visible v0.1 promises. It is the public source of truth for product scope, supported systems, privacy guarantees, known boundaries, and release completion. It does not describe the internal development workflow.
 
@@ -115,6 +115,7 @@ Non-English recognition, automatic language detection, manual recognition-langua
 - No sound plays by default.
 - Cancellation, no text, permission denial, capture failure, OCR failure, formatting failure, and internal errors before clipboard replacement leave the existing clipboard unchanged.
 - CopyLasso never reads or snapshots the prior general clipboard. If AppKit accepts the required clear but rejects the subsequent write, CopyLasso reports a clipboard-stage failure, but the prior contents may already be lost. This rare platform failure is a known v0.1 limitation.
+- A lock during an active drag is an accepted v0.1 recovery exception. Selection may remain pending after unlock, so the user must quit and reopen CopyLasso before another pointer action. If the retained selection is instead allowed to complete, the clipboard may change.
 - Feedback disappears automatically and CopyLasso returns to its idle state. Invoking Capture Text
   while feedback is visible dismisses that feedback and begins a fresh capture immediately.
 
@@ -136,7 +137,7 @@ Non-English recognition, automatic language detection, manual recognition-langua
   create overlapping workflows. A press while feedback is visible replaces that feedback with one
   fresh capture; an older feedback timer must not dismiss or otherwise mutate newer feedback.
 - Cancellation and failure at every pipeline stage must release overlays, images, callbacks, and transient text and return the app to a usable state.
-- The app must tolerate display changes, sleep and wake, lock and unlock, permission changes, and quitting during selection without requiring a force quit.
+- The app must tolerate display changes, sleep and wake, permission changes, and quitting during selection without requiring a force quit. The active-drag lock exception is documented above and in the release notes rather than represented as a passing lifecycle path.
 - Native controls must be keyboard accessible and VoiceOver labeled when introduced.
 - Onboarding, Settings, selection, permission recovery, errors, and feedback must remain understandable in supported appearance and accessibility configurations.
 
@@ -163,7 +164,7 @@ Non-English recognition, automatic language detection, manual recognition-langua
 
 CopyLasso v0.1.0 is complete only when:
 
-- Every approved v0.1 roadmap goal is complete with reproducible evidence.
+- Every primary v0.1 roadmap goal is complete, and every approved amendment is either complete or explicitly closed with a maintainer-accepted residual or evidence gap, with reproducible evidence and no blocked row represented as a pass.
 - The same release commit passes local and CI builds and automated tests.
 - Every separable production behavior was developed test-first, with documented manual procedures for system behavior that cannot be automated faithfully.
 - Debug and Release use their fixed, distinct bundle identifiers.

--- a/scripts/audit-brand-release.sh
+++ b/scripts/audit-brand-release.sh
@@ -52,6 +52,8 @@ require_file "$repository_root/docs/brand-assets.md"
 require_file "$repository_root/docs/developer-id-signing.md"
 require_file "$repository_root/docs/release-checklist.md"
 require_file "$repository_root/docs/clean-install-testing.md"
+require_file "$repository_root/docs/release-candidate-qualification.md"
+require_file "$repository_root/docs/release-notes/0.1.0.md"
 
 if [[ -e CopyLasso/Assets.xcassets/AppIcon.appiconset ]]; then
     fail "The empty development AppIcon catalog must not coexist with AppIcon.icon."
@@ -194,6 +196,12 @@ require_text docs/clean-install-testing.md '## G29 Partial Rehearsal Record'
 require_text docs/clean-install-testing.md 'accepted evidence gaps'
 require_text docs/v0.1-product-contract.md 'Before download, that account must have no CopyLasso application, production'
 require_text docs/v0.1-product-contract.md 'preferences, production container, login item, or Screen Recording approval.'
+require_text docs/v0.1-product-contract.md '**Implementation status:** Release-candidate qualification'
+require_text docs/v0.1-product-contract.md 'clipboard may change'
+require_text docs/release-candidate-qualification.md '## Exact Candidate Smoke Matrix'
+require_text docs/release-candidate-qualification.md 'Do not resume VirtualBuddy'
+require_text docs/release-notes/0.1.0.md 'CopyLasso 0.1.0'
+require_text docs/release-notes/0.1.0.md 'Locking the Mac during an active drag'
 require_text docs/brand-assets.md 'The final pre-artifact exact-name review was repeated on July 14, 2026'
 require_text THIRD_PARTY_NOTICES.md 'KeyboardShortcuts 3.0.1'
 require_text THIRD_PARTY_NOTICES.md 'License: MIT'
@@ -217,7 +225,9 @@ readonly public_copy=(
     docs/brand-assets.md
     docs/developer-id-signing.md
     docs/clean-install-testing.md
+    docs/release-candidate-qualification.md
     docs/release-checklist.md
+    docs/release-notes/0.1.0.md
     docs/v0.1-product-contract.md
 )
 readonly prohibited_public_pattern='TODO|example\.com|your organization|template organization|[Tt]ext[Ss]niper|[Oo][Cc][Rr][Aa][Cc][Yy]'

--- a/scripts/audit-release-workflow.sh
+++ b/scripts/audit-release-workflow.sh
@@ -193,6 +193,8 @@ for required_draft_text in \
     'prerelease=true' \
     'make_latest=false' \
     'release upload' \
+    '--paginate' \
+    '--slurp' \
     'git/ref/tags/' \
     'git/refs' \
     '--method DELETE' \

--- a/scripts/audit-release-workflow.sh
+++ b/scripts/audit-release-workflow.sh
@@ -15,6 +15,9 @@ readonly verification_library="$repository_root/scripts/lib/release-workflow-ver
 readonly focused_tests="$repository_root/scripts/test-release-workflow.sh"
 readonly documentation="$repository_root/docs/release-workflow.md"
 readonly release_checklist="$repository_root/docs/release-checklist.md"
+readonly qualification_documentation="$repository_root/docs/release-candidate-qualification.md"
+readonly release_notes="$repository_root/docs/release-notes/0.1.0.md"
+readonly product_contract="$repository_root/docs/v0.1-product-contract.md"
 
 fail() {
     echo "$1" >&2
@@ -45,7 +48,10 @@ for readable in \
     "$ci_export_options" \
     "$verification_library" \
     "$documentation" \
-    "$release_checklist"; do
+    "$release_checklist" \
+    "$qualification_documentation" \
+    "$release_notes" \
+    "$product_contract"; do
     [[ -r "$readable" ]] || \
         fail "Protected-release contract file is missing: $(basename "$readable")"
 done
@@ -67,6 +73,16 @@ for prohibited_key in teamID provisioningProfiles installerSigningCertificate; d
 done
 
 require_text "$workflow" 'workflow_dispatch:'
+require_text "$workflow" 'candidate_number:'
+require_text "$workflow" 'COPYLASSO_CANDIDATE_NUMBER: ${{ inputs.candidate_number }}'
+require_text "$workflow" 'assert_release_candidate_number "$COPYLASSO_CANDIDATE_NUMBER"'
+require_text "$workflow" 'release_candidate_tag "$COPYLASSO_CANDIDATE_NUMBER"'
+if [[ "$(/usr/bin/grep -Fc '${{ inputs.' "$workflow")" != "1" ]]; then
+    fail "candidate_number must be the protected workflow's sole dispatch input."
+fi
+if /usr/bin/grep -Eq '\$\{\{[[:space:]]*inputs\.(tag|ref|mode)' "$workflow"; then
+    fail "The protected workflow must not accept an arbitrary tag, ref, or mode input."
+fi
 for prohibited_trigger in pull_request: pull_request_target: push: repository_dispatch: workflow_run:; do
     if /usr/bin/grep -Eq "^[[:space:]]*${prohibited_trigger}[[:space:]]*$" "$workflow"; then
         fail "The protected release workflow has a prohibited trigger: $prohibited_trigger"
@@ -121,8 +137,12 @@ require_text "$workflow" 'if: always()'
 
 build_line="$(/usr/bin/grep -n './scripts/build-release-candidate.sh' "$workflow" | /usr/bin/cut -d: -f1)"
 cleanup_line="$(/usr/bin/grep -n './scripts/cleanup-release-keychain.sh' "$workflow" | /usr/bin/cut -d: -f1)"
-draft_line="$(/usr/bin/grep -n './scripts/create-draft-release.sh' "$workflow" | /usr/bin/cut -d: -f1)"
-if ((cleanup_line <= build_line || draft_line <= cleanup_line)); then
+draft_count="$(/usr/bin/grep -Fc './scripts/create-draft-release.sh' "$workflow")"
+[[ "$draft_count" == "2" ]] || \
+    fail "The protected workflow must invoke one draft helper in each validated release mode."
+first_draft_line="$(/usr/bin/grep -n './scripts/create-draft-release.sh' "$workflow" | \
+    /usr/bin/head -n 1 | /usr/bin/cut -d: -f1)"
+if ((cleanup_line <= build_line || first_draft_line <= cleanup_line)); then
     fail "Credential cleanup must follow packaging and precede draft creation."
 fi
 
@@ -167,18 +187,33 @@ for required_build_text in \
 done
 
 for required_draft_text in \
+    '--candidate-number' \
+    'release_candidate_tag' \
     'draft=true' \
     'prerelease=true' \
     'make_latest=false' \
     'release upload' \
+    'git/ref/tags/' \
+    'git/refs' \
     '--method DELETE' \
-    'assert_release_draft_record'; do
+    'assert_release_draft_record' \
+    'assert_release_candidate_record' \
+    'assert_release_candidate_tag_record'; do
     require_text "$draft_creator" "$required_draft_text"
 done
+for required_candidate_verification_text in \
+    'assert_release_candidate_number' \
+    'release_candidate_tag' \
+    'assert_release_candidate_record' \
+    'assert_release_candidate_tag_record' \
+    'sha256:' \
+    'uploaded release asset digest does not match'; do
+    require_text "$verification_library" "$required_candidate_verification_text"
+done
 if /usr/bin/grep -Eiq -- \
-    'release (publish|edit.+--draft=false)|--clobber|make_latest=true' \
+    'release (publish|edit.+--draft=false)|--clobber|make_latest=true|--method PATCH|force=true' \
     "$draft_creator" "$workflow"; then
-    fail "The G28 workflow must never publish, overwrite, or promote its draft."
+    fail "The protected workflow must never publish, overwrite, force-update, or promote a draft."
 fi
 
 for required_documentation_text in \
@@ -193,11 +228,37 @@ for required_documentation_text in \
     'credential cleanup' \
     'Draft creation is transactional' \
     'Never publish the G28 rehearsal' \
+    'v0.1.0-rc.N' \
+    'candidate_number' \
+    'asset digests' \
+    'tag is created last' \
     'G29' \
     'G30'; do
     require_text "$documentation" "$required_documentation_text"
 done
 require_text "$release_checklist" 'Keep the dSYM and verification bundle restricted to the draft'
+for required_qualification_text in \
+    'Disposable Local Account Preflight' \
+    'Exact Candidate Smoke Matrix' \
+    'Accepted Evidence Gaps' \
+    'Release-blocking' \
+    'Known limitation' \
+    'Deferred' \
+    '127.0.0.1' \
+    'Do not resume VirtualBuddy'; do
+    require_text "$qualification_documentation" "$required_qualification_text"
+done
+for required_release_note_text in \
+    'CopyLasso 0.1.0' \
+    'Free and open source' \
+    'Private, offline, and local' \
+    'Locking the Mac during an active drag' \
+    'clipboard'; do
+    require_text "$release_notes" "$required_release_note_text"
+done
+require_text "$product_contract" '**Implementation status:** Release-candidate qualification'
+require_text "$product_contract" 'lock during an active drag'
+require_text "$product_contract" 'clipboard may change'
 
 if /usr/bin/grep -Eq 'set -x|TeamIdentifier=[A-Z0-9]{10}|[[:alnum:]._%+-]+@[[:alnum:].-]+\.[A-Za-z]{2,}|[a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4}' \
     "$workflow" \

--- a/scripts/build-release-candidate.sh
+++ b/scripts/build-release-candidate.sh
@@ -14,7 +14,7 @@ usage() {
 Usage: build-release-candidate.sh \
   --source-commit <40-character-commit> \
   --handoff /path/under/RUNNER_TEMP/<commit> \
-  --output-dir /path/to/repository/dist/g28/<commit>/run
+  --output-dir /path/to/repository/dist/<release-mode>/<commit>/run
 TEXT
     exit 64
 }

--- a/scripts/create-draft-release.sh
+++ b/scripts/create-draft-release.sh
@@ -199,7 +199,12 @@ if [[ "$release_mode" == "candidate" ]]; then
         -f "ref=refs/tags/$tag" \
         -f "sha=$commit" \
         >/dev/null; then
-        protected_release_fail "The release-candidate transaction could not create its immutable tag."
+        if ! "$gh_binary" api \
+            "repos/$repository/git/ref/tags/$tag" > "$candidate_tag_record"; then
+            protected_release_fail \
+                "The release-candidate transaction could not create its immutable tag."
+        fi
+        assert_release_candidate_tag_record "$candidate_tag_record" "$commit" "$tag"
     fi
     candidate_tag_created="true"
     if ! "$gh_binary" api \

--- a/scripts/create-draft-release.sh
+++ b/scripts/create-draft-release.sh
@@ -12,7 +12,7 @@ usage() {
 Usage: create-draft-release.sh \
   --repository owner/repository \
   --commit <40-character-commit> \
-  --tag v0.1.0-g28.<run> \
+  (--tag v0.1.0-g28.<run> | --candidate-number <positive-integer>) \
   --run-dir /path/to/release-run \
   --readback /path/to/draft-release.json
 TEXT
@@ -22,6 +22,7 @@ TEXT
 repository=""
 commit=""
 tag=""
+candidate_number=""
 run_directory=""
 readback=""
 while [[ "$#" -gt 0 ]]; do
@@ -41,6 +42,11 @@ while [[ "$#" -gt 0 ]]; do
             tag="$2"
             shift 2
             ;;
+        --candidate-number)
+            [[ "$#" -ge 2 ]] || usage
+            candidate_number="$2"
+            shift 2
+            ;;
         --run-dir)
             [[ "$#" -ge 2 ]] || usage
             run_directory="$2"
@@ -54,26 +60,47 @@ while [[ "$#" -gt 0 ]]; do
         *) usage ;;
     esac
 done
-[[ -n "$repository" && -n "$commit" && -n "$tag" && \
-    -n "$run_directory" && -n "$readback" ]] || usage
+[[ -n "$repository" && -n "$commit" && -n "$run_directory" && -n "$readback" ]] || usage
+if [[ -n "$tag" && -n "$candidate_number" ]] || \
+    [[ -z "$tag" && -z "$candidate_number" ]]; then
+    usage
+fi
 
 [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || \
     protected_release_fail "The GitHub repository name is invalid."
 assert_full_release_commit "$commit"
-assert_release_draft_tag "$tag"
+release_mode="rehearsal"
+if [[ -n "$candidate_number" ]]; then
+    assert_release_candidate_number "$candidate_number"
+    tag="$(release_candidate_tag "$candidate_number")"
+    release_mode="candidate"
+else
+    assert_release_draft_tag "$tag"
+fi
+readonly release_mode
+readonly tag
 readonly verification_bundle="$run_directory/$COPYLASSO_G28_VERIFICATION"
 assert_release_workflow_assets "$run_directory" "$verification_bundle"
 [[ -n "${GH_TOKEN:-}" ]] || protected_release_fail "The draft-release token is unavailable."
 
 readonly gh_binary="${COPYLASSO_GH_BIN:-gh}"
-readonly temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/copylasso-g28-draft.XXXXXX")"
+readonly temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/copylasso-release-draft.XXXXXX")"
 readonly creation_record="$temporary_directory/created.json"
 readonly final_record="$temporary_directory/final.json"
 readonly notes="$temporary_directory/notes.md"
+readonly candidate_tag_record="$temporary_directory/tag.json"
+readonly reviewed_candidate_notes="$repository_root/docs/release-notes/0.1.0.md"
 release_identifier=""
+candidate_tag_created="false"
 draft_committed="false"
 
 rollback_draft() {
+    if [[ "$candidate_tag_created" == "true" && "$draft_committed" != "true" ]]; then
+        "$gh_binary" api \
+            --method DELETE \
+            "repos/$repository/git/refs/tags/$tag" \
+            >/dev/null 2>&1 || true
+    fi
     if [[ -n "$release_identifier" && "$draft_committed" != "true" ]]; then
         "$gh_binary" api \
             --method DELETE \
@@ -85,21 +112,36 @@ rollback_draft() {
 trap rollback_draft EXIT
 
 if "$gh_binary" api "repos/$repository/releases/tags/$tag" >/dev/null 2>&1; then
+    if [[ "$release_mode" == "candidate" ]]; then
+        protected_release_fail "A release already exists for the release-candidate tag."
+    fi
     protected_release_fail "A release already exists for the G28 rehearsal tag."
 fi
 
-printf '%s\n\n%s\n\n%s\n' \
-    'Protected G28 workflow rehearsal for CopyLasso 0.1.0.' \
-    "Exact source commit: $commit" \
-    'Draft only. Do not publish; G29 and G30 remain separate release gates.' \
-    > "$notes"
+if [[ "$release_mode" == "candidate" ]]; then
+    if "$gh_binary" api "repos/$repository/git/ref/tags/$tag" >/dev/null 2>&1; then
+        protected_release_fail "A tag already exists for the release candidate."
+    fi
+    [[ -f "$reviewed_candidate_notes" ]] || \
+        protected_release_fail "The reviewed release-candidate notes are missing."
+    /bin/cp "$reviewed_candidate_notes" "$notes"
+    release_name="CopyLasso 0.1.0 release candidate $candidate_number"
+else
+    printf '%s\n\n%s\n\n%s\n' \
+        'Protected G28 workflow rehearsal for CopyLasso 0.1.0.' \
+        "Exact source commit: $commit" \
+        'Draft only. Do not publish; G29 and G30 remain separate release gates.' \
+        > "$notes"
+    release_name="CopyLasso 0.1.0 protected workflow rehearsal"
+fi
+readonly release_name
 
 if ! "$gh_binary" api \
     --method POST \
     "repos/$repository/releases" \
     -f "tag_name=$tag" \
     -f "target_commitish=$commit" \
-    -f "name=CopyLasso 0.1.0 protected workflow rehearsal" \
+    -f "name=$release_name" \
     -F draft=true \
     -F prerelease=true \
     -f make_latest=false \
@@ -117,13 +159,48 @@ if ! "$gh_binary" release upload "$tag" \
     "$run_directory/$COPYLASSO_G28_DSYM" \
     "$verification_bundle" \
     --repo "$repository"; then
+    if [[ "$release_mode" == "candidate" ]]; then
+        protected_release_fail "The release-candidate transaction could not upload its complete asset set."
+    fi
     protected_release_fail "The complete protected draft asset set could not be uploaded."
 fi
 
 if ! "$gh_binary" api "repos/$repository/releases/$release_identifier" > "$final_record"; then
     protected_release_fail "The protected draft release could not be read back."
 fi
-assert_release_draft_record "$final_record" "$commit" "$tag"
+if [[ "$release_mode" == "candidate" ]]; then
+    assert_release_candidate_record \
+        "$final_record" \
+        "$commit" \
+        "$candidate_number" \
+        "$run_directory" \
+        "$reviewed_candidate_notes"
+    if ! "$gh_binary" api \
+        --method POST \
+        "repos/$repository/git/refs" \
+        -f "ref=refs/tags/$tag" \
+        -f "sha=$commit" \
+        >/dev/null; then
+        protected_release_fail "The release-candidate transaction could not create its immutable tag."
+    fi
+    candidate_tag_created="true"
+    if ! "$gh_binary" api \
+        "repos/$repository/git/ref/tags/$tag" > "$candidate_tag_record"; then
+        protected_release_fail "The release-candidate transaction could not read back its tag."
+    fi
+    assert_release_candidate_tag_record "$candidate_tag_record" "$commit" "$tag"
+    if ! "$gh_binary" api "repos/$repository/releases/$release_identifier" > "$final_record"; then
+        protected_release_fail "The release-candidate transaction could not complete final readback."
+    fi
+    assert_release_candidate_record \
+        "$final_record" \
+        "$commit" \
+        "$candidate_number" \
+        "$run_directory" \
+        "$reviewed_candidate_notes"
+else
+    assert_release_draft_record "$final_record" "$commit" "$tag"
+fi
 
 /bin/mkdir -p "$(dirname "$readback")"
 /bin/cp "$final_record" "$readback"

--- a/scripts/create-draft-release.sh
+++ b/scripts/create-draft-release.sh
@@ -89,6 +89,7 @@ readonly creation_record="$temporary_directory/created.json"
 readonly final_record="$temporary_directory/final.json"
 readonly notes="$temporary_directory/notes.md"
 readonly candidate_tag_record="$temporary_directory/tag.json"
+readonly release_listing="$temporary_directory/releases.json"
 readonly reviewed_candidate_notes="$repository_root/docs/release-notes/0.1.0.md"
 release_identifier=""
 candidate_tag_created="false"
@@ -119,6 +120,23 @@ if "$gh_binary" api "repos/$repository/releases/tags/$tag" >/dev/null 2>&1; then
 fi
 
 if [[ "$release_mode" == "candidate" ]]; then
+    if ! "$gh_binary" api \
+        --paginate \
+        --slurp \
+        "repos/$repository/releases?per_page=100" > "$release_listing"; then
+        protected_release_fail \
+            "Existing release candidates could not be checked before mutation."
+    fi
+    existing_release_count="$(/usr/bin/jq -er --arg tag "$tag" '
+        if type == "array" and all(.[]; type == "array") then
+            [.[][] | select(.tag_name == $tag)] | length
+        else
+            error("invalid release listing")
+        end
+    ' "$release_listing" 2>/dev/null)" || \
+        protected_release_fail "The existing-release listing is invalid."
+    [[ "$existing_release_count" == "0" ]] || \
+        protected_release_fail "A release already exists for the release-candidate tag."
     if "$gh_binary" api "repos/$repository/git/ref/tags/$tag" >/dev/null 2>&1; then
         protected_release_fail "A tag already exists for the release candidate."
     fi

--- a/scripts/lib/release-workflow-verification.sh
+++ b/scripts/lib/release-workflow-verification.sh
@@ -95,6 +95,28 @@ assert_release_draft_tag() {
         protected_release_fail "The G28 draft tag name is invalid."
 }
 
+assert_release_candidate_number() {
+    local candidate_number="$1"
+
+    [[ "$candidate_number" =~ ^[1-9][0-9]*$ ]] || \
+        protected_release_fail \
+            "The release-candidate number must be a positive canonical integer."
+}
+
+release_candidate_tag() {
+    local candidate_number="$1"
+
+    assert_release_candidate_number "$candidate_number"
+    printf 'v0.1.0-rc.%s\n' "$candidate_number"
+}
+
+assert_release_candidate_tag() {
+    local candidate_tag="$1"
+
+    [[ "$candidate_tag" =~ ^v0\.1\.0-rc\.[1-9][0-9]*$ ]] || \
+        protected_release_fail "The release-candidate tag name is invalid."
+}
+
 assert_release_workflow_assets() {
     local g28_asset_run_directory="$1"
     local g28_asset_verification_bundle="$2"
@@ -127,36 +149,121 @@ release_draft_asset_names() {
         ' | LC_ALL=C /usr/bin/sort
 }
 
-assert_release_draft_record() {
-    local g28_record="$1"
-    local g28_expected_commit="$2"
-    local g28_expected_tag="$3"
-    local g28_expected_assets
-    local g28_actual_assets
+assert_release_record_metadata() {
+    local release_record="$1"
+    local expected_commit="$2"
+    local expected_tag="$3"
+    local expected_assets
+    local actual_assets
 
-    [[ -f "$g28_record" ]] || protected_release_fail "The draft-release readback is missing."
-    /usr/bin/plutil -p "$g28_record" >/dev/null || \
+    [[ -f "$release_record" ]] || protected_release_fail "The draft-release readback is missing."
+    /usr/bin/plutil -p "$release_record" >/dev/null || \
         protected_release_fail "The draft-release readback is not valid JSON."
-    assert_full_release_commit "$g28_expected_commit"
-    assert_release_draft_tag "$g28_expected_tag"
+    assert_full_release_commit "$expected_commit"
 
-    [[ "$(/usr/bin/plutil -extract draft raw -o - "$g28_record" 2>/dev/null || true)" == "true" ]] || \
+    [[ "$(/usr/bin/plutil -extract draft raw -o - "$release_record" 2>/dev/null || true)" == "true" ]] || \
         protected_release_fail "The GitHub release is not a draft."
-    [[ "$(/usr/bin/plutil -extract prerelease raw -o - "$g28_record" 2>/dev/null || true)" == "true" ]] || \
+    [[ "$(/usr/bin/plutil -extract prerelease raw -o - "$release_record" 2>/dev/null || true)" == "true" ]] || \
         protected_release_fail "The GitHub release is not marked as a prerelease."
-    [[ "$(/usr/bin/plutil -extract tag_name raw -o - "$g28_record" 2>/dev/null || true)" == "$g28_expected_tag" ]] || \
+    [[ "$(/usr/bin/plutil -extract tag_name raw -o - "$release_record" 2>/dev/null || true)" == "$expected_tag" ]] || \
         protected_release_fail "The draft release has the wrong tag name."
-    [[ "$(/usr/bin/plutil -extract target_commitish raw -o - "$g28_record" 2>/dev/null || true)" == "$g28_expected_commit" ]] || \
+    [[ "$(/usr/bin/plutil -extract target_commitish raw -o - "$release_record" 2>/dev/null || true)" == "$expected_commit" ]] || \
         protected_release_fail "The draft release targets the wrong commit."
 
-    g28_expected_assets="$(printf '%s\n' \
+    expected_assets="$(printf '%s\n' \
         "$COPYLASSO_G28_CHECKSUM" \
         "$COPYLASSO_G28_DMG" \
         "$COPYLASSO_G28_DSYM" \
         "$COPYLASSO_G28_VERIFICATION" | LC_ALL=C /usr/bin/sort)"
-    g28_actual_assets="$(release_draft_asset_names "$g28_record")"
-    [[ "$g28_actual_assets" == "$g28_expected_assets" ]] || \
+    actual_assets="$(release_draft_asset_names "$release_record")"
+    [[ "$actual_assets" == "$expected_assets" ]] || \
         protected_release_fail "The draft release has an incomplete or unexpected asset set."
+}
+
+assert_release_draft_record() {
+    local g28_record="$1"
+    local g28_expected_commit="$2"
+    local g28_expected_tag="$3"
+    assert_release_draft_tag "$g28_expected_tag"
+    assert_release_record_metadata "$g28_record" "$g28_expected_commit" "$g28_expected_tag"
+}
+
+assert_release_candidate_record() {
+    local candidate_record="$1"
+    local expected_commit="$2"
+    local candidate_number="$3"
+    local release_run_directory="$4"
+    local reviewed_notes="$5"
+    local candidate_tag
+    local expected_notes
+    local actual_notes
+    local candidate_asset_name
+    local candidate_asset_path
+    local expected_digest
+    local actual_digest
+    local expected_checksum_line
+    local actual_checksum_line
+
+    candidate_tag="$(release_candidate_tag "$candidate_number")"
+    assert_release_record_metadata "$candidate_record" "$expected_commit" "$candidate_tag"
+    assert_release_workflow_assets \
+        "$release_run_directory" \
+        "$release_run_directory/$COPYLASSO_G28_VERIFICATION"
+    [[ -f "$reviewed_notes" ]] || \
+        protected_release_fail "The reviewed release notes are missing."
+    expected_notes="$(/bin/cat "$reviewed_notes")"
+    actual_notes="$(/usr/bin/plutil -extract body raw -o - "$candidate_record" 2>/dev/null || true)"
+    [[ "$actual_notes" == "$expected_notes" ]] || \
+        protected_release_fail "The release notes differ from the reviewed source."
+
+    for candidate_asset_name in \
+        "$COPYLASSO_G28_DMG" \
+        "$COPYLASSO_G28_CHECKSUM" \
+        "$COPYLASSO_G28_DSYM" \
+        "$COPYLASSO_G28_VERIFICATION"; do
+        candidate_asset_path="$release_run_directory/$candidate_asset_name"
+        expected_digest="sha256:$(/usr/bin/shasum -a 256 "$candidate_asset_path" | \
+            /usr/bin/awk '{print $1}')"
+        actual_digest="$(/usr/bin/jq -er --arg asset_name "$candidate_asset_name" '
+            [.assets[] | select(.name == $asset_name) | .digest]
+            | if length == 1 then .[0] else empty end
+        ' "$candidate_record" 2>/dev/null || true)"
+        [[ "$actual_digest" == "$expected_digest" ]] || \
+            protected_release_fail \
+                "An uploaded release asset digest does not match the qualified local asset."
+    done
+
+    expected_checksum_line="$(/usr/bin/shasum -a 256 \
+        "$release_run_directory/$COPYLASSO_G28_DMG" | \
+        /usr/bin/awk -v name="$COPYLASSO_G28_DMG" '{print $1 "  " name}')"
+    actual_checksum_line="$(/bin/cat \
+        "$release_run_directory/$COPYLASSO_G28_CHECKSUM")"
+    [[ "$actual_checksum_line" == "$expected_checksum_line" ]] || \
+        protected_release_fail \
+            "The release-candidate checksum does not match the qualified disk image."
+}
+
+assert_release_candidate_tag_record() {
+    local tag_record="$1"
+    local expected_commit="$2"
+    local expected_tag="$3"
+
+    [[ -f "$tag_record" ]] || protected_release_fail "The release-candidate tag readback is missing."
+    /usr/bin/plutil -p "$tag_record" >/dev/null || \
+        protected_release_fail "The release-candidate tag readback is not valid JSON."
+    assert_full_release_commit "$expected_commit"
+    assert_release_candidate_tag "$expected_tag"
+    [[ "$(/usr/bin/plutil -extract ref raw -o - "$tag_record" 2>/dev/null || true)" == \
+        "refs/tags/$expected_tag" ]] || \
+        protected_release_fail "The release-candidate tag readback has the wrong ref."
+    [[ "$(/usr/bin/plutil -extract object.type raw -o - "$tag_record" 2>/dev/null || true)" == \
+        "commit" ]] || \
+        protected_release_fail \
+            "The release-candidate tag does not point directly to the candidate commit."
+    [[ "$(/usr/bin/plutil -extract object.sha raw -o - "$tag_record" 2>/dev/null || true)" == \
+        "$expected_commit" ]] || \
+        protected_release_fail \
+            "The release-candidate tag does not point directly to the candidate commit."
 }
 
 assert_release_log_is_public_safe() {

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -12,6 +12,8 @@ readonly draft_creator="$repository_root/scripts/create-draft-release.sh"
 readonly verifier_library="$repository_root/scripts/lib/release-workflow-verification.sh"
 readonly workflow="$repository_root/.github/workflows/release.yml"
 readonly documentation="$repository_root/docs/release-workflow.md"
+readonly qualification_documentation="$repository_root/docs/release-candidate-qualification.md"
+readonly release_notes="$repository_root/docs/release-notes/0.1.0.md"
 
 fail() {
     echo "$1" >&2
@@ -29,7 +31,12 @@ for executable in \
         fail "Protected-release executable is missing: $(basename "$executable")"
 done
 
-for readable in "$verifier_library" "$workflow" "$documentation"; do
+for readable in \
+    "$verifier_library" \
+    "$workflow" \
+    "$documentation" \
+    "$qualification_documentation" \
+    "$release_notes"; do
     [[ -r "$readable" ]] || \
         fail "Protected-release contract file is missing: $(basename "$readable")"
 done
@@ -119,6 +126,20 @@ assert_release_draft_tag "v0.1.0-g28.12345"
 expect_failure "draft tag name is invalid" \
     assert_release_draft_tag "v0.1.0-rc.1"
 
+assert_release_candidate_number "1"
+assert_release_candidate_number "42"
+for invalid_candidate_number in "" 0 01 +1 -1 1.0 " 1" "1 " rc.1 arbitrary; do
+    expect_failure "candidate number must be a positive canonical integer" \
+        assert_release_candidate_number "$invalid_candidate_number"
+done
+[[ "$(release_candidate_tag "1")" == "v0.1.0-rc.1" ]] || \
+    fail "Candidate 1 must derive the exact v0.1.0-rc.1 tag."
+[[ "$(release_candidate_tag "42")" == "v0.1.0-rc.42" ]] || \
+    fail "Candidate 42 must derive the exact v0.1.0-rc.42 tag."
+assert_release_candidate_tag "v0.1.0-rc.1"
+expect_failure "release-candidate tag name is invalid" \
+    assert_release_candidate_tag "v0.1.0-g28.12345"
+
 readonly valid_draft="$temporary_directory/valid-draft.json"
 printf '%s\n' "{
   \"id\": 123,
@@ -178,25 +199,161 @@ expect_failure "protected release asset is missing" \
     "$release_run/CopyLasso-0.1.0-verification.zip"
 : > "$release_run/CopyLasso-0.1.0.dSYM.zip"
 
+printf 'qualified candidate disk image\n' > "$release_run/CopyLasso-0.1.0.dmg"
+(
+    cd "$release_run"
+    /usr/bin/shasum -a 256 CopyLasso-0.1.0.dmg > CopyLasso-0.1.0.dmg.sha256
+)
+printf 'qualified candidate symbols\n' > "$release_run/CopyLasso-0.1.0.dSYM.zip"
+printf 'qualified candidate verification\n' > "$release_run/CopyLasso-0.1.0-verification.zip"
+
+readonly candidate_dmg_digest="$(/usr/bin/shasum -a 256 \
+    "$release_run/CopyLasso-0.1.0.dmg" | /usr/bin/awk '{print $1}')"
+readonly candidate_checksum_digest="$(/usr/bin/shasum -a 256 \
+    "$release_run/CopyLasso-0.1.0.dmg.sha256" | /usr/bin/awk '{print $1}')"
+readonly candidate_dsym_digest="$(/usr/bin/shasum -a 256 \
+    "$release_run/CopyLasso-0.1.0.dSYM.zip" | /usr/bin/awk '{print $1}')"
+readonly candidate_verification_digest="$(/usr/bin/shasum -a 256 \
+    "$release_run/CopyLasso-0.1.0-verification.zip" | /usr/bin/awk '{print $1}')"
+readonly valid_candidate="$temporary_directory/valid-candidate.json"
+/usr/bin/jq -n \
+    --rawfile body "$release_notes" \
+    --arg commit "0123456789abcdef0123456789abcdef01234567" \
+    --arg dmg_digest "sha256:$candidate_dmg_digest" \
+    --arg checksum_digest "sha256:$candidate_checksum_digest" \
+    --arg dsym_digest "sha256:$candidate_dsym_digest" \
+    --arg verification_digest "sha256:$candidate_verification_digest" \
+    '{
+        id: 124,
+        draft: true,
+        prerelease: true,
+        tag_name: "v0.1.0-rc.1",
+        target_commitish: $commit,
+        body: $body,
+        assets: [
+            {name: "CopyLasso-0.1.0.dmg", digest: $dmg_digest},
+            {name: "CopyLasso-0.1.0.dmg.sha256", digest: $checksum_digest},
+            {name: "CopyLasso-0.1.0.dSYM.zip", digest: $dsym_digest},
+            {name: "CopyLasso-0.1.0-verification.zip", digest: $verification_digest}
+        ]
+    }' > "$valid_candidate"
+assert_release_candidate_record \
+    "$valid_candidate" \
+    "0123456789abcdef0123456789abcdef01234567" \
+    "1" \
+    "$release_run" \
+    "$release_notes"
+
+/usr/bin/jq '(.assets[] | select(.name == "CopyLasso-0.1.0.dmg") | .digest) =
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' \
+    "$valid_candidate" > "$temporary_directory/bad-candidate-digest.json"
+expect_failure "uploaded release asset digest does not match" \
+    assert_release_candidate_record \
+    "$temporary_directory/bad-candidate-digest.json" \
+    "0123456789abcdef0123456789abcdef01234567" \
+    "1" \
+    "$release_run" \
+    "$release_notes"
+
+/usr/bin/jq '.body = "different notes"' \
+    "$valid_candidate" > "$temporary_directory/bad-candidate-notes.json"
+expect_failure "release notes differ from the reviewed source" \
+    assert_release_candidate_record \
+    "$temporary_directory/bad-candidate-notes.json" \
+    "0123456789abcdef0123456789abcdef01234567" \
+    "1" \
+    "$release_run" \
+    "$release_notes"
+
+printf '%064d  %s\n' 0 CopyLasso-0.1.0.dmg > \
+    "$release_run/CopyLasso-0.1.0.dmg.sha256"
+readonly mismatched_checksum_digest="$(/usr/bin/shasum -a 256 \
+    "$release_run/CopyLasso-0.1.0.dmg.sha256" | /usr/bin/awk '{print $1}')"
+/usr/bin/jq --arg digest "sha256:$mismatched_checksum_digest" '
+    (.assets[] | select(.name == "CopyLasso-0.1.0.dmg.sha256") | .digest) = $digest
+' "$valid_candidate" > "$temporary_directory/bad-candidate-checksum.json"
+expect_failure "checksum does not match the qualified disk image" \
+    assert_release_candidate_record \
+    "$temporary_directory/bad-candidate-checksum.json" \
+    "0123456789abcdef0123456789abcdef01234567" \
+    "1" \
+    "$release_run" \
+    "$release_notes"
+(
+    cd "$release_run"
+    /usr/bin/shasum -a 256 CopyLasso-0.1.0.dmg > CopyLasso-0.1.0.dmg.sha256
+)
+
+readonly valid_candidate_tag="$temporary_directory/valid-candidate-tag.json"
+printf '%s\n' '{
+  "ref": "refs/tags/v0.1.0-rc.1",
+  "object": {
+    "type": "commit",
+    "sha": "0123456789abcdef0123456789abcdef01234567"
+  }
+}' > "$valid_candidate_tag"
+assert_release_candidate_tag_record \
+    "$valid_candidate_tag" \
+    "0123456789abcdef0123456789abcdef01234567" \
+    "v0.1.0-rc.1"
+/usr/bin/sed 's/"type": "commit"/"type": "tag"/' \
+    "$valid_candidate_tag" > "$temporary_directory/annotated-candidate-tag.json"
+expect_failure "does not point directly to the candidate commit" \
+    assert_release_candidate_tag_record \
+    "$temporary_directory/annotated-candidate-tag.json" \
+    "0123456789abcdef0123456789abcdef01234567" \
+    "v0.1.0-rc.1"
+/usr/bin/sed \
+    's/0123456789abcdef0123456789abcdef01234567/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/' \
+    "$valid_candidate_tag" > "$temporary_directory/wrong-candidate-tag.json"
+expect_failure "does not point directly to the candidate commit" \
+    assert_release_candidate_tag_record \
+    "$temporary_directory/wrong-candidate-tag.json" \
+    "0123456789abcdef0123456789abcdef01234567" \
+    "v0.1.0-rc.1"
+
 readonly fake_gh="$temporary_directory/gh"
 readonly fake_gh_log="$temporary_directory/gh.log"
+readonly fake_gh_tag_state="$temporary_directory/tag-created"
 cat > "$fake_gh" <<'SCRIPT'
 #!/bin/bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$FAKE_GH_LOG"
 if [[ "$1" == "api" && "$*" == *"releases/tags/"* ]]; then
+    if [[ "${FAKE_GH_MODE:-success}" == "preexisting-release" ]]; then
+        /bin/cat "$FAKE_GH_RECORD"
+        exit 0
+    fi
     exit 1
 fi
-if [[ "$1" == "api" && "$*" == *"--method POST"* ]]; then
+if [[ "$1" == "api" && "$*" == *"--method DELETE"* && "$*" == *"git/refs/tags/"* ]]; then
+    /bin/rm -f "$FAKE_GH_TAG_STATE"
+    exit 0
+fi
+if [[ "$1" == "api" && "$*" == *"--method DELETE"* ]]; then
+    exit 0
+fi
+if [[ "$1" == "api" && "$*" == *"git/ref/tags/"* ]]; then
+    if [[ "${FAKE_GH_MODE:-success}" == "preexisting-tag" || -f "$FAKE_GH_TAG_STATE" ]]; then
+        [[ "${FAKE_GH_MODE:-success}" != "tag-readback-fail" ]] || exit 1
+        /bin/cat "$FAKE_GH_TAG_RECORD"
+        exit 0
+    fi
+    exit 1
+fi
+if [[ "$1" == "api" && "$*" == *"--method POST"* && "$*" == *"git/refs"* ]]; then
+    [[ "${FAKE_GH_MODE:-success}" != "tag-create-fail" ]] || exit 1
+    : > "$FAKE_GH_TAG_STATE"
+    /bin/cat "$FAKE_GH_TAG_RECORD"
+    exit 0
+fi
+if [[ "$1" == "api" && "$*" == *"--method POST"* && "$*" == *"/releases"* ]]; then
     printf '{"id":123}\n'
     exit 0
 fi
 if [[ "$1" == "release" && "$2" == "upload" ]]; then
     [[ "${FAKE_GH_MODE:-success}" != "upload-fail" ]]
     exit
-fi
-if [[ "$1" == "api" && "$*" == *"--method DELETE"* ]]; then
-    exit 0
 fi
 if [[ "$1" == "api" && "$*" == *"releases/123"* ]]; then
     /bin/cat "$FAKE_GH_RECORD"
@@ -210,6 +367,8 @@ export GH_TOKEN="test-only"
 export COPYLASSO_GH_BIN="$fake_gh"
 export FAKE_GH_LOG="$fake_gh_log"
 export FAKE_GH_RECORD="$valid_draft"
+export FAKE_GH_TAG_RECORD="$valid_candidate_tag"
+export FAKE_GH_TAG_STATE="$fake_gh_tag_state"
 export FAKE_GH_MODE="success"
 "$draft_creator" \
     --repository owner/repository \
@@ -224,6 +383,9 @@ assert_release_draft_record \
 if /usr/bin/grep -Fq -- '--method DELETE' "$fake_gh_log"; then
     fail "A successful draft must not be rolled back."
 fi
+if /usr/bin/grep -Fq -- 'git/refs' "$fake_gh_log"; then
+    fail "The G28 rehearsal must not create or inspect a Git tag ref."
+fi
 
 : > "$fake_gh_log"
 export FAKE_GH_MODE="upload-fail"
@@ -237,6 +399,80 @@ expect_failure "asset set could not be uploaded" \
 /usr/bin/grep -Fq -- '--method DELETE' "$fake_gh_log" || \
     fail "A partial draft upload must delete the incomplete draft."
 
-unset GH_TOKEN COPYLASSO_GH_BIN FAKE_GH_LOG FAKE_GH_RECORD FAKE_GH_MODE
+: > "$fake_gh_log"
+/bin/rm -f "$fake_gh_tag_state"
+export FAKE_GH_MODE="success"
+export FAKE_GH_RECORD="$valid_candidate"
+"$draft_creator" \
+    --repository owner/repository \
+    --commit 0123456789abcdef0123456789abcdef01234567 \
+    --candidate-number 1 \
+    --run-dir "$release_run" \
+    --readback "$temporary_directory/candidate-readback.json"
+assert_release_candidate_record \
+    "$temporary_directory/candidate-readback.json" \
+    "0123456789abcdef0123456789abcdef01234567" \
+    "1" \
+    "$release_run" \
+    "$release_notes"
+[[ -f "$fake_gh_tag_state" ]] || fail "The verified RC transaction must create its tag."
+/usr/bin/grep -Fq -- '--method POST repos/owner/repository/git/refs' "$fake_gh_log" || \
+    fail "The verified RC transaction must create its tag through the Git ref API."
+if /usr/bin/grep -Eq -- '--method (DELETE|PATCH)|--clobber|force=' "$fake_gh_log"; then
+    fail "A successful RC transaction must not delete, overwrite, or force-update state."
+fi
+
+: > "$fake_gh_log"
+/bin/rm -f "$fake_gh_tag_state"
+export FAKE_GH_MODE="preexisting-release"
+expect_failure "release already exists for the release-candidate tag" \
+    "$draft_creator" \
+    --repository owner/repository \
+    --commit 0123456789abcdef0123456789abcdef01234567 \
+    --candidate-number 1 \
+    --run-dir "$release_run" \
+    --readback "$temporary_directory/preexisting-release.json"
+if /usr/bin/grep -Fq -- '--method POST' "$fake_gh_log"; then
+    fail "A pre-existing release must prevent every RC mutation."
+fi
+
+: > "$fake_gh_log"
+/bin/rm -f "$fake_gh_tag_state"
+export FAKE_GH_MODE="preexisting-tag"
+expect_failure "tag already exists for the release candidate" \
+    "$draft_creator" \
+    --repository owner/repository \
+    --commit 0123456789abcdef0123456789abcdef01234567 \
+    --candidate-number 1 \
+    --run-dir "$release_run" \
+    --readback "$temporary_directory/preexisting-tag.json"
+if /usr/bin/grep -Fq -- '--method POST' "$fake_gh_log"; then
+    fail "A pre-existing tag must prevent every RC mutation."
+fi
+
+for failure_mode in upload-fail tag-create-fail tag-readback-fail; do
+    : > "$fake_gh_log"
+    /bin/rm -f "$fake_gh_tag_state"
+    export FAKE_GH_MODE="$failure_mode"
+    expect_failure "release-candidate transaction" \
+        "$draft_creator" \
+        --repository owner/repository \
+        --commit 0123456789abcdef0123456789abcdef01234567 \
+        --candidate-number 1 \
+        --run-dir "$release_run" \
+        --readback "$temporary_directory/$failure_mode.json"
+    /usr/bin/grep -Fq -- '--method DELETE repos/owner/repository/releases/123' \
+        "$fake_gh_log" || fail "A failed RC transaction must delete its incomplete draft."
+    if [[ "$failure_mode" == "tag-readback-fail" ]]; then
+        /usr/bin/grep -Fq -- \
+            '--method DELETE repos/owner/repository/git/refs/tags/v0.1.0-rc.1' \
+            "$fake_gh_log" || fail "A failed RC tag readback must delete its newly created tag."
+    fi
+    [[ ! -f "$fake_gh_tag_state" ]] || \
+        fail "A failed RC transaction must not retain a tag created by that invocation."
+done
+
+unset GH_TOKEN COPYLASSO_GH_BIN FAKE_GH_LOG FAKE_GH_RECORD \
+    FAKE_GH_TAG_RECORD FAKE_GH_TAG_STATE FAKE_GH_MODE
 
 echo "Protected-release workflow tests passed."

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -326,6 +326,19 @@ if [[ "$1" == "api" && "$*" == *"releases/tags/"* ]]; then
     fi
     exit 1
 fi
+if [[ "$1" == "api" && "$*" == *"/releases?per_page=100"* ]]; then
+    [[ "${FAKE_GH_MODE:-success}" != "release-list-fail" ]] || exit 1
+    if [[ "${FAKE_GH_MODE:-success}" == "release-list-invalid" ]]; then
+        printf '{}\n'
+        exit 0
+    fi
+    if [[ "${FAKE_GH_MODE:-success}" == "preexisting-draft" ]]; then
+        /usr/bin/jq -n --slurpfile release "$FAKE_GH_RECORD" '[ $release ]'
+    else
+        printf '[[]]\n'
+    fi
+    exit 0
+fi
 if [[ "$1" == "api" && "$*" == *"--method DELETE"* && "$*" == *"git/refs/tags/"* ]]; then
     /bin/rm -f "$FAKE_GH_TAG_STATE"
     exit 0
@@ -418,6 +431,9 @@ assert_release_candidate_record \
 [[ -f "$fake_gh_tag_state" ]] || fail "The verified RC transaction must create its tag."
 /usr/bin/grep -Fq -- '--method POST repos/owner/repository/git/refs' "$fake_gh_log" || \
     fail "The verified RC transaction must create its tag through the Git ref API."
+/usr/bin/grep -Fq -- \
+    '--paginate --slurp repos/owner/repository/releases?per_page=100' \
+    "$fake_gh_log" || fail "The verified RC transaction must inspect every existing release."
 if /usr/bin/grep -Eq -- '--method (DELETE|PATCH)|--clobber|force=' "$fake_gh_log"; then
     fail "A successful RC transaction must not delete, overwrite, or force-update state."
 fi
@@ -434,6 +450,36 @@ expect_failure "release already exists for the release-candidate tag" \
     --readback "$temporary_directory/preexisting-release.json"
 if /usr/bin/grep -Fq -- '--method POST' "$fake_gh_log"; then
     fail "A pre-existing release must prevent every RC mutation."
+fi
+
+for failure_mode in release-list-fail release-list-invalid; do
+    : > "$fake_gh_log"
+    /bin/rm -f "$fake_gh_tag_state"
+    export FAKE_GH_MODE="$failure_mode"
+    expect_failure "release" \
+        "$draft_creator" \
+        --repository owner/repository \
+        --commit 0123456789abcdef0123456789abcdef01234567 \
+        --candidate-number 1 \
+        --run-dir "$release_run" \
+        --readback "$temporary_directory/$failure_mode.json"
+    if /usr/bin/grep -Fq -- '--method POST' "$fake_gh_log"; then
+        fail "An unavailable or invalid release listing must prevent every RC mutation."
+    fi
+done
+
+: > "$fake_gh_log"
+/bin/rm -f "$fake_gh_tag_state"
+export FAKE_GH_MODE="preexisting-draft"
+expect_failure "release already exists for the release-candidate tag" \
+    "$draft_creator" \
+    --repository owner/repository \
+    --commit 0123456789abcdef0123456789abcdef01234567 \
+    --candidate-number 1 \
+    --run-dir "$release_run" \
+    --readback "$temporary_directory/preexisting-draft.json"
+if /usr/bin/grep -Fq -- '--method POST' "$fake_gh_log"; then
+    fail "A pre-existing draft must prevent every RC mutation."
 fi
 
 : > "$fake_gh_log"

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -357,6 +357,7 @@ fi
 if [[ "$1" == "api" && "$*" == *"--method POST"* && "$*" == *"git/refs"* ]]; then
     [[ "${FAKE_GH_MODE:-success}" != "tag-create-fail" ]] || exit 1
     : > "$FAKE_GH_TAG_STATE"
+    [[ "${FAKE_GH_MODE:-success}" != "tag-create-uncertain" ]] || exit 1
     /bin/cat "$FAKE_GH_TAG_RECORD"
     exit 0
 fi
@@ -436,6 +437,21 @@ assert_release_candidate_record \
     "$fake_gh_log" || fail "The verified RC transaction must inspect every existing release."
 if /usr/bin/grep -Eq -- '--method (DELETE|PATCH)|--clobber|force=' "$fake_gh_log"; then
     fail "A successful RC transaction must not delete, overwrite, or force-update state."
+fi
+
+: > "$fake_gh_log"
+/bin/rm -f "$fake_gh_tag_state"
+export FAKE_GH_MODE="tag-create-uncertain"
+"$draft_creator" \
+    --repository owner/repository \
+    --commit 0123456789abcdef0123456789abcdef01234567 \
+    --candidate-number 1 \
+    --run-dir "$release_run" \
+    --readback "$temporary_directory/uncertain-tag-readback.json"
+[[ -f "$fake_gh_tag_state" ]] || \
+    fail "An ambiguously created exact tag must be retained after successful readback."
+if /usr/bin/grep -Fq -- '--method DELETE' "$fake_gh_log"; then
+    fail "An ambiguously created exact tag must complete without rollback."
 fi
 
 : > "$fake_gh_log"


### PR DESCRIPTION
## Summary

- add a protected G30 release-candidate mode driven only by a validated positive candidate number
- verify exact release notes, four uploaded asset digests, the DMG checksum, and a direct tag-to-commit readback before retaining the draft
- document the bounded disposable-account qualification matrix, accepted evidence gaps, and final 0.1.0 release notes
- preserve the completed G28 rehearsal path and refuse existing tags, releases, overwrites, force updates, or publication

## Verification

- `./scripts/test-release-workflow.sh`
- `./scripts/audit-release-workflow.sh`
- `./scripts/test-ci-contract.sh`
- `./scripts/audit-privacy-security.sh`
- Developer ID and release-package audit/test pairs
- `./scripts/ci.sh`
- `COPYLASSO_CI_ARCH=x86_64 ./scripts/ci.sh`
- `git diff --cached --check`

Both canonical pipelines passed with zero test failures and Universal 2 Release products containing arm64 and x86_64.

## Boundary

This PR enables G30 Phase 1 only. It does not dispatch the protected release workflow, create an RC tag or draft, publish a release, or begin G31. The source PR must be green, reviewed, and separately merged before Phase 2 runs from protected main.
