### PR TITLE
G32: close v0.1.1 release state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to CopyLasso will be documented in this file.
 
 ## Unreleased
 
-## 0.1.1 - Unreleased
+## 0.1.1 - 2026-07-21
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to CopyLasso
 
-Thank you for helping build CopyLasso. CopyLasso 0.1.0 is publicly released. Focused changes that preserve its privacy and reliability contracts are the easiest to review; new product scope requires a separately approved post-v0.1 roadmap and product-contract update.
+Thank you for helping build CopyLasso. CopyLasso 0.1.1 is publicly released. Focused changes that preserve its privacy and reliability contracts are the easiest to review; new product scope requires a separately approved post-v0.1 roadmap and product-contract update.
 
 ## Before Making a Change
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # CopyLasso Privacy
 
-**Status:** Approved privacy contract for CopyLasso 0.1.0.
+**Status:** Approved privacy contract for CopyLasso 0.1.x, including the current 0.1.1 release.
 
 CopyLasso is designed as a local-first macOS utility. Its core job is to capture a user-selected screen region, recognize visible text, and place the result on the clipboard without uploading or retaining the captured content.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CopyLasso is a free and open-source macOS utility for copying visible text from anywhere on screen. Press `⇧⌘2`, drag around text, and receive recognized plain text on the clipboard. Recognition runs locally with Apple's Vision framework, and CopyLasso does not retain a screenshot or OCR history.
 
-CopyLasso 0.1.0 is the latest public release.
+CopyLasso 0.1.1 is the latest public release.
 
 ## Requirements
 
@@ -14,20 +14,20 @@ CopyLasso 0.1.0 is the latest public release.
 
 ## Install CopyLasso
 
-Download CopyLasso 0.1.0 from the [release page](https://github.com/bennetthilberg/copylasso/releases/tag/v0.1.0):
+Download CopyLasso 0.1.1 from the [release page](https://github.com/bennetthilberg/copylasso/releases/tag/v0.1.1):
 
-- [CopyLasso-0.1.0.dmg](https://github.com/bennetthilberg/copylasso/releases/download/v0.1.0/CopyLasso-0.1.0.dmg)
-- [CopyLasso-0.1.0.dmg.sha256](https://github.com/bennetthilberg/copylasso/releases/download/v0.1.0/CopyLasso-0.1.0.dmg.sha256)
+- [CopyLasso-0.1.1.dmg](https://github.com/bennetthilberg/copylasso/releases/download/v0.1.1/CopyLasso-0.1.1.dmg)
+- [CopyLasso-0.1.1.dmg.sha256](https://github.com/bennetthilberg/copylasso/releases/download/v0.1.1/CopyLasso-0.1.1.dmg.sha256)
 
 Place both files in the same folder, then verify the download before opening it:
 
 ```sh
-shasum -a 256 -c CopyLasso-0.1.0.dmg.sha256
+shasum -a 256 -c CopyLasso-0.1.1.dmg.sha256
 ```
 
-The result must report `CopyLasso-0.1.0.dmg: OK`. Then:
+The result must report `CopyLasso-0.1.1.dmg: OK`. Then:
 
-1. Open `CopyLasso-0.1.0.dmg` and drag CopyLasso into Applications.
+1. Open `CopyLasso-0.1.1.dmg` and drag CopyLasso into Applications.
 2. Open CopyLasso. It runs in the menu bar and does not add a Dock icon.
 3. Complete the short first-run setup and keep the suggested `⇧⌘2` shortcut or record another one.
 4. The first capture asks macOS for Screen Recording permission. Approve CopyLasso, then choose **Quit & Reopen** if macOS offers it.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -79,10 +79,10 @@ matrix and accepted-risk record.
 
 ## G32 - v0.1.1 Settings Hotfix
 
-- [ ] Confirm the exact protected commit contains the merged Settings presentation fix, version `0.1.1`, build `2`, and no unrelated application behavior.
-- [ ] Pass the release-metadata, Developer ID, package, protected-workflow, brand, privacy, CI-contract, canonical arm64/x86_64, and macOS 14 gates.
-- [ ] After separate pull-request merge approval, dispatch candidate `v0.1.1-rc.N` from that exact protected `main` commit and approve only the protected release environment.
-- [ ] Read back the private draft, four exact assets, reviewed `0.1.1` notes, checksums, GitHub digests, target commit, signed application, notarization, Gatekeeper result, version/build, Universal 2 slices, and two-item DMG layout.
-- [ ] Create a signed annotated `v0.1.1` tag on the qualified commit, publish only the exact DMG and checksum as the latest non-prerelease release, and leave `v0.1.0` plus all private historical drafts unchanged.
-- [ ] Download the public DMG with genuine quarantine, repeat checksum/signature/notarization/Gatekeeper/install verification, and smoke Settings plus one capture.
-- [ ] With action-time confirmation, reset only `ScreenCapture` for `io.github.bennetthilberg.copylasso`, grant the public app once, and verify one current CopyLasso privacy row.
+- [x] Confirm the exact protected commit contains the merged Settings presentation fix, version `0.1.1`, build `2`, and no unrelated application behavior.
+- [x] Pass the release-metadata, Developer ID, package, protected-workflow, brand, privacy, CI-contract, canonical arm64/x86_64, and macOS 14 gates.
+- [x] After separate pull-request merge approval, dispatch candidate `v0.1.1-rc.N` from that exact protected `main` commit and approve only the protected release environment.
+- [x] Read back the private draft, four exact assets, reviewed `0.1.1` notes, checksums, GitHub digests, target commit, signed application, notarization, Gatekeeper result, version/build, Universal 2 slices, and two-item DMG layout.
+- [x] Create a signed annotated `v0.1.1` tag on the qualified commit, publish only the exact DMG and checksum as the latest non-prerelease release, and leave `v0.1.0` plus all private historical drafts unchanged.
+- [x] Download the public DMG with genuine quarantine, repeat checksum/signature/notarization/Gatekeeper/install verification, and smoke Settings plus one capture.
+- [x] With action-time confirmation, reset only `ScreenCapture` for `io.github.bennetthilberg.copylasso`, grant the public app once, and verify one current CopyLasso privacy row.

--- a/docs/security-and-privacy-review.md
+++ b/docs/security-and-privacy-review.md
@@ -1,6 +1,6 @@
 # Security And Privacy Review
 
-This review describes the public CopyLasso 0.1.0 implementation boundary. It reconciles the source, built products, dependency graph, entitlements, persistence, and public privacy promises.
+This review describes the public CopyLasso 0.1.x implementation boundary, including the current 0.1.1 release. It reconciles the source, built products, dependency graph, entitlements, persistence, and public privacy promises.
 
 ## Result
 

--- a/docs/v0.1-product-contract.md
+++ b/docs/v0.1-product-contract.md
@@ -2,7 +2,7 @@
 
 - **Status:** Approved scope for the first public release
 - **Approved:** July 9, 2026
-- **Implementation status:** Released as 0.1.0 on July 19, 2026
+- **Implementation status:** Released as 0.1.0 on July 19, 2026; maintained as 0.1.1 on July 21, 2026
 
 This document defines CopyLasso's user-visible v0.1 promises. It is the public source of truth for product scope, supported systems, privacy guarantees, known boundaries, and release completion. It does not describe the internal development workflow.
 

--- a/scripts/audit-brand-release.sh
+++ b/scripts/audit-brand-release.sh
@@ -166,15 +166,16 @@ for text in \
     require_text README.md "$text"
 done
 
-require_text README.md 'https://github.com/bennetthilberg/copylasso/releases/tag/v0.1.0'
-require_text README.md 'https://github.com/bennetthilberg/copylasso/releases/download/v0.1.0/CopyLasso-0.1.0.dmg'
-require_text README.md 'https://github.com/bennetthilberg/copylasso/releases/download/v0.1.0/CopyLasso-0.1.0.dmg.sha256'
-require_text CHANGELOG.md '## 0.1.1 - Unreleased'
+require_text README.md 'CopyLasso 0.1.1 is the latest public release.'
+require_text README.md 'https://github.com/bennetthilberg/copylasso/releases/tag/v0.1.1'
+require_text README.md 'https://github.com/bennetthilberg/copylasso/releases/download/v0.1.1/CopyLasso-0.1.1.dmg'
+require_text README.md 'https://github.com/bennetthilberg/copylasso/releases/download/v0.1.1/CopyLasso-0.1.1.dmg.sha256'
+require_text CHANGELOG.md '## 0.1.1 - 2026-07-21'
 require_text CHANGELOG.md '## 0.1.0 - 2026-07-19'
 require_text CHANGELOG.md 'pasteboard clear-success followed by text-write rejection'
 require_text SECURITY.md 'CopyLasso 0.1.x'
-require_text CONTRIBUTING.md 'CopyLasso 0.1.0 is publicly released.'
-require_text PRIVACY.md '**Status:** Approved privacy contract for CopyLasso 0.1.0.'
+require_text CONTRIBUTING.md 'CopyLasso 0.1.1 is publicly released.'
+require_text PRIVACY.md '**Status:** Approved privacy contract for CopyLasso 0.1.x, including the current 0.1.1 release.'
 require_text docs/release-checklist.md '## G26 - Developer ID Signing And Notarization'
 require_text docs/release-checklist.md '## G27 - Reproducible Release Package'
 require_text docs/release-checklist.md '## G28 - Protected Release Workflow'
@@ -210,19 +211,24 @@ require_text docs/clean-install-testing.md '## G29 Partial Rehearsal Record'
 require_text docs/clean-install-testing.md 'accepted evidence gaps'
 require_text docs/v0.1-product-contract.md 'Before download, that account must have no CopyLasso application, production'
 require_text docs/v0.1-product-contract.md 'preferences, production container, login item, or Screen Recording approval.'
-require_text docs/v0.1-product-contract.md '**Implementation status:** Released as 0.1.0 on July 19, 2026'
+require_text docs/v0.1-product-contract.md \
+    '**Implementation status:** Released as 0.1.0 on July 19, 2026; maintained as 0.1.1 on July 21, 2026'
 require_text docs/v0.1-product-contract.md 'clipboard may change'
 require_text docs/security-and-privacy-review.md \
-    'This review describes the public CopyLasso 0.1.0 implementation boundary.'
+    'This review describes the public CopyLasso 0.1.x implementation boundary, including the current 0.1.1 release.'
 require_text docs/release-candidate-qualification.md '## Exact Candidate Smoke Matrix'
 require_text docs/release-candidate-qualification.md '## G32 v0.1.1 Maintenance Qualification'
 require_text docs/release-candidate-qualification.md 'Do not resume VirtualBuddy'
 require_text docs/release-notes/0.1.0.md 'CopyLasso 0.1.0'
 require_text docs/release-notes/0.1.0.md 'Locking the Mac during an active drag'
 require_text docs/release-notes/0.1.1.md 'Settings now appears immediately'
-if [[ "$(/usr/bin/sed -n '/^## G31 - Final Tag And Publication$/,$p' \
+if [[ "$(/usr/bin/sed -n '/^## G31 - Final Tag And Publication$/,/^## G32 - v0.1.1 Settings Hotfix$/p' \
     docs/release-checklist.md | /usr/bin/grep -c '^- \[x\]')" != 7 ]]; then
     fail "Every G31 publication checklist row must be complete."
+fi
+if [[ "$(/usr/bin/sed -n '/^## G32 - v0.1.1 Settings Hotfix$/,$p' \
+    docs/release-checklist.md | /usr/bin/grep -c '^- \[x\]')" != 7 ]]; then
+    fail "Every G32 maintenance-release checklist row must be complete."
 fi
 require_text docs/brand-assets.md 'The final pre-artifact exact-name review was repeated on July 14, 2026'
 require_text THIRD_PARTY_NOTICES.md 'KeyboardShortcuts 3.0.1'

--- a/scripts/audit-release-workflow.sh
+++ b/scripts/audit-release-workflow.sh
@@ -261,7 +261,7 @@ for required_release_note_text in \
     require_text "$release_notes" "$required_release_note_text"
 done
 require_text "$product_contract" \
-    '**Implementation status:** Released as 0.1.0 on July 19, 2026'
+    '**Implementation status:** Released as 0.1.0 on July 19, 2026; maintained as 0.1.1 on July 21, 2026'
 require_text "$product_contract" 'lock during an active drag'
 require_text "$product_contract" 'clipboard may change'
 

--- a/scripts/test-release-metadata.sh
+++ b/scripts/test-release-metadata.sh
@@ -48,8 +48,8 @@ fi
 
 [[ -r "$repository_root/docs/release-notes/0.1.1.md" ]] || \
     fail "Reviewed 0.1.1 release notes are missing."
-/usr/bin/grep -Fq '## 0.1.1 - Unreleased' "$repository_root/CHANGELOG.md" || \
-    fail "The changelog must contain the undated 0.1.1 hotfix entry."
+/usr/bin/grep -Fq '## 0.1.1 - 2026-07-21' "$repository_root/CHANGELOG.md" || \
+    fail "The changelog must date the published 0.1.1 hotfix entry."
 /usr/bin/grep -Fq 'Settings now appears immediately' \
     "$repository_root/docs/release-notes/0.1.1.md" || \
     fail "The 0.1.1 notes must describe the Settings presentation fix."


### PR DESCRIPTION
## Summary

- mark CopyLasso 0.1.1 as the current public release across user-facing documentation
- date the 0.1.1 changelog entry and complete the G32 release checklist
- enforce released-state documentation and goal-scoped checklist counts in canonical audits

## Testing

- `./scripts/test-release-metadata.sh`
- `./scripts/audit-release-workflow.sh`
- `./scripts/test-ci-contract.sh`
- `./scripts/audit-privacy-security.sh`
- `COPYLASSO_CI_ARCH=arm64 ./scripts/ci.sh`
- `COPYLASSO_CI_ARCH=x86_64 ./scripts/ci.sh`