### PR TITLE
G34: approve the v0.2 product contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,11 @@
 # Contributing to CopyLasso
 
-Thank you for helping build CopyLasso. CopyLasso 0.1.1 is publicly released. Focused changes that preserve its privacy and reliability contracts are the easiest to review; new product scope requires a separately approved post-v0.1 roadmap and product-contract update.
+Thank you for helping build CopyLasso. CopyLasso 0.1.1 is publicly released. Focused changes that preserve its privacy and reliability contracts are the easiest to review. The v0.2 product contract approves planned scope, but every implementation goal still requires its own bounded plan and approval.
 
 ## Before Making a Change
 
 - Read the [v0.1 product contract](docs/v0.1-product-contract.md) for supported behavior, privacy guarantees, and non-goals.
+- Read the [v0.2 product contract](docs/v0.2-product-contract.md) when proposing updater, sound, QR/barcode, or conditional LaTeX work. It describes planned behavior, not features currently present in 0.1.1.
 - Review the [development environment](docs/development-environment.md) and use the documented stable Xcode toolchain.
 - Open an issue before starting a large feature, architectural change, new dependency, or product-scope change.
 - Never include credentials, signing material, captured screen content, recognized private text, or other sensitive data in a commit, issue, test fixture, screenshot, or log.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -102,4 +102,4 @@ matrix and accepted-risk record.
 - [x] Lock automatic-update, success-sound, separate capture-command, QR/barcode, conditional LaTeX, privacy, accessibility, and version/build decisions.
 - [x] Add the focused v0.2 contract audit and enforce exactly one canonical CI invocation.
 - [x] Narrow issue #38 to on-screen QR/barcode recognition and create separate issues for file/PDF input, configurable success sound, and conditional offline LaTeX recognition.
-- [ ] Pass both canonical architectures, hosted checks, exact-head review, and final ready-PR readback without changing application source, dependencies, entitlements, release metadata, feeds, tags, or public artifacts.
+- [x] Pass both canonical architectures, hosted checks, exact-head review, and final ready-PR readback without changing application source, dependencies, entitlements, release metadata, feeds, tags, or public artifacts.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -95,3 +95,11 @@ matrix and accepted-risk record.
 - [x] Qualify ordinary reinstall with preferences retained and enabled/disabled Launch at Login across sign-in or restart using the exact public CopyLasso 0.1.1 DMG.
 - [x] Qualify the complete scoped uninstall/reinstall; record the maintainer-stopped disposable-account recreation as skipped rather than an account-isolation or VM-clone pass.
 - [x] Restore the exact public installation and intended maintainer settings, confirm it is the sole production Launch Services registration, and close issue #41 through the ready G33 pull request.
+
+## G34 - v0.2 Product Contract
+
+- [x] Preserve the historical v0.1 contract and document v0.2 as approved planned scope rather than shipped 0.1.1 behavior.
+- [x] Lock automatic-update, success-sound, separate capture-command, QR/barcode, conditional LaTeX, privacy, accessibility, and version/build decisions.
+- [x] Add the focused v0.2 contract audit and enforce exactly one canonical CI invocation.
+- [x] Narrow issue #38 to on-screen QR/barcode recognition and create separate issues for file/PDF input, configurable success sound, and conditional offline LaTeX recognition.
+- [ ] Pass both canonical architectures, hosted checks, exact-head review, and final ready-PR readback without changing application source, dependencies, entitlements, release metadata, feeds, tags, or public artifacts.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -338,6 +338,28 @@ Signed XCUITests remain focused on first-run, Settings, menu, recovery, and acce
 
 The versioned release checklist and performance result sheet are maintained in [Manual QA and Performance](manual-qa-and-performance.md). G24 executed that document from one clean, stably signed Debug state; partial or historical evidence must not be promoted into a release pass. The reusable procedure, partial browser-quarantined Sonoma rehearsal, incomplete latest-stable attempt, and accepted restart/reinstall gaps are recorded separately in [Clean Installation Testing](clean-install-testing.md).
 
+## v0.2 Product Contract Audit
+
+`scripts/audit-v02-contract.sh` is the documentation gate for the approved
+[v0.2 product contract](v0.2-product-contract.md). Canonical CI invokes it
+exactly once, and `scripts/test-ci-contract.sh` enforces that invocation. The
+audit checks the approved update, sound, command, QR/barcode, LaTeX, privacy,
+accessibility, and version/build decisions while also proving the shipped
+0.1.1 release metadata, current no-updater documentation, and one-key sandbox
+entitlement remain unchanged.
+
+Run the focused gate with:
+
+```sh
+./scripts/audit-v02-contract.sh
+./scripts/test-ci-contract.sh
+```
+
+This is a documentation and scope gate. It does not qualify an updater,
+network entitlement, new capture mode, sound asset, recognition dependency, or
+v0.2 release. Those require their later approved goals and direct behavioral
+tests.
+
 The July 13, 2026 signed run completed many functional, permission, and OCR rows
 before exposing a pre-drag sleep/wake failure. G24U subsequently passed exact
 signed pre-drag and drag-phase sleep interruption with full cleanup, clipboard

--- a/docs/v0.2-product-contract.md
+++ b/docs/v0.2-product-contract.md
@@ -71,7 +71,7 @@ already published 0.1.x binaries.
 - A check fetches only static, cryptographically signed update metadata. It
   sends no screen pixels, recognized text, barcode payload, LaTeX output,
   clipboard content, filenames, document contents, preferences, analytics,
-  telemetry, or a stable user or device identifier.
+  or telemetry. It sends no stable user or device identifier.
 - Update checks are independent of onboarding, Screen Recording, Launch at
   Login, selection, recognition, the clipboard, and capture feedback. Offline
   or failed checks cannot prevent CopyLasso from launching or capturing.
@@ -130,16 +130,20 @@ remain outside v0.2.
 - A result is eligible only when Vision returns a nonempty string payload. A
   binary-only, payload-less, unsupported, partial, or malformed observation is
   ignored rather than guessed or decoded through a network service.
-- For one eligible code, CopyLasso copies its payload as plain, inert text.
-- For multiple eligible codes whose payloads contain no carriage return or line
-  feed, CopyLasso copies unique payloads in visual top-to-bottom, left-to-right
-  order, separated by one newline between payloads.
-- A payload containing a line break is copied exactly when it is the sole
-  eligible result. If a multi-code result contains any line break, CopyLasso
+- Eligible observations are sorted in visual top-to-bottom, left-to-right order,
+  then exact string duplicates are removed while retaining the first
+  observation. Deduplication happens before any single-result, multiline, or
+  join decision.
+- If one unique payload remains, CopyLasso copies it exactly as plain, inert
+  text, including any carriage return or line feed it contains.
+- If multiple unique payloads remain and none contains a carriage return or line
+  feed, CopyLasso joins them in the retained visual order with one newline
+  between payloads.
+- If multiple unique payloads remain and any contains a line break, CopyLasso
   preserves the clipboard and presents a bounded, mode-specific ambiguity
   result instead of emitting text with destroyed payload boundaries.
-- Exact duplicate payloads appear once. Different payloads are never merged,
-  interpreted, reformatted as actions, or silently dropped.
+- Different payloads are never merged, interpreted, reformatted as actions, or
+  silently dropped.
 - If no eligible payload remains, CopyLasso preserves the clipboard and presents
   a bounded, mode-specific no-code result.
 
@@ -163,6 +167,13 @@ positive class contains at least 15 examples. A sample may count toward
 multiple class tallies only when its ground truth genuinely exercises each
 reported class; every tally and per-class result is published.
 
+These minimums apply to a blind evaluation corpus, not to development,
+training, candidate comparison, or tuning data. Before any evaluation label or
+candidate output on that corpus is inspected, G39 freezes the selected
+candidate, preprocessing, decoding parameters, normalization rules, and scoring
+implementation. Any change after unblinding invalidates the result and requires
+a fresh unseen evaluation corpus meeting the same class and size requirements.
+
 A candidate may receive a go recommendation only if the same reproducible
 design meets every gate:
 
@@ -170,8 +181,15 @@ design meets every gate:
 - Accuracy over all positive math samples is at least 85% normalized exact
   match, and no reported positive class is below 70% normalized exact match.
 - Negative no-math inputs produce no more than 1% false-success rate.
-- Warm end-to-end recognition has p95 recognition latency no greater than 2 seconds on Apple Silicon and no greater than 4 seconds on Intel. Cold model
-  load time is measured and reported separately.
+- Warm end-to-end recognition has p95 recognition latency no greater than 2
+  seconds on a base M1 MacBook Air with 8 GB memory, and no greater than 4
+  seconds on a 2018 MacBook Air with a 1.6 GHz dual-core Intel Core i5 and 8 GB
+  memory, or on demonstrably slower supported hardware in each architecture.
+  Measurements use AC power, Low Power Mode off, no reported thermal pressure,
+  and a pinned macOS 14 maintenance release. The exact model identifier, OS,
+  power state, run count, and warm-up are recorded. If the reference or slower
+  hardware cannot be measured, the candidate cannot receive a go
+  recommendation. Cold model load time is measured and reported separately.
 - The feature adds no more than 750 MiB of added peak memory above the existing
   text-capture baseline during the controlled benchmark.
 - The shipped application and required model data add no more than 200 MiB of installed-size growth relative to the same-source build without LaTeX.

--- a/docs/v0.2-product-contract.md
+++ b/docs/v0.2-product-contract.md
@@ -1,0 +1,250 @@
+# CopyLasso v0.2 Product Contract
+
+- **Status:** Approved scope for the planned v0.2 release
+- **Approved:** July 22, 2026
+- **Implementation status:** Planned; these features are not present in CopyLasso 0.1.1
+
+This document defines the approved user-visible delta for CopyLasso v0.2. It
+does not rewrite the historical [v0.1 product contract](v0.1-product-contract.md).
+Until each later goal is implemented, qualified, and released, the v0.1
+contract and the public 0.1.1 documentation remain the description of shipped
+behavior.
+
+## Preserved Product Baseline
+
+CopyLasso remains a free, open-source, local-first macOS utility. The production
+bundle identifier remains `io.github.bennetthilberg.copylasso`, the minimum
+system remains macOS 14, the application remains Universal 2 (`arm64` and
+`x86_64`), and App Sandbox and Hardened Runtime remain required.
+
+The existing Capture Text workflow remains stable:
+
+- `Shift-Command-2` (`⇧⌘2`) remains assigned only to Capture Text.
+- Capture Text still selects visible screen pixels, recognizes ordinary
+  horizontal English text locally with Vision, and writes successful plain
+  text to the clipboard.
+- Screen Recording remains the only privacy permission required by capture.
+- Existing focus restoration, cancellation, clipboard preservation,
+  single-display clamping, feedback, lifecycle, and accessibility contracts
+  continue to apply.
+- Accounts, analytics, telemetry, cloud recognition, and content history remain
+  absent.
+
+CopyLasso remains at public version and build `0.1.1 (2)` throughout G34-G40.
+G41 may freeze `0.2.0 (3)` only after the actual v0.2 feature set passes its
+release-level qualification. G34 does not change application metadata, source,
+dependencies, entitlements, releases, or update feeds.
+
+## Recognition Commands and Shortcuts
+
+Capture Text, Capture Code, and Capture LaTeX are separate commands. This keeps
+their success, no-result, failure, clipboard, and accessibility states explicit
+instead of making the application guess the user's intent.
+
+- Capture Text retains `⇧⌘2` and its existing configurable shortcut.
+- Capture Code and Capture LaTeX shortcuts are unset by default. Settings may
+  let the user assign or clear each optional shortcut independently.
+- The status menu exposes a clearly named command for every shipped mode.
+- A mode command must not silently fall back to a different recognizer. No text,
+  no code, and no math remain mode-specific no-result outcomes.
+- Starting any mode while another permission, selection, capture, or recognition
+  operation is active follows the existing single-workflow busy contract.
+- Every command uses the same established selection and in-memory screen-capture
+  boundaries. A recognition mode never receives another mode's retained output.
+
+Capture LaTeX appears only if G39 passes every approved gate and G40 ships the
+approved design. G40 is omitted if G39 concludes no-go; v0.2 may ship Text and
+Code without a LaTeX command.
+
+## Secure Update Contract
+
+The first updater-enabled release still requires one manual download by users
+of 0.1.x. Installing that release does not retroactively add an updater to the
+already published 0.1.x binaries.
+
+### Checking
+
+- In an updater-enabled release, automatic update checks are enabled by default.
+- The user can disable automatic checks in Settings at any time.
+- The status menu and Settings provide an accessible **Check for Updates**
+  action whether automatic checks are enabled or disabled.
+- A check fetches only static, cryptographically signed update metadata. It
+  sends no screen pixels, recognized text, barcode payload, LaTeX output,
+  clipboard content, filenames, document contents, preferences, analytics,
+  telemetry, or a stable user or device identifier.
+- Update checks are independent of onboarding, Screen Recording, Launch at
+  Login, selection, recognition, the clipboard, and capture feedback. Offline
+  or failed checks cannot prevent CopyLasso from launching or capturing.
+
+### Downloading and installing
+
+- CopyLasso presents the authenticated version, release notes, and download
+  size before an update transaction proceeds.
+- Downloading, installing, and relaunching always require explicit user confirmation.
+- Deferral leaves the installed version unchanged and keeps later manual and
+  automatic checks available.
+- Invalid signatures, malformed or replayed metadata, downgrades, mismatched
+  versions or digests, interrupted downloads, and unavailable services fail
+  closed. They never replace or damage the installed application.
+- Staged update data is bounded, app-owned, and removed after success,
+  cancellation, or failure. Update state never contains captured or recognized
+  user content.
+- G35 owns the dependency-versus-first-party decision, threat model, signing-key
+  separation, static feed location, and local malicious-fixture proof. G36 owns
+  user-visible integration and private staged-update qualification. No public
+  feed is authorized before the later approved release goals.
+
+The updater is the only approved v0.2 network client. Its entitlement and
+implementation may be added only by G36 after G35 proves the design.
+
+## Success Sound Contract
+
+- Success sound is enabled by default for new and upgraded users whose v0.2
+  sound preference has not yet been set.
+- Settings provides an independently keyboard-accessible and VoiceOver-labeled
+  toggle. The preference persists across relaunch and upgrade.
+- CopyLasso plays one brief sound only after the clipboard write succeeds for a
+  nonempty Text, Code, or LaTeX result.
+- Cancellation, no result, permission denial, capture failure, recognition
+  failure, formatting failure, clipboard failure, and internal failure are
+  silent.
+- Muted output, a missing output device, or an unavailable audio service is a
+  silent feedback failure. It does not reverse a successful clipboard write,
+  show a new error, request microphone or notification permission, activate
+  CopyLasso, or delay immediate reuse.
+- The sound must be original repository-owned audio or a documented public
+  macOS sound API with compatible redistribution terms. G37 records provenance
+  and any required acknowledgement.
+
+## On-Screen QR and Barcode Contract
+
+Capture Code recognizes only codes visible in the selected screen pixels. File
+import, camera capture, code generation, and application-specific data access
+remain outside v0.2.
+
+### Supported result handling
+
+- G38 must prove every shipped symbology with deterministic fixtures on the
+  supported platform matrix and publish the final list. QR codes are required;
+  an unproven barcode symbology is not advertised as supported.
+- A result is eligible only when Vision returns a nonempty string payload. A
+  binary-only, payload-less, unsupported, partial, or malformed observation is
+  ignored rather than guessed or decoded through a network service.
+- For one eligible code, CopyLasso copies its payload as plain, inert text.
+- For multiple eligible codes, CopyLasso copies unique payloads in visual top-to-bottom, left-to-right order, separated by one newline between payloads.
+- Exact duplicate payloads appear once. Different payloads are never merged,
+  interpreted, reformatted as actions, or silently dropped.
+- If no eligible payload remains, CopyLasso preserves the clipboard and presents
+  a bounded, mode-specific no-code result.
+
+A code payload is always inert clipboard text. CopyLasso never opens a URL,
+launches an application, joins Wi-Fi, adds a contact or calendar item, executes
+a command, or otherwise acts on embedded data. The HUD preview remains bounded
+and ephemeral, and complete payloads never enter logs, preferences, caches,
+history, analytics, telemetry, or updater traffic.
+
+## Offline LaTeX Feasibility Gate
+
+G39 is a go/no-go study, not authorization to ship a weak recognizer. Its
+controlled corpus must contain at least 200 controlled samples spanning clean
+inline and display math, fractions, roots, superscripts, subscripts, Greek
+symbols, operators, delimiters, aligned equations, matrices, degraded and
+low-resolution inputs, and negative selections containing no math.
+
+A candidate may receive a go recommendation only if the same reproducible
+design meets every gate:
+
+- Accuracy on clean common math is at least 95% structurally correct.
+- Accuracy over the complete corpus is at least 85% normalized exact match.
+- Negative no-math inputs produce no more than 1% false-success rate.
+- Warm end-to-end recognition has p95 recognition latency no greater than 2 seconds on Apple Silicon and no greater than 4 seconds on Intel. Cold model
+  load time is measured and reported separately.
+- The feature adds no more than 750 MiB of added peak memory above the existing
+  text-capture baseline during the controlled benchmark.
+- The shipped application and required model data add no more than 200 MiB of installed-size growth relative to the same-source build without LaTeX.
+- Recognition works with networking denied, persists no image or recognized
+  content, and has no cloud fallback, analytics, or telemetry.
+- The implementation supports macOS 14 or newer and ships as Universal 2 with
+  executable support for both `arm64` and `x86_64`.
+- Every dependency, model, dataset-derived artifact, and notice has clear,
+  compatible, redistributable licensing for CopyLasso's MIT source and direct
+  Developer ID distribution. Model provenance and digests are reproducible.
+
+The benchmark records per-class results, normalization rules, failure classes,
+cold and warm latency, model load time, peak memory, installed-size impact, and
+both architectures. A candidate that misses any threshold is no-go. Narrowing
+the corpus, supported math, platform, or threshold requires a new product-
+contract amendment rather than an implementation exception.
+
+If approved and implemented, Capture LaTeX copies plain LaTeX source as inert
+text. CopyLasso does not render, execute, compile, upload, or automatically paste
+the result.
+
+## Privacy, Security, and Data Lifetime
+
+- Screen images and all recognition outputs remain local, in memory, and scoped
+  to the active operation.
+- Text, code payloads, LaTeX output, clipboard data, and HUD previews never
+  enter update requests, logs, crash breadcrumbs, preferences, caches,
+  analytics, telemetry, or history.
+- Unsuccessful recognition paths preserve the clipboard under the existing
+  privacy-first write-only clipboard contract.
+- The updater persists only the minimum non-content state required for check
+  timing, deferral, staged authenticated bytes, and recovery. G35 must define
+  exact retention and deletion behavior before G36 implementation.
+- No new capture mode may add a privacy permission. The success sound requests
+  no permission. The updater's narrowly reviewed network entitlement is the
+  only planned entitlement change.
+- Core Text, Code, and conditional LaTeX capture remain fully usable while
+  networking is denied and while automatic update checks are disabled.
+
+## Accessibility, Focus, and Failure Behavior
+
+- Every new menu command, optional shortcut recorder, Settings toggle, update
+  action, confirmation, progress state, no-result state, and recovery action
+  has a stable accessible name, value, state, and help where needed.
+- Keyboard-only and VoiceOver users can check, defer, confirm, cancel, and retry
+  updates and configure sound or optional recognition shortcuts.
+- Update UI may activate only when the user explicitly opens it or responds to
+  a presented update. Background checks, sound, selection, recognition, and HUD
+  feedback remain nonactivating.
+- No outcome relies on sound or color alone. Successful clipboard state retains
+  visual and accessible feedback when sound is disabled or unavailable.
+- A failure in one recognition mode, the sound service, or the updater cannot
+  corrupt another mode's state or prevent the stable Text workflow from running.
+
+## Goal and Issue Ownership
+
+| Promise | Implementation owner | Required proof |
+| --- | --- | --- |
+| Signed update architecture and key separation | G35 | ADR, threat model, malicious local fixtures, offline failure behavior |
+| User-controlled updater | G36 / issue #36 | Accessible UI, signed staged upgrade, preserved preferences, content-egress audit |
+| Default-on configurable success sound | G37 / issue #48 | Preference migration, success-only routing, output-device and accessibility matrix |
+| Screen QR/barcode recognition | G38 / issue #38 | Symbology fixtures, ordering/deduplication, inert output, clipboard and lifetime tests |
+| LaTeX feasibility | G39 / issue #49 | Controlled corpus, numeric gate report, license and architecture audit, explicit go/no-go |
+| Conditional LaTeX implementation | G40 / issue #49 only after a G39 go | Corpus regressions, mode isolation, memory/lifecycle/offline/signed UI proof |
+| Version and release-level qualification | G41 | Frozen feature list, `0.2.0 (3)` metadata, complete privacy/security/accessibility/performance matrix |
+
+File and PDF import is tracked separately in issue #47. The existing issue #38
+is narrowed to screen QR/barcode recognition so it can close independently of
+later file input. Issues #48 and #49 track success sound and LaTeX respectively.
+
+## Explicit v0.2 Non-Goals
+
+- File, image, or PDF import and multi-page document handling.
+- Camera capture or QR/barcode generation.
+- Automatic URL opening, code actions, Wi-Fi joining, contact creation, or any
+  other execution of QR/barcode payloads.
+- Screenshot, OCR, code, LaTeX, or clipboard history.
+- Cross-display selection or image stitching.
+- Rich-text, Markdown, table, or general layout reconstruction.
+- Translation, text-to-speech, expanded OCR-language settings, and cloud OCR.
+- Accounts, synchronization, analytics, telemetry, advertising, or content
+  reporting.
+- Mac App Store distribution, Homebrew Cask, or a general public website.
+- A public update feed, final v0.2 tag, or release before the separately approved
+  qualification and publication goals.
+
+Changes to these approved promises require an explicit product-contract
+amendment before implementation. Later goals may choose implementation details
+only within these boundaries.

--- a/docs/v0.2-product-contract.md
+++ b/docs/v0.2-product-contract.md
@@ -131,7 +131,13 @@ remain outside v0.2.
   binary-only, payload-less, unsupported, partial, or malformed observation is
   ignored rather than guessed or decoded through a network service.
 - For one eligible code, CopyLasso copies its payload as plain, inert text.
-- For multiple eligible codes, CopyLasso copies unique payloads in visual top-to-bottom, left-to-right order, separated by one newline between payloads.
+- For multiple eligible codes whose payloads contain no carriage return or line
+  feed, CopyLasso copies unique payloads in visual top-to-bottom, left-to-right
+  order, separated by one newline between payloads.
+- A payload containing a line break is copied exactly when it is the sole
+  eligible result. If a multi-code result contains any line break, CopyLasso
+  preserves the clipboard and presents a bounded, mode-specific ambiguity
+  result instead of emitting text with destroyed payload boundaries.
 - Exact duplicate payloads appear once. Different payloads are never merged,
   interpreted, reformatted as actions, or silently dropped.
 - If no eligible payload remains, CopyLasso preserves the clipboard and presents
@@ -146,16 +152,23 @@ history, analytics, telemetry, or updater traffic.
 ## Offline LaTeX Feasibility Gate
 
 G39 is a go/no-go study, not authorization to ship a weak recognizer. Its
-controlled corpus must contain at least 200 controlled samples spanning clean
-inline and display math, fractions, roots, superscripts, subscripts, Greek
-symbols, operators, delimiters, aligned equations, matrices, degraded and
-low-resolution inputs, and negative selections containing no math.
+preregistered controlled corpus must contain at least 300 samples. It includes
+at least 200 positive math samples and at least 100 negative selections
+containing no math.
+The positive set spans clean inline and display math, fractions, roots,
+superscripts, subscripts, Greek symbols, operators, delimiters, aligned
+equations, matrices, degraded inputs, and low-resolution inputs. The clean
+common-math subset contains at least 100 samples, and every other listed
+positive class contains at least 15 examples. A sample may count toward
+multiple class tallies only when its ground truth genuinely exercises each
+reported class; every tally and per-class result is published.
 
 A candidate may receive a go recommendation only if the same reproducible
 design meets every gate:
 
 - Accuracy on clean common math is at least 95% structurally correct.
-- Accuracy over the complete corpus is at least 85% normalized exact match.
+- Accuracy over all positive math samples is at least 85% normalized exact
+  match, and no reported positive class is below 70% normalized exact match.
 - Negative no-math inputs produce no more than 1% false-success rate.
 - Warm end-to-end recognition has p95 recognition latency no greater than 2 seconds on Apple Silicon and no greater than 4 seconds on Intel. Cold model
   load time is measured and reported separately.

--- a/scripts/audit-v02-contract.sh
+++ b/scripts/audit-v02-contract.sh
@@ -7,6 +7,7 @@ readonly contract="$repository_root/docs/v0.2-product-contract.md"
 readonly baseline_contract="$repository_root/docs/v0.1-product-contract.md"
 readonly release_metadata="$repository_root/Configuration/ReleaseMetadata.xcconfig"
 readonly entitlements="$repository_root/CopyLasso/CopyLasso.entitlements"
+readonly expected_baseline_contract_digest='3426807f08168cec2aaca337b80d7657a8a2d8569d48ecaafe0ec75672f92291'
 
 fail() {
     echo "$1" >&2
@@ -22,6 +23,11 @@ require_contract_text() {
 
 [[ -f "$contract" ]] || fail "Required v0.2 contract file is missing: docs/v0.2-product-contract.md"
 [[ -f "$baseline_contract" ]] || fail "The historical v0.1 product contract must remain present."
+
+baseline_contract_digest="$(/usr/bin/shasum -a 256 "$baseline_contract" | /usr/bin/awk '{print $1}')"
+if [[ "$baseline_contract_digest" != "$expected_baseline_contract_digest" ]]; then
+    fail "G34 must preserve the reviewed historical v0.1 product contract byte for byte."
+fi
 
 for required_text in \
     '# CopyLasso v0.2 Product Contract' \
@@ -54,6 +60,11 @@ for required_text in \
     'macOS 14 or newer' \
     'Universal 2' \
     'redistributable licensing' \
+    '## Privacy, Security, and Data Lifetime' \
+    'Text, code payloads, LaTeX output, clipboard data, and HUD previews never' \
+    '## Accessibility, Focus, and Failure Behavior' \
+    'Keyboard-only and VoiceOver users can check, defer, confirm, cancel, and retry' \
+    'No outcome relies on sound or color alone.' \
     '0.1.1 (2)' \
     'G41 may freeze `0.2.0 (3)`' \
     'G40 is omitted if G39 concludes no-go' \
@@ -78,10 +89,10 @@ if /usr/bin/grep -Eq 'com\.apple\.security\.network\.(client|server)' "$entitlem
     fail "G34 must not add a network entitlement."
 fi
 
-/usr/bin/grep -Fq 'automatic updater' "$repository_root/README.md" || \
-    fail "README current-state copy must still say the 0.1.1 app has no updater."
-/usr/bin/grep -Fq 'network-client implementation' "$repository_root/README.md" || \
-    fail "README current-state copy must still say the 0.1.1 app has no network client."
+/usr/bin/grep -Fq \
+    'The application has no accounts, analytics, telemetry, cloud OCR, automatic updater, or network-client implementation.' \
+    "$repository_root/README.md" || \
+    fail "README current-state copy must still deny updater and network-client behavior."
 /usr/bin/grep -Fq \
     'no network-client or server entitlement, networking implementation, telemetry service, or automatic updater' \
     "$repository_root/PRIVACY.md" || \

--- a/scripts/audit-v02-contract.sh
+++ b/scripts/audit-v02-contract.sh
@@ -40,28 +40,33 @@ for required_text in \
     'disable automatic checks in Settings' \
     'Check for Updates' \
     'static, cryptographically signed update metadata' \
-    'stable user or device identifier' \
+    'It sends no stable user or device identifier.' \
     'Downloading, installing, and relaunching always require explicit user confirmation.' \
     'Success sound is enabled by default' \
     'only after the clipboard write succeeds' \
     'Capture Text, Capture Code, and Capture LaTeX are separate commands.' \
     '`Shift-Command-2` (`⇧⌘2`) remains assigned only to Capture Text.' \
     'Capture Code and Capture LaTeX shortcuts are unset by default.' \
-    'unique payloads in visual top-to-bottom, left-to-right' \
-    'one newline between payloads' \
-    'If a multi-code result contains any line break' \
+    'Eligible observations are sorted in visual top-to-bottom, left-to-right order' \
+    'Deduplication happens before any single-result, multiline, or' \
+    'retained visual order with one newline' \
+    'If multiple unique payloads remain and any contains a line break' \
     'mode-specific ambiguity' \
     'never opens a URL' \
     'at least 300 samples' \
     'at least 200 positive math samples' \
     'at least 100 negative selections' \
     'at least 15 examples' \
+    'blind evaluation corpus' \
+    'Any change after unblinding invalidates the result' \
     'at least 95% structurally correct' \
     'Accuracy over all positive math samples is at least 85%' \
     'no reported positive class is below 70% normalized exact match' \
     'no more than 1% false-success rate' \
-    'p95 recognition latency no greater than 2 seconds on Apple Silicon' \
-    'no greater than 4 seconds on Intel' \
+    'p95 recognition latency no greater than 2' \
+    'base M1 MacBook Air with 8 GB memory' \
+    '2018 MacBook Air with a 1.6 GHz dual-core Intel Core i5 and 8 GB' \
+    'hardware cannot be measured, the candidate cannot receive a go' \
     'no more than 750 MiB of added peak memory' \
     'no more than 200 MiB of installed-size growth' \
     'macOS 14 or newer' \
@@ -87,9 +92,13 @@ if /usr/bin/grep -Eq '(^|[^0-9])0\.2\.0[[:space:]]*\([[:space:]]*[12][[:space:]]
     fail "The planned v0.2 contract must not reuse a released build number."
 fi
 
-/usr/bin/grep -Fq 'COPYLASSO_RELEASE_VERSION = 0.1.1' "$release_metadata" || \
+/usr/bin/grep -Eq \
+    '^COPYLASSO_RELEASE_VERSION[[:space:]]*=[[:space:]]*0\.1\.1[[:space:]]*$' \
+    "$release_metadata" || \
     fail "G34 must leave the current release version at 0.1.1."
-/usr/bin/grep -Fq 'COPYLASSO_RELEASE_BUILD = 2' "$release_metadata" || \
+/usr/bin/grep -Eq \
+    '^COPYLASSO_RELEASE_BUILD[[:space:]]*=[[:space:]]*2[[:space:]]*$' \
+    "$release_metadata" || \
     fail "G34 must leave the current release build at 2."
 
 [[ -f "$entitlements" ]] || fail "G34 must preserve the reviewed App Sandbox entitlements file."

--- a/scripts/audit-v02-contract.sh
+++ b/scripts/audit-v02-contract.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && /bin/pwd -P)"
+readonly contract="$repository_root/docs/v0.2-product-contract.md"
+readonly baseline_contract="$repository_root/docs/v0.1-product-contract.md"
+readonly release_metadata="$repository_root/Configuration/ReleaseMetadata.xcconfig"
+readonly entitlements="$repository_root/CopyLasso/CopyLasso.entitlements"
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+require_contract_text() {
+    local required_text="$1"
+
+    /usr/bin/grep -Fq "$required_text" "$contract" || \
+        fail "The v0.2 contract is missing required text: $required_text"
+}
+
+[[ -f "$contract" ]] || fail "Required v0.2 contract file is missing: docs/v0.2-product-contract.md"
+[[ -f "$baseline_contract" ]] || fail "The historical v0.1 product contract must remain present."
+
+for required_text in \
+    '# CopyLasso v0.2 Product Contract' \
+    '**Status:** Approved scope for the planned v0.2 release' \
+    '**Approved:** July 22, 2026' \
+    '**Implementation status:** Planned; these features are not present in CopyLasso 0.1.1' \
+    '[v0.1 product contract](v0.1-product-contract.md)' \
+    'automatic update checks are enabled by default' \
+    'disable automatic checks in Settings' \
+    'Check for Updates' \
+    'static, cryptographically signed update metadata' \
+    'stable user or device identifier' \
+    'Downloading, installing, and relaunching always require explicit user confirmation.' \
+    'Success sound is enabled by default' \
+    'only after the clipboard write succeeds' \
+    'Capture Text, Capture Code, and Capture LaTeX are separate commands.' \
+    '`Shift-Command-2` (`⇧⌘2`) remains assigned only to Capture Text.' \
+    'Capture Code and Capture LaTeX shortcuts are unset by default.' \
+    'unique payloads in visual top-to-bottom, left-to-right order' \
+    'one newline between payloads' \
+    'never opens a URL' \
+    'at least 200 controlled samples' \
+    'at least 95% structurally correct' \
+    'at least 85% normalized exact match' \
+    'no more than 1% false-success rate' \
+    'p95 recognition latency no greater than 2 seconds on Apple Silicon' \
+    'no greater than 4 seconds on Intel' \
+    'no more than 750 MiB of added peak memory' \
+    'no more than 200 MiB of installed-size growth' \
+    'macOS 14 or newer' \
+    'Universal 2' \
+    'redistributable licensing' \
+    '0.1.1 (2)' \
+    'G41 may freeze `0.2.0 (3)`' \
+    'G40 is omitted if G39 concludes no-go' \
+    'issue #36' \
+    'issue #38' \
+    'issue #47' \
+    'issue #48' \
+    'issue #49'; do
+    require_contract_text "$required_text"
+done
+
+if /usr/bin/grep -Eq '(^|[^0-9])0\.2\.0[[:space:]]*\([[:space:]]*[12][[:space:]]*\)' "$contract"; then
+    fail "The planned v0.2 contract must not reuse a released build number."
+fi
+
+/usr/bin/grep -Fq 'COPYLASSO_RELEASE_VERSION = 0.1.1' "$release_metadata" || \
+    fail "G34 must leave the current release version at 0.1.1."
+/usr/bin/grep -Fq 'COPYLASSO_RELEASE_BUILD = 2' "$release_metadata" || \
+    fail "G34 must leave the current release build at 2."
+
+if /usr/bin/grep -Eq 'com\.apple\.security\.network\.(client|server)' "$entitlements"; then
+    fail "G34 must not add a network entitlement."
+fi
+
+/usr/bin/grep -Fq 'automatic updater' "$repository_root/README.md" || \
+    fail "README current-state copy must still say the 0.1.1 app has no updater."
+/usr/bin/grep -Fq 'network-client implementation' "$repository_root/README.md" || \
+    fail "README current-state copy must still say the 0.1.1 app has no network client."
+/usr/bin/grep -Fq \
+    'no network-client or server entitlement, networking implementation, telemetry service, or automatic updater' \
+    "$repository_root/PRIVACY.md" || \
+    fail "PRIVACY current-state copy must still describe the 0.1.1 network boundary."
+/usr/bin/grep -Fq \
+    'no network-client or server entitlement, networking implementation, content-history store, updater' \
+    "$repository_root/docs/security-and-privacy-review.md" || \
+    fail "The security review must still describe the 0.1.1 network boundary."
+
+if /usr/bin/grep -R -nE \
+    'TODO|example\.com|Capture (Code|LaTeX) (is|are) (available now|shipping|included in 0\.1\.1)' \
+    "$contract"; then
+    fail "The v0.2 contract contains a placeholder or falsely shipped feature claim."
+fi
+
+echo "CopyLasso v0.2 product-contract audit passed."

--- a/scripts/audit-v02-contract.sh
+++ b/scripts/audit-v02-contract.sh
@@ -8,6 +8,7 @@ readonly baseline_contract="$repository_root/docs/v0.1-product-contract.md"
 readonly release_metadata="$repository_root/Configuration/ReleaseMetadata.xcconfig"
 readonly entitlements="$repository_root/CopyLasso/CopyLasso.entitlements"
 readonly expected_baseline_contract_digest='3426807f08168cec2aaca337b80d7657a8a2d8569d48ecaafe0ec75672f92291'
+readonly expected_entitlements_digest='b746c74b201e6af4e0864fbd1f4f629f96156a7ec4b7208bc995d0a5089bb592'
 
 fail() {
     echo "$1" >&2
@@ -46,12 +47,18 @@ for required_text in \
     'Capture Text, Capture Code, and Capture LaTeX are separate commands.' \
     '`Shift-Command-2` (`⇧⌘2`) remains assigned only to Capture Text.' \
     'Capture Code and Capture LaTeX shortcuts are unset by default.' \
-    'unique payloads in visual top-to-bottom, left-to-right order' \
+    'unique payloads in visual top-to-bottom, left-to-right' \
     'one newline between payloads' \
+    'If a multi-code result contains any line break' \
+    'mode-specific ambiguity' \
     'never opens a URL' \
-    'at least 200 controlled samples' \
+    'at least 300 samples' \
+    'at least 200 positive math samples' \
+    'at least 100 negative selections' \
+    'at least 15 examples' \
     'at least 95% structurally correct' \
-    'at least 85% normalized exact match' \
+    'Accuracy over all positive math samples is at least 85%' \
+    'no reported positive class is below 70% normalized exact match' \
     'no more than 1% false-success rate' \
     'p95 recognition latency no greater than 2 seconds on Apple Silicon' \
     'no greater than 4 seconds on Intel' \
@@ -84,6 +91,12 @@ fi
     fail "G34 must leave the current release version at 0.1.1."
 /usr/bin/grep -Fq 'COPYLASSO_RELEASE_BUILD = 2' "$release_metadata" || \
     fail "G34 must leave the current release build at 2."
+
+[[ -f "$entitlements" ]] || fail "G34 must preserve the reviewed App Sandbox entitlements file."
+entitlements_digest="$(/usr/bin/shasum -a 256 "$entitlements" | /usr/bin/awk '{print $1}')"
+if [[ "$entitlements_digest" != "$expected_entitlements_digest" ]]; then
+    fail "G34 must preserve the reviewed one-key App Sandbox entitlement byte for byte."
+fi
 
 if /usr/bin/grep -Eq 'com\.apple\.security\.network\.(client|server)' "$entitlements"; then
     fail "G34 must not add a network entitlement."

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -76,6 +76,9 @@ echo "Auditing platform and reinstall qualification"
 echo "Testing platform and reinstall qualification"
 ./scripts/test-platform-qualification.sh
 
+echo "Auditing the approved v0.2 product contract"
+./scripts/audit-v02-contract.sh
+
 readonly committed_development_team_pattern='^[[:space:]]*"?DEVELOPMENT_TEAM(\[[^]]+\])?"?[[:space:]]*=[[:space:]]*[A-Z0-9]{10};'
 
 if /usr/bin/grep -Eq "$committed_development_team_pattern" \

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -11,6 +11,7 @@ readonly release_package_audit_script="$repository_root/scripts/audit-release-pa
 readonly release_workflow_audit_script="$repository_root/scripts/audit-release-workflow.sh"
 readonly platform_qualification_audit_script="$repository_root/scripts/audit-platform-qualification.sh"
 readonly platform_qualification_test_script="$repository_root/scripts/test-platform-qualification.sh"
+readonly v02_contract_audit_script="$repository_root/scripts/audit-v02-contract.sh"
 readonly generated_app_cleanup_runner="$repository_root/scripts/run-with-generated-app-cleanup.sh"
 readonly ordinary_release_cleanup="$repository_root/scripts/unregister-generated-release.sh"
 readonly repeatability_script="$repository_root/scripts/test-repeatability.sh"
@@ -124,6 +125,15 @@ if [[ "$platform_qualification_test_invocations" != "1" ]]; then
     fail "Canonical CI must invoke scripts/test-platform-qualification.sh exactly once."
 fi
 
+v02_contract_audit_invocations="$({
+    /usr/bin/grep -Ec \
+        '^[[:space:]]*\./scripts/audit-v02-contract\.sh[[:space:]]*$' \
+        "$ci_script" || true
+})"
+if [[ "$v02_contract_audit_invocations" != "1" ]]; then
+    fail "Canonical CI must invoke scripts/audit-v02-contract.sh exactly once."
+fi
+
 if [[ ! -x "$developer_id_audit_script" ]] || \
     [[ ! -x "$repository_root/scripts/verify-developer-id-app.sh" ]] || \
     [[ ! -x "$repository_root/scripts/test-developer-id-release.sh" ]]; then
@@ -154,6 +164,10 @@ if [[ ! -x "$platform_qualification_audit_script" ]] || \
     [[ ! -x "$generated_app_cleanup_runner" ]] || \
     [[ ! -x "$ordinary_release_cleanup" ]]; then
     fail "Platform-qualification and generated-app cleanup scripts must be executable."
+fi
+
+if [[ ! -x "$v02_contract_audit_script" ]]; then
+    fail "The v0.2 product-contract audit must be executable."
 fi
 
 if ! /usr/bin/grep -Fq \


### PR DESCRIPTION
## Summary

- approve the v0.2 product-contract delta for user-controlled secure updates, configurable success sound, separate text/code/conditional LaTeX commands, and inert on-screen QR/barcode results
- define the numeric offline LaTeX go/no-go gates while preserving the shipped 0.1.1 (2) product and release boundary
- add one canonical contract audit and split issues #38, #47, #48, and #49 by independently approvable scope

## Verification

- `./scripts/audit-v02-contract.sh`
- `./scripts/test-ci-contract.sh`
- `./scripts/audit-privacy-security.sh`
- `./scripts/test-release-metadata.sh`
- `./scripts/audit-platform-qualification.sh`
- `COPYLASSO_CI_ARCH=arm64 ./scripts/ci.sh`
- `COPYLASSO_CI_ARCH=x86_64 ./scripts/ci.sh`
- `git diff --check`

Both canonical pipelines passed 244 ordinary tests, networking-denied tests, three repeatability passes, coverage, release and brand audits, Debug and Release builds, and Universal 2 verification.

## Boundary

This is a documentation and CI-contract change only. It does not change application source, dependencies, entitlements, version/build metadata, update feeds, tags, or public artifacts, and it does not implement any v0.2 feature.
