### PR TITLE
G31: publish CopyLasso v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to CopyLasso will be documented in this file.
 
 ## Unreleased
 
-## 0.1.0 - Unreleased
+## 0.1.0 - 2026-07-19
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to CopyLasso
 
-Thank you for helping build CopyLasso. The project is still in early pre-release development, so focused changes that preserve the approved v0.1 scope are the easiest to review.
+Thank you for helping build CopyLasso. CopyLasso 0.1.0 is publicly released. Focused changes that preserve its privacy and reliability contracts are the easiest to review; new product scope requires a separately approved post-v0.1 roadmap and product-contract update.
 
 ## Before Making a Change
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # CopyLasso Privacy
 
-**Status:** Approved privacy contract for the pre-release v0.1 application.
+**Status:** Approved privacy contract for CopyLasso 0.1.0.
 
 CopyLasso is designed as a local-first macOS utility. Its core job is to capture a user-selected screen region, recognize visible text, and place the result on the clipboard without uploading or retaining the captured content.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CopyLasso is a free and open-source macOS utility for copying visible text from anywhere on screen. Press `⇧⌘2`, drag around text, and receive recognized plain text on the clipboard. Recognition runs locally with Apple's Vision framework, and CopyLasso does not retain a screenshot or OCR history.
 
-> **Pre-release status:** Version 0.1.0 is being prepared and is not available for public download yet. This page previews the installation and usage flow that the signed, notarized release will provide.
+CopyLasso 0.1.0 is the latest public release.
 
 ## Requirements
 
@@ -12,17 +12,25 @@ CopyLasso is a free and open-source macOS utility for copying visible text from 
 - An Apple silicon or Intel Mac; the release is a native Universal 2 application
 - Screen Recording permission for region capture
 
-## Installation Preview
+## Install CopyLasso
 
-The public release will be distributed as a signed and notarized disk image from this repository's GitHub Releases page. When it is published:
+Download CopyLasso 0.1.0 from the [release page](https://github.com/bennetthilberg/copylasso/releases/tag/v0.1.0):
 
-1. Download `CopyLasso-0.1.0.dmg` and compare its SHA-256 checksum with the value on the release page.
-2. Open the disk image and drag CopyLasso into Applications.
-3. Open CopyLasso. It runs in the menu bar and does not add a Dock icon.
-4. Complete the short first-run setup and keep the suggested `⇧⌘2` shortcut or record another one.
-5. The first capture asks macOS for Screen Recording permission. Approve CopyLasso, then choose **Quit & Reopen** if macOS offers it.
+- [CopyLasso-0.1.0.dmg](https://github.com/bennetthilberg/copylasso/releases/download/v0.1.0/CopyLasso-0.1.0.dmg)
+- [CopyLasso-0.1.0.dmg.sha256](https://github.com/bennetthilberg/copylasso/releases/download/v0.1.0/CopyLasso-0.1.0.dmg.sha256)
 
-No unsigned download or placeholder release link is provided before the qualified artifact is published.
+Place both files in the same folder, then verify the download before opening it:
+
+```sh
+shasum -a 256 -c CopyLasso-0.1.0.dmg.sha256
+```
+
+The result must report `CopyLasso-0.1.0.dmg: OK`. Then:
+
+1. Open `CopyLasso-0.1.0.dmg` and drag CopyLasso into Applications.
+2. Open CopyLasso. It runs in the menu bar and does not add a Dock icon.
+3. Complete the short first-run setup and keep the suggested `⇧⌘2` shortcut or record another one.
+4. The first capture asks macOS for Screen Recording permission. Approve CopyLasso, then choose **Quit & Reopen** if macOS offers it.
 
 ## Use CopyLasso
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,11 @@
 
 ## Supported Versions
 
-CopyLasso is in pre-release development and does not yet have a supported public release. Security reports about the source, planned application behavior, build process, or repository configuration are still welcome.
+CopyLasso 0.1.x is the currently supported public release line. Security reports about the released application, source, build process, or repository configuration are welcome.
+
+| Version | Supported |
+| --- | --- |
+| 0.1.x | Yes |
 
 ## Report a Vulnerability Privately
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -69,10 +69,10 @@ matrix and accepted-risk record.
 
 ## G31 - Final Tag And Publication
 
-- [ ] Confirm every required prior gate is green, every accepted evidence gap is recorded, and no source or artifact has changed since candidate qualification.
-- [ ] Create the final `v0.1.0` tag on the same commit as the qualified release candidate and verify the tag remotely.
-- [ ] Date the `0.1.0` changelog entry, update the README download link and checksum instructions, and verify the final documentation commit relationship required by the roadmap.
-- [ ] Publish only the exact qualified DMG and checksum assets; never replace an asset under an existing release tag.
-- [ ] Download the public artifacts in a fresh browser session, verify hashes, signatures, notarization, version/build, and successful launch, then record the public URLs and results.
-- [ ] Confirm the release page, repository homepage, security policy, contribution link, privacy policy, license, and third-party notices are reachable.
-- [ ] Announce completion only after the post-publication smoke check is green.
+- [x] Confirm every required prior gate is green, every accepted evidence gap is recorded, and no source or artifact has changed since candidate qualification.
+- [x] Create the final `v0.1.0` tag on the same commit as the qualified release candidate and verify the tag remotely.
+- [x] Date the `0.1.0` changelog entry, update the README download link and checksum instructions, and verify the final documentation commit relationship required by the roadmap.
+- [x] Publish only the exact qualified DMG and checksum assets; never replace an asset under an existing release tag.
+- [x] Download the public artifacts in a fresh browser session, verify hashes, signatures, notarization, version/build, and successful launch, then record the public URLs and results.
+- [x] Confirm the release page, repository homepage, security policy, contribution link, privacy policy, license, and third-party notices are reachable.
+- [x] Announce completion only after the post-publication smoke check is green.

--- a/docs/security-and-privacy-review.md
+++ b/docs/security-and-privacy-review.md
@@ -1,6 +1,6 @@
 # Security And Privacy Review
 
-This review describes CopyLasso's pre-release v0.1 implementation boundary. It reconciles the source, built products, dependency graph, entitlements, persistence, and public privacy promises.
+This review describes the public CopyLasso 0.1.0 implementation boundary. It reconciles the source, built products, dependency graph, entitlements, persistence, and public privacy promises.
 
 ## Result
 
@@ -49,7 +49,7 @@ An inspected development container contained preference/window metadata, one 240
 
 Settings links ask macOS to open the user's default browser. CopyLasso itself does not fetch those URLs. Releases are downloaded manually; v0.1 has no automatic updater.
 
-Local Apple Development signing adds `com.apple.security.get-task-allow` to both audited development-signed products. That key is not present in the tracked product entitlement. G26 must read back the final Developer ID-signed archive and reject `get-task-allow` or any entitlement beyond App Sandbox before notarization.
+Local Apple Development signing adds `com.apple.security.get-task-allow` to audited development-signed products. That key is not present in the tracked product entitlement or shipped Developer ID artifact. The released application was verified to contain only the Boolean App Sandbox entitlement, with no `get-task-allow` or unreviewed capability, before and after notarization.
 
 ## Trust Boundaries And Misuse Cases
 

--- a/docs/v0.1-product-contract.md
+++ b/docs/v0.1-product-contract.md
@@ -2,7 +2,7 @@
 
 - **Status:** Approved scope for the first public release
 - **Approved:** July 9, 2026
-- **Implementation status:** Release-candidate qualification
+- **Implementation status:** Released as 0.1.0 on July 19, 2026
 
 This document defines CopyLasso's user-visible v0.1 promises. It is the public source of truth for product scope, supported systems, privacy guarantees, known boundaries, and release completion. It does not describe the internal development workflow.
 

--- a/scripts/audit-brand-release.sh
+++ b/scripts/audit-brand-release.sh
@@ -147,7 +147,7 @@ fi
 
 for text in \
     '## Requirements' \
-    '## Installation Preview' \
+    '## Install CopyLasso' \
     '## Use CopyLasso' \
     '## Permission and Recovery' \
     '## Privacy' \
@@ -160,8 +160,14 @@ for text in \
     require_text README.md "$text"
 done
 
-require_text CHANGELOG.md '## 0.1.0 - Unreleased'
+require_text README.md 'https://github.com/bennetthilberg/copylasso/releases/tag/v0.1.0'
+require_text README.md 'https://github.com/bennetthilberg/copylasso/releases/download/v0.1.0/CopyLasso-0.1.0.dmg'
+require_text README.md 'https://github.com/bennetthilberg/copylasso/releases/download/v0.1.0/CopyLasso-0.1.0.dmg.sha256'
+require_text CHANGELOG.md '## 0.1.0 - 2026-07-19'
 require_text CHANGELOG.md 'pasteboard clear-success followed by text-write rejection'
+require_text SECURITY.md 'CopyLasso 0.1.x'
+require_text CONTRIBUTING.md 'CopyLasso 0.1.0 is publicly released.'
+require_text PRIVACY.md '**Status:** Approved privacy contract for CopyLasso 0.1.0.'
 require_text docs/release-checklist.md '## G26 - Developer ID Signing And Notarization'
 require_text docs/release-checklist.md '## G27 - Reproducible Release Package'
 require_text docs/release-checklist.md '## G28 - Protected Release Workflow'
@@ -196,12 +202,18 @@ require_text docs/clean-install-testing.md '## G29 Partial Rehearsal Record'
 require_text docs/clean-install-testing.md 'accepted evidence gaps'
 require_text docs/v0.1-product-contract.md 'Before download, that account must have no CopyLasso application, production'
 require_text docs/v0.1-product-contract.md 'preferences, production container, login item, or Screen Recording approval.'
-require_text docs/v0.1-product-contract.md '**Implementation status:** Release-candidate qualification'
+require_text docs/v0.1-product-contract.md '**Implementation status:** Released as 0.1.0 on July 19, 2026'
 require_text docs/v0.1-product-contract.md 'clipboard may change'
+require_text docs/security-and-privacy-review.md \
+    'This review describes the public CopyLasso 0.1.0 implementation boundary.'
 require_text docs/release-candidate-qualification.md '## Exact Candidate Smoke Matrix'
 require_text docs/release-candidate-qualification.md 'Do not resume VirtualBuddy'
 require_text docs/release-notes/0.1.0.md 'CopyLasso 0.1.0'
 require_text docs/release-notes/0.1.0.md 'Locking the Mac during an active drag'
+if [[ "$(/usr/bin/sed -n '/^## G31 - Final Tag And Publication$/,$p' \
+    docs/release-checklist.md | /usr/bin/grep -c '^- \[x\]')" != 7 ]]; then
+    fail "Every G31 publication checklist row must be complete."
+fi
 require_text docs/brand-assets.md 'The final pre-artifact exact-name review was repeated on July 14, 2026'
 require_text THIRD_PARTY_NOTICES.md 'KeyboardShortcuts 3.0.1'
 require_text THIRD_PARTY_NOTICES.md 'License: MIT'

--- a/scripts/audit-release-workflow.sh
+++ b/scripts/audit-release-workflow.sh
@@ -258,7 +258,8 @@ for required_release_note_text in \
     'clipboard'; do
     require_text "$release_notes" "$required_release_note_text"
 done
-require_text "$product_contract" '**Implementation status:** Release-candidate qualification'
+require_text "$product_contract" \
+    '**Implementation status:** Released as 0.1.0 on July 19, 2026'
 require_text "$product_contract" 'lock during an active drag'
 require_text "$product_contract" 'clipboard may change'
 


### PR DESCRIPTION
## Summary

- document CopyLasso 0.1.0 as the latest public release with direct DMG and checksum links
- date the changelog and reconcile security, privacy, contribution, product-contract, and checklist status
- require the released state through the existing brand and protected-release audits

## Release verification

- published v0.1.0 from the approved v0.1.0-rc.1 candidate without rebuilding
- verified public download, checksum, Developer ID signature, notarization, Gatekeeper, Universal 2, source archives, install, launch, capture, clipboard, HUD, and quit
- retained the private rehearsal and release-candidate drafts unchanged

## Tests

- ./scripts/ci.sh
- COPYLASSO_CI_ARCH=x86_64 ./scripts/ci.sh
- focused brand, release-workflow, privacy/security, packaging, Developer ID, CI-contract, and whitespace audits