### PR TITLE
Fix settings window presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to CopyLasso will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Settings now appears immediately when opened from the menu instead of surfacing during the next capture.
+
 ## 0.1.0 - 2026-07-19
 
 ### Added

--- a/CopyLasso/App/MenuBarCommandHandler.swift
+++ b/CopyLasso/App/MenuBarCommandHandler.swift
@@ -1,7 +1,10 @@
+import AppKit
+
 @MainActor
 final class MenuBarCommandHandler {
   private let captureCommand: CaptureCommand
   private let applicationTerminator: any ApplicationTerminating
+  private let activateApplication: () -> Void
 
   var isCaptureEnabled: Bool {
     captureCommand.isEnabled
@@ -9,15 +12,24 @@ final class MenuBarCommandHandler {
 
   init(
     captureCommand: CaptureCommand,
-    applicationTerminator: any ApplicationTerminating
+    applicationTerminator: any ApplicationTerminating,
+    activateApplication: @escaping () -> Void = {
+      NSApp.activate(ignoringOtherApps: true)
+    }
   ) {
     self.captureCommand = captureCommand
     self.applicationTerminator = applicationTerminator
+    self.activateApplication = activateApplication
   }
 
   @discardableResult
   func captureText() -> CaptureTransitionResult {
     captureCommand.perform()
+  }
+
+  func openSettings(_ open: () -> Void) {
+    activateApplication()
+    open()
   }
 
   func quit() {

--- a/CopyLasso/SharedUI/MenuBarMenuView.swift
+++ b/CopyLasso/SharedUI/MenuBarMenuView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct MenuBarMenuView: View {
+  @Environment(\.openSettings) private var openSettings
   @Environment(\.openWindow) private var openWindow
 
   let commandHandler: MenuBarCommandHandler
@@ -14,8 +15,10 @@ struct MenuBarMenuView: View {
 
     Divider()
 
-    SettingsLink {
-      Text("Settings…")
+    Button("Settings…") {
+      commandHandler.openSettings {
+        openSettings()
+      }
     }
     .keyboardShortcut(",", modifiers: .command)
     .accessibilityIdentifier("copylasso.menu.settings")

--- a/CopyLassoTests/App/MenuBarShellTests.swift
+++ b/CopyLassoTests/App/MenuBarShellTests.swift
@@ -5,6 +5,25 @@ import XCTest
 
 @MainActor
 final class MenuBarShellTests: XCTestCase {
+  func testOpeningSettingsActivatesApplicationBeforeOpeningSettings() {
+    var events: [String] = []
+    let coordinator = CaptureCoordinator()
+    let handler = MenuBarCommandHandler(
+      captureCommand: makeTestCaptureCommand(
+        coordinator: coordinator,
+        scheduleWork: { _ in }
+      ),
+      applicationTerminator: SpyApplicationTerminator(),
+      activateApplication: { events.append("activate") }
+    )
+
+    handler.openSettings {
+      events.append("open settings")
+    }
+
+    XCTAssertEqual(events, ["activate", "open settings"])
+  }
+
   func testQuitRoutesToTheInjectedApplicationTerminatorExactlyOnce() {
     let terminator = SpyApplicationTerminator()
     let coordinator = CaptureCoordinator()

--- a/CopyLassoUITests/CopyLassoUITests.swift
+++ b/CopyLassoUITests/CopyLassoUITests.swift
@@ -220,6 +220,21 @@ final class CopyLassoUITests: XCTestCase {
   }
 
   @MainActor
+  func testSettingsOpenedFromMenuWhileFinderIsFrontmostAppearsImmediately() {
+    let app = completedApp()
+    app.launch()
+    defer { app.terminate() }
+
+    XCUIApplication(bundleIdentifier: "com.apple.finder").activate()
+    openMenu(in: app)
+    menuItem("Settings…", in: app).click()
+
+    XCTAssertTrue(
+      app.staticTexts["copylasso.settings.title"].waitForExistence(timeout: 5)
+    )
+  }
+
+  @MainActor
   private func assertAccessibleText(
     _ element: XCUIElement,
     equals expected: String,


### PR DESCRIPTION
## Summary

- activate CopyLasso before opening Settings from the status menu
- prevent a hidden Settings window from surfacing during the next capture
- add unit and UI regressions for activation order and Finder-frontmost presentation

## Verification

- focused MenuBarShellTests: 6 passed
- Finder-frontmost signed UI regression: passed
- canonical arm64 pipeline: passed
- canonical x86_64 pipeline: passed
- swift-format lint and git diff checks: passed