### PR TITLE
G35: prove secure update architecture

### DIFF
--- a/CopyLasso.xcodeproj/project.pbxproj
+++ b/CopyLasso.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		C0B1A0033002000000000003 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = C0B1A0013002000000000001 /* KeyboardShortcuts */; };
 		C0B1A0043002000000000004 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = C0B1A0023002000000000002 /* KeyboardShortcuts */; };
+		C0D35A033500000000000003 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C0D35A023500000000000002 /* Sparkle */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +69,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C0B1A0043002000000000004 /* KeyboardShortcuts in Frameworks */,
+				C0D35A033500000000000003 /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -156,6 +158,7 @@
 			name = CopyLassoTests;
 			packageProductDependencies = (
 				C0B1A0023002000000000002 /* KeyboardShortcuts */,
+				C0D35A023500000000000002 /* Sparkle */,
 			);
 			productName = CopyLassoTests;
 			productReference = AACED2F830004BEC001F9909 /* CopyLassoTests.xctest */;
@@ -218,6 +221,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				C0B1A0053002000000000005 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
+				C0D35A013500000000000001 /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = AACED2EC30004BEB001F9909 /* Products */;
@@ -604,6 +608,14 @@
 				version = 3.0.1;
 			};
 		};
+		C0D35A013500000000000001 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = exactVersion;
+				version = 2.9.4;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -616,6 +628,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C0B1A0053002000000000005 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;
 			productName = KeyboardShortcuts;
+		};
+		C0D35A023500000000000002 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C0D35A013500000000000001 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/CopyLasso.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CopyLasso.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "69c39523ac0471922b625cc56b8722155cfd2afd660bdd4f5ff67335b5b87714",
+  "originHash" : "bd98f0be2af71cea5645be75ecf05037da9d09ea8295306d01254963541210cb",
   "pins" : [
     {
       "identity" : "keyboardshortcuts",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "49c3fc04ea827f816df67843bfcc57286b47ff06",
         "version" : "3.0.1"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
       }
     }
   ],

--- a/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift
+++ b/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift
@@ -51,52 +51,6 @@ final class SecureUpdateArchitectureProofTests: XCTestCase {
     assertRejected(\.actualDownloadBytes, value: 4_095, reason: .sizeMismatch)
   }
 
-  func testOnlyExpectedSingleGitHubAssetRedirectIsAccepted() {
-    let source = SecureUpdateProofCandidate.valid.downloadURL
-    let destination = URL(
-      string:
-        "https://release-assets.githubusercontent.com/github-production-release-asset/12345/01234567-89ab-cdef-0123-456789abcdef?sp=r&sig=fixture"
-    )!
-
-    XCTAssertTrue(
-      policy.allowsEnclosureRedirect(
-        from: source,
-        to: destination,
-        redirectNumber: 1,
-        displayVersion: "0.2.0"
-      )
-    )
-    XCTAssertFalse(
-      policy.allowsEnclosureRedirect(
-        from: source,
-        to: destination,
-        redirectNumber: 2,
-        displayVersion: "0.2.0"
-      )
-    )
-
-    for location in [
-      "http://release-assets.githubusercontent.com/github-production-release-asset/12345/01234567-89ab-cdef-0123-456789abcdef?sig=fixture",
-      "https://objects.githubusercontent.com/github-production-release-asset/12345/01234567-89ab-cdef-0123-456789abcdef?sig=fixture",
-      "https://user@release-assets.githubusercontent.com/github-production-release-asset/12345/01234567-89ab-cdef-0123-456789abcdef?sig=fixture",
-      "https://release-assets.githubusercontent.com:443/github-production-release-asset/12345/01234567-89ab-cdef-0123-456789abcdef?sig=fixture",
-      "https://release-assets.githubusercontent.com/github-production-release-asset/12345/01234567-89ab-cdef-0123-456789abcdef",
-      "https://release-assets.githubusercontent.com/other/12345/01234567-89ab-cdef-0123-456789abcdef?sig=fixture",
-      "https://release-assets.githubusercontent.com/github-production-release-asset/not-numeric/01234567-89ab-cdef-0123-456789abcdef?sig=fixture",
-      "https://release-assets.githubusercontent.com/github-production-release-asset/12345/%2e%2e?sig=fixture",
-    ] {
-      XCTAssertFalse(
-        policy.allowsEnclosureRedirect(
-          from: source,
-          to: URL(string: location)!,
-          redirectNumber: 1,
-          displayVersion: "0.2.0"
-        ),
-        location
-      )
-    }
-  }
-
   func testDowngradeReplayAndMalformedLocationFailClosed() {
     var downgrade = SecureUpdateProofCandidate.valid
     downgrade.feedBuild = "1"
@@ -331,37 +285,6 @@ private struct SecureUpdateProofPolicy {
     return .installAllowed
   }
 
-  func allowsEnclosureRedirect(
-    from source: URL,
-    to destination: URL,
-    redirectNumber: Int,
-    displayVersion: String
-  ) -> Bool {
-    guard redirectNumber == 1,
-      isApprovedDownloadLocation(source, displayVersion: displayVersion),
-      destination.scheme == "https",
-      destination.host == "release-assets.githubusercontent.com",
-      destination.user == nil,
-      destination.password == nil,
-      destination.port == nil,
-      destination.query?.isEmpty == false,
-      destination.fragment == nil
-    else {
-      return false
-    }
-
-    let pathComponents = destination.pathComponents
-    guard pathComponents.count == 4,
-      pathComponents[0] == "/",
-      pathComponents[1] == "github-production-release-asset",
-      isASCIIDecimal(pathComponents[2]),
-      isOpaqueAssetIdentifier(pathComponents[3])
-    else {
-      return false
-    }
-    return true
-  }
-
   private func isCanonicalBuild(_ version: String) -> Bool {
     guard (1...18).contains(version.utf8.count),
       version.utf8.first.map({ (49...57).contains($0) }) == true
@@ -398,16 +321,6 @@ private struct SecureUpdateProofPolicy {
     return true
   }
 
-  private func isASCIIDecimal(_ value: String) -> Bool {
-    !value.isEmpty && value.utf8.allSatisfy { (48...57).contains($0) }
-  }
-
-  private func isOpaqueAssetIdentifier(_ value: String) -> Bool {
-    guard (1...128).contains(value.utf8.count) else { return false }
-    return value.utf8.allSatisfy {
-      (48...57).contains($0) || (65...90).contains($0) || (97...122).contains($0) || $0 == 45
-    }
-  }
 }
 
 private enum SecureUpdateProofFailure: CaseIterable, Equatable {

--- a/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift
+++ b/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift
@@ -32,12 +32,69 @@ final class SecureUpdateArchitectureProofTests: XCTestCase {
     )
   }
 
+  func testCurrentBuildBelowAuthenticatedHighWaterIsReplay() {
+    var candidate = SecureUpdateProofCandidate.valid
+    candidate.feedBuild = "2"
+    candidate.archiveBuild = "2"
+
+    XCTAssertEqual(
+      policy.decision(for: candidate, installedBuild: "2", highestAuthenticatedBuild: "3"),
+      .rejected(.replay)
+    )
+  }
+
   func testUntrustedOrMismatchedCandidatesFailClosed() {
     assertRejected(\.feedAuthenticated, value: false, reason: .invalidFeedSignature)
     assertRejected(\.archiveAuthenticated, value: false, reason: .invalidArchiveSignature)
     assertRejected(\.archiveBuild, value: "4", reason: .versionMismatch)
     assertRejected(\.archiveDisplayVersion, value: "0.2.1", reason: .versionMismatch)
     assertRejected(\.actualDownloadBytes, value: 4_095, reason: .sizeMismatch)
+  }
+
+  func testOnlyExpectedSingleGitHubAssetRedirectIsAccepted() {
+    let source = SecureUpdateProofCandidate.valid.downloadURL
+    let destination = URL(
+      string:
+        "https://release-assets.githubusercontent.com/github-production-release-asset/12345/01234567-89ab-cdef-0123-456789abcdef?sp=r&sig=fixture"
+    )!
+
+    XCTAssertTrue(
+      policy.allowsEnclosureRedirect(
+        from: source,
+        to: destination,
+        redirectNumber: 1,
+        displayVersion: "0.2.0"
+      )
+    )
+    XCTAssertFalse(
+      policy.allowsEnclosureRedirect(
+        from: source,
+        to: destination,
+        redirectNumber: 2,
+        displayVersion: "0.2.0"
+      )
+    )
+
+    for location in [
+      "http://release-assets.githubusercontent.com/github-production-release-asset/12345/01234567-89ab-cdef-0123-456789abcdef?sig=fixture",
+      "https://objects.githubusercontent.com/github-production-release-asset/12345/01234567-89ab-cdef-0123-456789abcdef?sig=fixture",
+      "https://user@release-assets.githubusercontent.com/github-production-release-asset/12345/01234567-89ab-cdef-0123-456789abcdef?sig=fixture",
+      "https://release-assets.githubusercontent.com:443/github-production-release-asset/12345/01234567-89ab-cdef-0123-456789abcdef?sig=fixture",
+      "https://release-assets.githubusercontent.com/github-production-release-asset/12345/01234567-89ab-cdef-0123-456789abcdef",
+      "https://release-assets.githubusercontent.com/other/12345/01234567-89ab-cdef-0123-456789abcdef?sig=fixture",
+      "https://release-assets.githubusercontent.com/github-production-release-asset/not-numeric/01234567-89ab-cdef-0123-456789abcdef?sig=fixture",
+      "https://release-assets.githubusercontent.com/github-production-release-asset/12345/%2e%2e?sig=fixture",
+    ] {
+      XCTAssertFalse(
+        policy.allowsEnclosureRedirect(
+          from: source,
+          to: URL(string: location)!,
+          redirectNumber: 1,
+          displayVersion: "0.2.0"
+        ),
+        location
+      )
+    }
   }
 
   func testDowngradeReplayAndMalformedLocationFailClosed() {
@@ -265,13 +322,44 @@ private struct SecureUpdateProofPolicy {
       toVersion: installedBuild
     )
     if installedComparison == .orderedAscending { return .rejected(.downgrade) }
-    if installedComparison == .orderedSame { return .noUpdate }
     if comparator.compareVersion(candidate.feedBuild, toVersion: highestAuthenticatedBuild)
       == .orderedAscending
     {
       return .rejected(.replay)
     }
+    if installedComparison == .orderedSame { return .noUpdate }
     return .installAllowed
+  }
+
+  func allowsEnclosureRedirect(
+    from source: URL,
+    to destination: URL,
+    redirectNumber: Int,
+    displayVersion: String
+  ) -> Bool {
+    guard redirectNumber == 1,
+      isApprovedDownloadLocation(source, displayVersion: displayVersion),
+      destination.scheme == "https",
+      destination.host == "release-assets.githubusercontent.com",
+      destination.user == nil,
+      destination.password == nil,
+      destination.port == nil,
+      destination.query?.isEmpty == false,
+      destination.fragment == nil
+    else {
+      return false
+    }
+
+    let pathComponents = destination.pathComponents
+    guard pathComponents.count == 4,
+      pathComponents[0] == "/",
+      pathComponents[1] == "github-production-release-asset",
+      isASCIIDecimal(pathComponents[2]),
+      isOpaqueAssetIdentifier(pathComponents[3])
+    else {
+      return false
+    }
+    return true
   }
 
   private func isCanonicalBuild(_ version: String) -> Bool {
@@ -308,6 +396,17 @@ private struct SecureUpdateProofPolicy {
       return false
     }
     return true
+  }
+
+  private func isASCIIDecimal(_ value: String) -> Bool {
+    !value.isEmpty && value.utf8.allSatisfy { (48...57).contains($0) }
+  }
+
+  private func isOpaqueAssetIdentifier(_ value: String) -> Bool {
+    guard (1...128).contains(value.utf8.count) else { return false }
+    return value.utf8.allSatisfy {
+      (48...57).contains($0) || (65...90).contains($0) || (97...122).contains($0) || $0 == 45
+    }
   }
 }
 

--- a/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift
+++ b/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift
@@ -1,0 +1,351 @@
+import Foundation
+import Sparkle
+import XCTest
+
+final class SecureUpdateArchitectureProofTests: XCTestCase {
+  private let policy = SecureUpdateProofPolicy(maximumDownloadBytes: 256 * 1_024 * 1_024)
+
+  func testPinnedSparkleComparatorUsesBundleBuildOrdering() {
+    let comparator = SUStandardVersionComparator.default
+
+    XCTAssertEqual(comparator.compareVersion("2", toVersion: "2"), .orderedSame)
+    XCTAssertEqual(comparator.compareVersion("3", toVersion: "2"), .orderedDescending)
+    XCTAssertEqual(comparator.compareVersion("2", toVersion: "3"), .orderedAscending)
+    XCTAssertEqual(comparator.compareVersion("10", toVersion: "9"), .orderedDescending)
+  }
+
+  func testAuthenticatedNewerMatchingCandidateReachesInstallDecision() {
+    XCTAssertEqual(
+      policy.decision(for: .valid, installedBuild: "2", highestAuthenticatedBuild: "2"),
+      .installAllowed
+    )
+  }
+
+  func testCurrentVersionIsNotAnUpdate() {
+    var candidate = SecureUpdateProofCandidate.valid
+    candidate.feedBuild = "2"
+    candidate.archiveBuild = "2"
+
+    XCTAssertEqual(
+      policy.decision(for: candidate, installedBuild: "2", highestAuthenticatedBuild: "2"),
+      .noUpdate
+    )
+  }
+
+  func testUntrustedOrMismatchedCandidatesFailClosed() {
+    assertRejected(\.feedAuthenticated, value: false, reason: .invalidFeedSignature)
+    assertRejected(\.archiveAuthenticated, value: false, reason: .invalidArchiveSignature)
+    assertRejected(\.archiveBuild, value: "4", reason: .versionMismatch)
+    assertRejected(\.archiveDisplayVersion, value: "0.2.1", reason: .versionMismatch)
+    assertRejected(\.actualDownloadBytes, value: 4_095, reason: .sizeMismatch)
+  }
+
+  func testDowngradeReplayAndMalformedLocationFailClosed() {
+    var downgrade = SecureUpdateProofCandidate.valid
+    downgrade.feedBuild = "1"
+    downgrade.archiveBuild = "1"
+    XCTAssertEqual(
+      policy.decision(for: downgrade, installedBuild: "2", highestAuthenticatedBuild: "2"),
+      .rejected(.downgrade)
+    )
+
+    var replay = SecureUpdateProofCandidate.valid
+    replay.feedBuild = "3"
+    replay.archiveBuild = "3"
+    XCTAssertEqual(
+      policy.decision(for: replay, installedBuild: "2", highestAuthenticatedBuild: "4"),
+      .rejected(.replay)
+    )
+
+    for location in [
+      "http://github.com/bennetthilberg/copylasso/releases/download/v0.2.0/CopyLasso-0.2.0.dmg",
+      "https://example.invalid/CopyLasso-0.2.0.dmg",
+      "https://github.com/bennetthilberg/copylasso/archive/CopyLasso-0.2.0.dmg",
+      "https://github.com/bennetthilberg/copylasso/releases/download/v0.2.0/update.zip",
+      "https://github.com/bennetthilberg/copylasso/releases/download/v0.2.0/CopyLasso-0.2.0.dmg?tracking=1",
+    ] {
+      var malformed = SecureUpdateProofCandidate.valid
+      malformed.downloadURL = URL(string: location)!
+      XCTAssertEqual(
+        policy.decision(for: malformed, installedBuild: "2", highestAuthenticatedBuild: "2"),
+        .rejected(.invalidDownloadLocation),
+        location
+      )
+    }
+  }
+
+  func testBuildVersionsMustUseCanonicalPositiveDecimalIntegers() {
+    for version in ["", "0", "01", "1.0", "+3", " 3", "3 ", "３", "1234567890123456789"] {
+      var candidate = SecureUpdateProofCandidate.valid
+      candidate.feedBuild = version
+      candidate.archiveBuild = version
+      XCTAssertEqual(
+        policy.decision(for: candidate, installedBuild: "2", highestAuthenticatedBuild: "2"),
+        .rejected(.invalidVersion),
+        version
+      )
+    }
+
+    XCTAssertEqual(
+      policy.decision(
+        for: .valid,
+        installedBuild: "02",
+        highestAuthenticatedBuild: "2"
+      ),
+      .rejected(.invalidVersion)
+    )
+    XCTAssertEqual(
+      policy.decision(
+        for: .valid,
+        installedBuild: "2",
+        highestAuthenticatedBuild: ""
+      ),
+      .rejected(.invalidVersion)
+    )
+  }
+
+  func testEmptyAndOversizedDownloadsFailClosed() {
+    for size in [0, 256 * 1_024 * 1_024 + 1] {
+      var candidate = SecureUpdateProofCandidate.valid
+      candidate.expectedDownloadBytes = size
+      candidate.actualDownloadBytes = size
+      XCTAssertEqual(
+        policy.decision(for: candidate, installedBuild: "2", highestAuthenticatedBuild: "2"),
+        .rejected(.invalidDownloadSize)
+      )
+    }
+  }
+
+  func testCancellationInterruptionAndOfflineFailureRemoveStagingAndPreserveInstall() {
+    for failure in SecureUpdateProofFailure.allCases {
+      var transaction = SecureUpdateProofTransaction(installedBuild: "2")
+      transaction.beginCheck()
+      transaction.beginDownload(candidateBuild: "3")
+      transaction.fail(failure)
+
+      XCTAssertEqual(transaction.installedBuild, "2", String(describing: failure))
+      XCTAssertNil(transaction.stagedBuild, String(describing: failure))
+      XCTAssertEqual(transaction.state, .failed(failure), String(describing: failure))
+    }
+  }
+
+  func testDeferralAndSuccessfulCommitAreExplicitAndDeterministic() {
+    var deferred = SecureUpdateProofTransaction(installedBuild: "2")
+    deferred.beginCheck()
+    deferred.deferUpdate(candidateBuild: "3")
+    XCTAssertEqual(deferred.state, .deferred(candidateBuild: "3"))
+    XCTAssertEqual(deferred.installedBuild, "2")
+    XCTAssertNil(deferred.stagedBuild)
+
+    var premature = SecureUpdateProofTransaction(installedBuild: "2")
+    premature.beginCheck()
+    premature.beginDownload(candidateBuild: "3")
+    premature.commitInstallAfterConfirmation()
+    XCTAssertEqual(premature.installedBuild, "2")
+    XCTAssertEqual(premature.state, .downloading(candidateBuild: "3"))
+
+    var installed = SecureUpdateProofTransaction(installedBuild: "2")
+    installed.beginCheck()
+    installed.beginDownload(candidateBuild: "3")
+    installed.finishDownload()
+    installed.commitInstallAfterConfirmation()
+    XCTAssertEqual(installed.state, .idle)
+    XCTAssertEqual(installed.installedBuild, "3")
+    XCTAssertNil(installed.stagedBuild)
+  }
+
+  private func assertRejected<Value>(
+    _ keyPath: WritableKeyPath<SecureUpdateProofCandidate, Value>,
+    value: Value,
+    reason: SecureUpdateProofRejection,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    var candidate = SecureUpdateProofCandidate.valid
+    candidate[keyPath: keyPath] = value
+    XCTAssertEqual(
+      policy.decision(for: candidate, installedBuild: "2", highestAuthenticatedBuild: "2"),
+      .rejected(reason),
+      file: file,
+      line: line
+    )
+  }
+}
+
+private struct SecureUpdateProofCandidate {
+  var feedAuthenticated: Bool
+  var archiveAuthenticated: Bool
+  var feedBuild: String
+  var archiveBuild: String
+  var displayVersion: String
+  var archiveDisplayVersion: String
+  var expectedDownloadBytes: Int
+  var actualDownloadBytes: Int
+  var downloadURL: URL
+
+  static let valid = SecureUpdateProofCandidate(
+    feedAuthenticated: true,
+    archiveAuthenticated: true,
+    feedBuild: "3",
+    archiveBuild: "3",
+    displayVersion: "0.2.0",
+    archiveDisplayVersion: "0.2.0",
+    expectedDownloadBytes: 4_096,
+    actualDownloadBytes: 4_096,
+    downloadURL: URL(
+      string:
+        "https://github.com/bennetthilberg/copylasso/releases/download/v0.2.0/CopyLasso-0.2.0.dmg"
+    )!
+  )
+}
+
+private enum SecureUpdateProofRejection: Equatable {
+  case downgrade
+  case invalidArchiveSignature
+  case invalidDownloadLocation
+  case invalidDownloadSize
+  case invalidFeedSignature
+  case invalidVersion
+  case replay
+  case sizeMismatch
+  case versionMismatch
+}
+
+private enum SecureUpdateProofDecision: Equatable {
+  case installAllowed
+  case noUpdate
+  case rejected(SecureUpdateProofRejection)
+}
+
+private struct SecureUpdateProofPolicy {
+  let maximumDownloadBytes: Int
+
+  func decision(
+    for candidate: SecureUpdateProofCandidate,
+    installedBuild: String,
+    highestAuthenticatedBuild: String
+  ) -> SecureUpdateProofDecision {
+    let comparator = SUStandardVersionComparator.default
+
+    guard isCanonicalBuild(candidate.feedBuild),
+      isCanonicalBuild(candidate.archiveBuild),
+      isCanonicalBuild(installedBuild),
+      isCanonicalBuild(highestAuthenticatedBuild)
+    else {
+      return .rejected(.invalidVersion)
+    }
+    guard candidate.feedAuthenticated else { return .rejected(.invalidFeedSignature) }
+    guard candidate.archiveAuthenticated else { return .rejected(.invalidArchiveSignature) }
+    guard candidate.feedBuild == candidate.archiveBuild,
+      candidate.displayVersion == candidate.archiveDisplayVersion
+    else {
+      return .rejected(.versionMismatch)
+    }
+    guard candidate.expectedDownloadBytes > 0,
+      candidate.expectedDownloadBytes <= maximumDownloadBytes
+    else {
+      return .rejected(.invalidDownloadSize)
+    }
+    guard candidate.expectedDownloadBytes == candidate.actualDownloadBytes else {
+      return .rejected(.sizeMismatch)
+    }
+    guard isApprovedDownloadLocation(candidate.downloadURL) else {
+      return .rejected(.invalidDownloadLocation)
+    }
+
+    let installedComparison = comparator.compareVersion(
+      candidate.feedBuild,
+      toVersion: installedBuild
+    )
+    if installedComparison == .orderedAscending { return .rejected(.downgrade) }
+    if installedComparison == .orderedSame { return .noUpdate }
+    if comparator.compareVersion(candidate.feedBuild, toVersion: highestAuthenticatedBuild)
+      == .orderedAscending
+    {
+      return .rejected(.replay)
+    }
+    return .installAllowed
+  }
+
+  private func isCanonicalBuild(_ version: String) -> Bool {
+    guard (1...18).contains(version.utf8.count),
+      version.utf8.first.map({ (49...57).contains($0) }) == true
+    else {
+      return false
+    }
+    return version.utf8.allSatisfy { (48...57).contains($0) }
+  }
+
+  private func isApprovedDownloadLocation(_ url: URL) -> Bool {
+    guard url.scheme == "https",
+      url.host == "github.com",
+      url.user == nil,
+      url.password == nil,
+      url.port == nil,
+      url.query == nil,
+      url.fragment == nil,
+      url.path.hasPrefix("/bennetthilberg/copylasso/releases/download/"),
+      url.lastPathComponent.hasPrefix("CopyLasso-"),
+      url.pathExtension == "dmg"
+    else {
+      return false
+    }
+    return true
+  }
+}
+
+private enum SecureUpdateProofFailure: CaseIterable, Equatable {
+  case cancelled
+  case diskExhausted
+  case interrupted
+  case malformedFeed
+  case offline
+  case signatureRejected
+  case timedOut
+}
+
+private enum SecureUpdateProofTransactionState: Equatable {
+  case checking
+  case deferred(candidateBuild: String)
+  case downloading(candidateBuild: String)
+  case failed(SecureUpdateProofFailure)
+  case idle
+  case staged(candidateBuild: String)
+}
+
+private struct SecureUpdateProofTransaction {
+  private(set) var installedBuild: String
+  private(set) var stagedBuild: String?
+  private(set) var state = SecureUpdateProofTransactionState.idle
+
+  mutating func beginCheck() {
+    state = .checking
+  }
+
+  mutating func deferUpdate(candidateBuild: String) {
+    stagedBuild = nil
+    state = .deferred(candidateBuild: candidateBuild)
+  }
+
+  mutating func beginDownload(candidateBuild: String) {
+    stagedBuild = candidateBuild
+    state = .downloading(candidateBuild: candidateBuild)
+  }
+
+  mutating func finishDownload() {
+    guard let stagedBuild else { return }
+    state = .staged(candidateBuild: stagedBuild)
+  }
+
+  mutating func commitInstallAfterConfirmation() {
+    guard case .staged(let candidateBuild) = state else { return }
+    installedBuild = candidateBuild
+    stagedBuild = nil
+    state = .idle
+  }
+
+  mutating func fail(_ failure: SecureUpdateProofFailure) {
+    stagedBuild = nil
+    state = .failed(failure)
+  }
+}

--- a/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift
+++ b/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift
@@ -63,6 +63,8 @@ final class SecureUpdateArchitectureProofTests: XCTestCase {
       "https://github.com/bennetthilberg/copylasso/archive/CopyLasso-0.2.0.dmg",
       "https://github.com/bennetthilberg/copylasso/releases/download/v0.2.0/update.zip",
       "https://github.com/bennetthilberg/copylasso/releases/download/v0.2.0/CopyLasso-0.2.0.dmg?tracking=1",
+      "https://github.com/bennetthilberg/copylasso/releases/download/tag/%2e%2e/%2e%2e/evil/CopyLasso-0.2.0.dmg",
+      "https://github.com/bennetthilberg/copylasso/releases/download//v0.2.0/CopyLasso-0.2.0.dmg",
     ] {
       var malformed = SecureUpdateProofCandidate.valid
       malformed.downloadURL = URL(string: location)!
@@ -249,7 +251,12 @@ private struct SecureUpdateProofPolicy {
     guard candidate.expectedDownloadBytes == candidate.actualDownloadBytes else {
       return .rejected(.sizeMismatch)
     }
-    guard isApprovedDownloadLocation(candidate.downloadURL) else {
+    guard
+      isApprovedDownloadLocation(
+        candidate.downloadURL,
+        displayVersion: candidate.displayVersion
+      )
+    else {
       return .rejected(.invalidDownloadLocation)
     }
 
@@ -276,7 +283,18 @@ private struct SecureUpdateProofPolicy {
     return version.utf8.allSatisfy { (48...57).contains($0) }
   }
 
-  private func isApprovedDownloadLocation(_ url: URL) -> Bool {
+  private func isApprovedDownloadLocation(_ url: URL, displayVersion: String) -> Bool {
+    let expectedPath =
+      "/bennetthilberg/copylasso/releases/download/v\(displayVersion)/CopyLasso-\(displayVersion).dmg"
+    let expectedComponents = [
+      "/",
+      "bennetthilberg",
+      "copylasso",
+      "releases",
+      "download",
+      "v\(displayVersion)",
+      "CopyLasso-\(displayVersion).dmg",
+    ]
     guard url.scheme == "https",
       url.host == "github.com",
       url.user == nil,
@@ -284,9 +302,8 @@ private struct SecureUpdateProofPolicy {
       url.port == nil,
       url.query == nil,
       url.fragment == nil,
-      url.path.hasPrefix("/bennetthilberg/copylasso/releases/download/"),
-      url.lastPathComponent.hasPrefix("CopyLasso-"),
-      url.pathExtension == "dmg"
+      url.path(percentEncoded: true) == expectedPath,
+      url.pathComponents == expectedComponents
     else {
       return false
     }

--- a/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift
+++ b/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift
@@ -43,12 +43,43 @@ final class SecureUpdateArchitectureProofTests: XCTestCase {
     )
   }
 
+  func testFirstUpdaterLaunchSeedsHighWaterFromAuthenticatedInstalledBuild() {
+    XCTAssertEqual(
+      policy.initialHighWaterBuild(installedBuild: "2", persistedBuild: nil),
+      "2"
+    )
+    XCTAssertEqual(
+      policy.decision(for: .valid, installedBuild: "2", highestAuthenticatedBuild: nil),
+      .installAllowed
+    )
+    XCTAssertEqual(
+      policy.decision(for: .valid, installedBuild: "2", highestAuthenticatedBuild: ""),
+      .rejected(.invalidVersion)
+    )
+  }
+
   func testUntrustedOrMismatchedCandidatesFailClosed() {
     assertRejected(\.feedAuthenticated, value: false, reason: .invalidFeedSignature)
     assertRejected(\.archiveAuthenticated, value: false, reason: .invalidArchiveSignature)
     assertRejected(\.archiveBuild, value: "4", reason: .versionMismatch)
     assertRejected(\.archiveDisplayVersion, value: "0.2.1", reason: .versionMismatch)
     assertRejected(\.actualDownloadBytes, value: 4_095, reason: .sizeMismatch)
+  }
+
+  func testOnlySignedInlinePlainTextReleaseNotesAreAccepted() {
+    for source in [
+      SecureUpdateProofReleaseNotes.externalURL,
+      .inlineHTML,
+      .inlinePlainText(" \n"),
+      .missing,
+    ] {
+      var candidate = SecureUpdateProofCandidate.valid
+      candidate.releaseNotes = source
+      XCTAssertEqual(
+        policy.decision(for: candidate, installedBuild: "2", highestAuthenticatedBuild: "2"),
+        .rejected(.invalidReleaseNotes)
+      )
+    }
   }
 
   func testDowngradeReplayAndMalformedLocationFailClosed() {
@@ -129,6 +160,36 @@ final class SecureUpdateArchitectureProofTests: XCTestCase {
     }
   }
 
+  func testStreamingDownloadCancelsAtSignedLengthAndAbsoluteCap() {
+    var signedLengthCancellationCount = 0
+    var signedLengthBudget = SecureUpdateProofDownloadBudget(
+      signedExpectedBytes: 4_096,
+      maximumBytes: 256 * 1_024 * 1_024
+    )
+    signedLengthBudget.begin {
+      signedLengthCancellationCount += 1
+    }
+    signedLengthBudget.receiveData(length: 4_096)
+    XCTAssertFalse(signedLengthBudget.cancelled)
+    signedLengthBudget.receiveData(length: 1)
+    XCTAssertTrue(signedLengthBudget.cancelled)
+    XCTAssertEqual(signedLengthCancellationCount, 1)
+    signedLengthBudget.receiveData(length: UInt64.max)
+    XCTAssertEqual(signedLengthCancellationCount, 1)
+
+    var capCancellationCount = 0
+    var capBudget = SecureUpdateProofDownloadBudget(
+      signedExpectedBytes: 256 * 1_024 * 1_024,
+      maximumBytes: 256 * 1_024 * 1_024
+    )
+    capBudget.begin {
+      capCancellationCount += 1
+    }
+    capBudget.receiveExpectedContentLength(300 * 1_024 * 1_024)
+    XCTAssertTrue(capBudget.cancelled)
+    XCTAssertEqual(capCancellationCount, 1)
+  }
+
   func testCancellationInterruptionAndOfflineFailureRemoveStagingAndPreserveInstall() {
     for failure in SecureUpdateProofFailure.allCases {
       var transaction = SecureUpdateProofTransaction(installedBuild: "2")
@@ -192,6 +253,7 @@ private struct SecureUpdateProofCandidate {
   var archiveBuild: String
   var displayVersion: String
   var archiveDisplayVersion: String
+  var releaseNotes: SecureUpdateProofReleaseNotes
   var expectedDownloadBytes: Int
   var actualDownloadBytes: Int
   var downloadURL: URL
@@ -203,6 +265,7 @@ private struct SecureUpdateProofCandidate {
     archiveBuild: "3",
     displayVersion: "0.2.0",
     archiveDisplayVersion: "0.2.0",
+    releaseNotes: .inlinePlainText("Security and reliability improvements."),
     expectedDownloadBytes: 4_096,
     actualDownloadBytes: 4_096,
     downloadURL: URL(
@@ -212,12 +275,20 @@ private struct SecureUpdateProofCandidate {
   )
 }
 
+private enum SecureUpdateProofReleaseNotes: Equatable {
+  case externalURL
+  case inlineHTML
+  case inlinePlainText(String)
+  case missing
+}
+
 private enum SecureUpdateProofRejection: Equatable {
   case downgrade
   case invalidArchiveSignature
   case invalidDownloadLocation
   case invalidDownloadSize
   case invalidFeedSignature
+  case invalidReleaseNotes
   case invalidVersion
   case replay
   case sizeMismatch
@@ -236,14 +307,16 @@ private struct SecureUpdateProofPolicy {
   func decision(
     for candidate: SecureUpdateProofCandidate,
     installedBuild: String,
-    highestAuthenticatedBuild: String
+    highestAuthenticatedBuild: String?
   ) -> SecureUpdateProofDecision {
     let comparator = SUStandardVersionComparator.default
 
     guard isCanonicalBuild(candidate.feedBuild),
       isCanonicalBuild(candidate.archiveBuild),
-      isCanonicalBuild(installedBuild),
-      isCanonicalBuild(highestAuthenticatedBuild)
+      let resolvedHighWaterBuild = initialHighWaterBuild(
+        installedBuild: installedBuild,
+        persistedBuild: highestAuthenticatedBuild
+      )
     else {
       return .rejected(.invalidVersion)
     }
@@ -253,6 +326,11 @@ private struct SecureUpdateProofPolicy {
       candidate.displayVersion == candidate.archiveDisplayVersion
     else {
       return .rejected(.versionMismatch)
+    }
+    guard case .inlinePlainText(let releaseNotes) = candidate.releaseNotes,
+      !releaseNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else {
+      return .rejected(.invalidReleaseNotes)
     }
     guard candidate.expectedDownloadBytes > 0,
       candidate.expectedDownloadBytes <= maximumDownloadBytes
@@ -276,13 +354,20 @@ private struct SecureUpdateProofPolicy {
       toVersion: installedBuild
     )
     if installedComparison == .orderedAscending { return .rejected(.downgrade) }
-    if comparator.compareVersion(candidate.feedBuild, toVersion: highestAuthenticatedBuild)
+    if comparator.compareVersion(candidate.feedBuild, toVersion: resolvedHighWaterBuild)
       == .orderedAscending
     {
       return .rejected(.replay)
     }
     if installedComparison == .orderedSame { return .noUpdate }
     return .installAllowed
+  }
+
+  func initialHighWaterBuild(installedBuild: String, persistedBuild: String?) -> String? {
+    guard isCanonicalBuild(installedBuild) else { return nil }
+    guard let persistedBuild else { return installedBuild }
+    guard isCanonicalBuild(persistedBuild) else { return nil }
+    return persistedBuild
   }
 
   private func isCanonicalBuild(_ version: String) -> Bool {
@@ -321,6 +406,52 @@ private struct SecureUpdateProofPolicy {
     return true
   }
 
+}
+
+private struct SecureUpdateProofDownloadBudget {
+  let signedExpectedBytes: UInt64
+  let maximumBytes: UInt64
+
+  private(set) var cancelled = false
+  private(set) var receivedBytes: UInt64 = 0
+  private var cancellation: (() -> Void)?
+
+  init(signedExpectedBytes: UInt64, maximumBytes: UInt64) {
+    self.signedExpectedBytes = signedExpectedBytes
+    self.maximumBytes = maximumBytes
+  }
+
+  mutating func begin(cancellation: @escaping () -> Void) {
+    self.cancellation = cancellation
+  }
+
+  mutating func receiveExpectedContentLength(_ length: UInt64) {
+    guard length == signedExpectedBytes, length <= maximumBytes else {
+      cancel()
+      return
+    }
+  }
+
+  mutating func receiveData(length: UInt64) {
+    guard !cancelled else { return }
+    let (nextReceivedBytes, overflowed) = receivedBytes.addingReportingOverflow(length)
+    guard !overflowed,
+      nextReceivedBytes <= signedExpectedBytes,
+      nextReceivedBytes <= maximumBytes
+    else {
+      cancel()
+      return
+    }
+    receivedBytes = nextReceivedBytes
+  }
+
+  private mutating func cancel() {
+    guard !cancelled else { return }
+    cancelled = true
+    let cancellation = self.cancellation
+    self.cancellation = nil
+    cancellation?()
+  }
 }
 
 private enum SecureUpdateProofFailure: CaseIterable, Equatable {

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Clone the repository, open `CopyLasso.xcodeproj`, and run the shared `CopyLasso`
 ./scripts/ci.sh
 ```
 
-Architecture and test details are documented in [Architecture Overview](docs/architecture/overview.md), [Testing](docs/testing.md), and [Manual QA and Performance](docs/manual-qa-and-performance.md). The exact KeyboardShortcuts dependency and license are recorded in [Third-Party Notices](THIRD_PARTY_NOTICES.md).
+Architecture and test details are documented in [Architecture Overview](docs/architecture/overview.md), [Testing](docs/testing.md), and [Manual QA and Performance](docs/manual-qa-and-performance.md). The exact shipping KeyboardShortcuts dependency and license are recorded in [Third-Party Notices](THIRD_PARTY_NOTICES.md); the test-only secure-update dependency proof is recorded in [ADR-004](docs/architecture/ADR-004-secure-updates.md).
 
 ## Contributing
 

--- a/docs/architecture/ADR-004-secure-updates.md
+++ b/docs/architecture/ADR-004-secure-updates.md
@@ -58,14 +58,20 @@ G35 neither publishes nor requests either endpoint.
 
 [GitHub's release-asset API](https://docs.github.com/en/rest/releases/assets#get-a-release-asset)
 documents that an asset request may return the bytes directly or redirect the
-client. G36 may follow exactly one redirect from an already validated enclosure
-URL to HTTPS `release-assets.githubusercontent.com`, with no user information,
-custom port, fragment, or further redirect. The destination must retain
-GitHub's `github-production-release-asset/<numeric repository>/<opaque asset>`
-path shape and a nonempty signed query. A different host or shape fails closed
-until a separately reviewed architecture change. The downloaded bytes still
-must pass length, Ed25519, Developer ID, notarization, version, and architecture
-checks; transport location never authorizes installation.
+client. Sparkle 2.9.4 constructs the initial enclosure request from
+`SUAppcastItem.fileURL`, exposes that request through
+`updater:willDownloadUpdate:withRequest:`, and then downloads it with an
+internal `NSURLSession`. Its public API exposes no per-redirect decision hook;
+the session therefore follows ordinary HTTPS redirects. G36 must validate the
+exact initial enclosure URL from the `SUAppcastItem` passed to
+`SPUUserDriver.showUpdateFound` before returning the Install choice that begins
+the download, but it must not claim that CopyLasso can enforce a
+destination-host or redirect-count allowlist through Sparkle's supported API.
+Every response body remains untrusted until the signed enclosure length and
+Ed25519 signature pass, followed by Developer ID, notarization, version, and
+architecture checks. If redirect-level policy becomes a requirement, the
+architecture must be amended before shipping rather than relying on an
+unconnected policy helper or Sparkle private API.
 
 G36 will use these non-secret settings:
 
@@ -79,6 +85,11 @@ G36 will use these non-secret settings:
 - `SURequireSignedFeed = YES`;
 - `SUSignedFeedFailureExpirationInterval = 0`; and
 - `SUEnableInstallerLauncherService = YES`, without the downloader service.
+
+The signed-feed expiration spelling above is locked to the pinned 2.9.4 source:
+`SUConstants.m` maps `SUSignedFeedFailureExpirationIntervalKey` to that exact
+Info.plist key, and `SUAppcastDriver.m` treats zero as never recovering from a
+failed feed signature.
 
 The app will add `com.apple.security.network.client` and one
 `com.apple.security.temporary-exception.mach-lookup.global-name` array containing
@@ -108,8 +119,10 @@ The G35 proof uses Sparkle's real `SUStandardVersionComparator`, real
   exposure.
 - Only the fixed HTTPS GitHub Releases owner, repository, tag path, DMG naming,
   and a URL without user info, port, query, or fragment are accepted.
-- The sole allowed redirect is the bounded GitHub release-asset CDN handoff
-  above; all other and follow-on redirects fail closed.
+- Redirect destinations are transport, not trust inputs. Sparkle's supported
+  integration surface does not expose a redirect-policy callback, so enclosure
+  signature and metadata verification must fail closed regardless of the final
+  response URL.
 - Offline, timeout, malformed feed, invalid signature, cancellation, disk-full,
   and interruption paths remove staging and preserve the installed build.
 - Installation commits only after a verified download and explicit final user

--- a/docs/architecture/ADR-004-secure-updates.md
+++ b/docs/architecture/ADR-004-secure-updates.md
@@ -105,7 +105,9 @@ The G35 proof uses Sparkle's real `SUStandardVersionComparator`, real
 The fixture creates a fresh test-only Ed25519 key in a temporary directory,
 signs and verifies an archive and appcast with Sparkle's shipped tools while
 network access is denied, rejects mutations inside the signed feed bytes,
-archive tampering, and a second key, then destroys all fixture material.
+archive tampering, and a second key. It also authenticates deliberately
+malformed XML and proves Sparkle's real appcast parser rejects it before any
+selection decision, then destroys all fixture material.
 Sparkle's signed-feed envelope authenticates an explicit content length and
 parses only those verified bytes; data appended after that envelope cannot alter
 the authenticated appcast. No production key or public feed exists in G35.

--- a/docs/architecture/ADR-004-secure-updates.md
+++ b/docs/architecture/ADR-004-secure-updates.md
@@ -1,0 +1,124 @@
+# ADR-004: Sparkle Provides the Secure Update Boundary
+
+- **Status:** Accepted for G36 implementation
+- **Date:** July 22, 2026
+- **Scope:** G35 architecture proof only; no updater ships in this goal
+
+## Context
+
+CopyLasso 0.2 must check for updates about once per day, let the user defer or
+disable checks, show authenticated update details before a download begins, and
+install only a verified replacement. The app is sandboxed, dockless, and
+distributed outside the Mac App Store. G35 must select and prove an architecture
+without adding a public feed, a production signing secret, an update UI, or a
+shipping updater framework.
+
+The proof pins [Sparkle 2.9.4](https://github.com/sparkle-project/Sparkle/releases/tag/2.9.4)
+at source revision `b6496a74a087257ef5e6da1c5b29a447a60f5bd7`. Its official Swift Package
+artifact has SHA-256
+`cb6fdbdc8884f15d62a616e79face92b08322410fd2d425edc6596ccbf4ba3b0`.
+That release was published July 3, 2026, includes a dockless-application update
+UI fix, and its macOS framework contains both `arm64` and `x86_64` slices.
+Sparkle is linked only into `CopyLassoTests` in G35 so the production app,
+entitlements, release bytes, and third-party notices remain unchanged.
+
+## Options
+
+| Criterion | Sparkle 2.9.4 | First-party updater |
+| --- | --- | --- |
+| Feed and archive authentication | Ed25519 appcast and archive verification with maintained tools | New canonicalization, signing, parsing, and rotation code to design and audit |
+| Sandboxed installation | Documented installer services and hardened-runtime integration | New privileged/helper lifecycle and replacement transaction |
+| macOS 14 and Universal 2 | Pinned artifact supports macOS 10.15+ and contains `arm64` plus `x86_64` | Every helper, installer, and transaction must be built and qualified twice |
+| Failure recovery | Mature download, extraction, install, relaunch, and error paths | New interruption, disk-full, rollback, cleanup, and relaunch state machine |
+| User control | Scheduled and user-initiated drivers, deferral, cancellation, progress | Every state and accessible surface must be built from scratch |
+| Maintenance and license | Active, permissive [license bundle](https://github.com/sparkle-project/Sparkle/blob/2.9.4/LICENSE); one pinned dependency | No dependency, but CopyLasso permanently owns a large security-sensitive subsystem |
+| Small dockless app fit | 2.9.4 specifically fixes dockless app activation during update UI | Unknown until independently implemented and qualified |
+
+## Decision
+
+Use Sparkle 2.9.4 for update retrieval, Ed25519 verification, staging,
+installation, and relaunch. Building the equivalent first-party subsystem would
+create substantially more security-critical code without improving the product's
+privacy contract.
+
+G36 will integrate `SPUUpdater` with a small CopyLasso-owned `SPUUserDriver` and
+an updater delegate behind a narrow application boundary. The custom driver is
+required because Sparkle's standard alert does not expose the enclosure size
+until download progress begins, while the v0.2 contract requires version,
+release notes, file size, and install/relaunch consequences before the user
+explicitly starts the transaction. Sparkle remains responsible for all security
+and installation work; CopyLasso owns only presentation, consent, focus, and
+retention policy.
+
+The future fixed feed URL is
+`https://updates.copylasso.com/appcast.xml`. Enclosures must use immutable URLs
+of the form
+`https://github.com/bennetthilberg/copylasso/releases/download/<tag>/CopyLasso-<version>.dmg`.
+G35 neither publishes nor requests either endpoint.
+
+G36 will use these non-secret settings:
+
+- `SUFeedURL = https://updates.copylasso.com/appcast.xml` and the reviewed
+  `SUPublicEDKey` value created in G36;
+- `SUEnableAutomaticChecks = YES` and a 24-hour interval;
+- `SUScheduledCheckInterval = 86400`;
+- `SUAutomaticallyUpdate = NO` and `SUAllowsAutomaticUpdates = NO`;
+- `SUEnableSystemProfiling = NO`;
+- `SUVerifyUpdateBeforeExtraction = YES`;
+- `SURequireSignedFeed = YES`;
+- `SUSignedFeedFailureExpirationInterval = 0`; and
+- `SUEnableInstallerLauncherService = YES`, without the downloader service.
+
+The app will add `com.apple.security.network.client` and one
+`com.apple.security.temporary-exception.mach-lookup.global-name` array containing
+exactly `$(PRODUCT_BUNDLE_IDENTIFIER)-spks` and
+`$(PRODUCT_BUNDLE_IDENTIFIER)-spki`, as required by Sparkle's sandboxed
+installer. CopyLasso will not enable `SUEnableDownloaderService`; the pinned
+prebuilt downloader is unsandboxed by default and unnecessary when the app has
+outbound network access. Because the network client entitlement is not
+host-scoped, a static audit will lock the sole feed URL and reject custom request
+headers, cookies, delegate-supplied query parameters, system profiling, or other
+runtime networking.
+
+## Verified Policy
+
+The G35 proof uses Sparkle's real `SUStandardVersionComparator`, real
+`sign_update` tooling, and deterministic transaction policy tests.
+
+- `CFBundleVersion` is the ordering authority and must be a canonical positive
+  ASCII decimal integer of at most 18 digits; display version must match the
+  authenticated archive metadata.
+- An update must be strictly newer than the installed build and not lower than
+  the highest authenticated build previously observed. Lower values fail closed
+  as downgrade or replay attempts.
+- The feed and enclosure must both authenticate, declared and downloaded sizes
+  must match, and an enclosure must be 1 byte through 256 MiB. This conservative
+  ceiling is far above current CopyLasso packages while bounding disk and parser
+  exposure.
+- Only the fixed HTTPS GitHub Releases owner, repository, tag path, DMG naming,
+  and a URL without user info, port, query, or fragment are accepted.
+- Offline, timeout, malformed feed, invalid signature, cancellation, disk-full,
+  and interruption paths remove staging and preserve the installed build.
+- Installation commits only after a verified download and explicit final user
+  confirmation. Deferral leaves the current application untouched.
+
+The fixture creates a fresh test-only Ed25519 key in a temporary directory,
+signs and verifies an archive and appcast with Sparkle's shipped tools while
+network access is denied, rejects mutations inside the signed feed bytes,
+archive tampering, and a second key, then destroys all fixture material.
+Sparkle's signed-feed envelope authenticates an explicit content length and
+parses only those verified bytes; data appended after that envelope cannot alter
+the authenticated appcast. No production key or public feed exists in G35.
+
+## Consequences
+
+Sparkle 2.9.4 becomes a reviewed test-only package dependency in G35 and a
+planned shipping dependency in G36. Before G36 may link it into CopyLasso, the
+production key, sandbox services, UI behavior, acknowledgements, privacy copy,
+release workflow, and rollback record must satisfy
+[`secure-update-operations.md`](../secure-update-operations.md) and
+[`secure-update-threat-model.md`](../secure-update-threat-model.md).
+
+Users on 0.1.x have no updater and must install the first updater-enabled release
+manually from the existing authenticated GitHub release channel. Automatic
+updates can begin only after that bootstrap.

--- a/docs/architecture/ADR-004-secure-updates.md
+++ b/docs/architecture/ADR-004-secure-updates.md
@@ -56,6 +56,13 @@ of the form
 `https://github.com/bennetthilberg/copylasso/releases/download/<tag>/CopyLasso-<version>.dmg`.
 G35 neither publishes nor requests either endpoint.
 
+Release notes must be nonempty inline plain text in the signed appcast. G36
+rejects `releaseNotesURL`, `fullReleaseNotesURL`, HTML descriptions, and missing
+notes before presenting update consent, and its updater delegate returns false
+from `updater:shouldDownloadReleaseNotesForUpdate:`. This keeps the text shown
+to the user inside the authenticated feed envelope and prevents a second
+content or network origin from entering the update flow.
+
 [GitHub's release-asset API](https://docs.github.com/en/rest/releases/assets#get-a-release-asset)
 documents that an asset request may return the bytes directly or redirect the
 client. Sparkle 2.9.4 constructs the initial enclosure request from
@@ -91,6 +98,16 @@ The signed-feed expiration spelling above is locked to the pinned 2.9.4 source:
 Info.plist key, and `SUAppcastDriver.m` treats zero as never recovering from a
 failed feed signature.
 
+With automatic downloads disabled, the custom user driver receives
+`showDownloadInitiatedWithCancellation:` before bytes arrive. It retains that
+cancellation closure only for the active transaction, verifies every
+`showDownloadDidReceiveExpectedContentLength:` value against the signed length
+and 256 MiB ceiling, and sums each
+`showDownloadDidReceiveDataOfLength:` delta with overflow checking. The first
+callback that would exceed either boundary invokes cancellation exactly once,
+removes staging, and rejects the candidate. The final downloaded length must
+still equal the signed length before extraction or installation is authorized.
+
 The app will add `com.apple.security.network.client` and one
 `com.apple.security.temporary-exception.mach-lookup.global-name` array containing
 exactly `$(PRODUCT_BUNDLE_IDENTIFIER)-spks` and
@@ -117,6 +134,8 @@ The G35 proof uses Sparkle's real `SUStandardVersionComparator`, real
   must match, and an enclosure must be 1 byte through 256 MiB. This conservative
   ceiling is far above current CopyLasso packages while bounding disk and parser
   exposure.
+- Only nonempty inline plain-text release notes inside the signed feed are
+  accepted; remote, HTML, and missing notes fail before consent.
 - Only the fixed HTTPS GitHub Releases owner, repository, tag path, DMG naming,
   and a URL without user info, port, query, or fragment are accepted.
 - Redirect destinations are transport, not trust inputs. Sparkle's supported
@@ -127,6 +146,10 @@ The G35 proof uses Sparkle's real `SUStandardVersionComparator`, real
   and interruption paths remove staging and preserve the installed build.
 - Installation commits only after a verified download and explicit final user
   confirmation. Deferral leaves the current application untouched.
+- On the first updater-enabled launch only, an absent authenticated high-water
+  record is initialized from the canonical running `CFBundleVersion` before a
+  network check. A present malformed record fails closed rather than being
+  replaced.
 
 The fixture creates a fresh test-only Ed25519 key in a temporary directory,
 signs and verifies an archive and appcast with Sparkle's shipped tools while

--- a/docs/architecture/ADR-004-secure-updates.md
+++ b/docs/architecture/ADR-004-secure-updates.md
@@ -56,6 +56,17 @@ of the form
 `https://github.com/bennetthilberg/copylasso/releases/download/<tag>/CopyLasso-<version>.dmg`.
 G35 neither publishes nor requests either endpoint.
 
+[GitHub's release-asset API](https://docs.github.com/en/rest/releases/assets#get-a-release-asset)
+documents that an asset request may return the bytes directly or redirect the
+client. G36 may follow exactly one redirect from an already validated enclosure
+URL to HTTPS `release-assets.githubusercontent.com`, with no user information,
+custom port, fragment, or further redirect. The destination must retain
+GitHub's `github-production-release-asset/<numeric repository>/<opaque asset>`
+path shape and a nonempty signed query. A different host or shape fails closed
+until a separately reviewed architecture change. The downloaded bytes still
+must pass length, Ed25519, Developer ID, notarization, version, and architecture
+checks; transport location never authorizes installation.
+
 G36 will use these non-secret settings:
 
 - `SUFeedURL = https://updates.copylasso.com/appcast.xml` and the reviewed
@@ -97,6 +108,8 @@ The G35 proof uses Sparkle's real `SUStandardVersionComparator`, real
   exposure.
 - Only the fixed HTTPS GitHub Releases owner, repository, tag path, DMG naming,
   and a URL without user info, port, query, or fragment are accepted.
+- The sole allowed redirect is the bounded GitHub release-asset CDN handoff
+  above; all other and follow-on redirects fail closed.
 - Offline, timeout, malformed feed, invalid signature, cancellation, disk-full,
   and interruption paths remove staging and preserve the installed build.
 - Installation commits only after a verified download and explicit final user
@@ -107,7 +120,9 @@ signs and verifies an archive and appcast with Sparkle's shipped tools while
 network access is denied, rejects mutations inside the signed feed bytes,
 archive tampering, and a second key. It also authenticates deliberately
 malformed XML and proves Sparkle's real appcast parser rejects it before any
-selection decision, then destroys all fixture material.
+selection decision. A signed well-formed appcast must pass the same parser as a
+positive control before that negative result is accepted, then the fixture
+destroys all material.
 Sparkle's signed-feed envelope authenticates an explicit content length and
 parses only those verified bytes; data appended after that envelope cannot alter
 the authenticated appcast. No production key or public feed exists in G35.

--- a/docs/architecture/build-configuration.md
+++ b/docs/architecture/build-configuration.md
@@ -37,11 +37,13 @@ There is no source-file exclusion list for experimental code. The G05-G07 execut
 
 Both configurations generate their Info.plist through Xcode and set `LSUIElement` to `YES`. The canonical pipeline checks the build setting and the generated Debug and Release bundles so a normal Dock application cannot be introduced accidentally.
 
-## Swift Package Dependency
+## Swift Package Dependencies
 
 KeyboardShortcuts 3.0.1 is an exact Swift Package Manager dependency used for shortcut recording, conflict validation, persistence, and global event delivery. The Xcode project uses an exact-version requirement and commits `Package.resolved` with revision `49c3fc04ea827f816df67843bfcc57286b47ff06`. Its upstream source and MIT license are recorded in [Third-Party Notices](../../THIRD_PARTY_NOTICES.md).
 
 The dependency is confined to the app, Settings, and SwiftUI presentation layers. Models and capture-workflow state remain independent of KeyboardShortcuts, AppKit, SwiftUI, ScreenCaptureKit, and Vision.
+
+G35 also pins Sparkle 2.9.4 at revision `b6496a74a087257ef5e6da1c5b29a447a60f5bd7`, but links it only into `CopyLassoTests` for the real comparator and offline Ed25519 architecture proof. It is absent from the application target, Release bundle, entitlements, and shipped acknowledgements. [ADR-004](ADR-004-secure-updates.md) records the dependency decision, official artifact checksum, license, and G36 gate.
 
 ## Signing
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -103,3 +103,12 @@ matrix and accepted-risk record.
 - [x] Add the focused v0.2 contract audit and enforce exactly one canonical CI invocation.
 - [x] Narrow issue #38 to on-screen QR/barcode recognition and create separate issues for file/PDF input, configurable success sound, and conditional offline LaTeX recognition.
 - [x] Pass both canonical architectures, hosted checks, exact-head review, and final ready-PR readback without changing application source, dependencies, entitlements, release metadata, feeds, tags, or public artifacts.
+
+## G35 - Secure Update Architecture Proof
+
+- [ ] Compare a maintained permissive updater with a first-party implementation and record the accepted architecture, scope, dependency pin, license, and acknowledgement gate.
+- [ ] Threat-model feed, hosting, transport, workflow, signing-key, replay/downgrade, malformed input, interruption, disk, cancellation, privacy, and recovery boundaries.
+- [ ] Prove real comparator and offline Ed25519 archive/appcast behavior with only ephemeral fixture keys; reject tampering, wrong keys, mismatched metadata, unapproved URLs, replay, downgrade, malformed/oversized input, and interrupted transactions.
+- [ ] Confirm Sparkle remains test-only, CopyLasso.app has no updater configuration or network entitlement, release metadata remains `0.1.1 (2)`, and no key, appcast, or public update artifact is created.
+- [ ] Run focused proofs, privacy/security and secure-update audits, canonical arm64/x86_64 pipelines, hosted checks, exact-head review, and ready-PR readback.
+- [ ] Preserve the operations and 0.1.x manual-bootstrap record for G36; do not create production key material, publish a feed, install an update, or start G36.

--- a/docs/secure-update-operations.md
+++ b/docs/secure-update-operations.md
@@ -10,6 +10,15 @@ The production appcast will live at
 GitHub Release assets. DNS and public feed publication are later, separately
 approved work.
 
+The enclosure starts at the exact immutable `github.com` release URL recorded
+in the authenticated feed. GitHub may return the asset directly or issue one
+redirect. Only an HTTPS redirect to `release-assets.githubusercontent.com` with
+the reviewed release-asset path shape, no credentials/custom port/fragment,
+and a nonempty signed query is allowed. No second redirect is followed. A host
+change is a fail-closed incident and requires a reviewed contract update; it is
+not learned dynamically. Enclosure authentication and metadata checks remain
+mandatory after the transport handoff.
+
 Automatic checks default on, run no more often than every 24 hours, and can be
 disabled. A user command may check immediately. Requests contain no system
 profile, hardware data, stable identifier, cookies, custom headers, screen or

--- a/docs/secure-update-operations.md
+++ b/docs/secure-update-operations.md
@@ -1,0 +1,88 @@
+# Secure Update Operations
+
+This runbook records the secure-update decisions that G36 and later release
+goals must implement. G35 creates only local proof fixtures.
+
+## Endpoint and Request Contract
+
+The production appcast will live at
+`https://updates.copylasso.com/appcast.xml`; release DMGs remain immutable
+GitHub Release assets. DNS and public feed publication are later, separately
+approved work.
+
+Automatic checks default on, run no more often than every 24 hours, and can be
+disabled. A user command may check immediately. Requests contain no system
+profile, hardware data, stable identifier, cookies, custom headers, screen or
+clipboard content, or delegate-provided query parameters. Sparkle's ordinary
+user agent contains only the application/display version and Sparkle version.
+The server therefore observes only normal transport metadata such as IP address
+and request time.
+
+## Signing-Key Lifecycle
+
+G36 will create the production Ed25519 key through Sparkle's supported tooling.
+The private key must be passphrase-protected and stored only in the maintainer's
+nonsynchronized login Keychain, a protected GitHub `release` environment secret,
+and one encrypted offline recovery copy. It must never appear in a command
+argument, log, fixture, repository file, build artifact, app bundle, appcast, or
+issue. The public key may be compiled into CopyLasso.
+
+Developer ID credentials, the SSH release-tag signing key, and the update
+Ed25519 key remain separate. Protected release jobs import only the credentials
+needed for their stage after all ordinary tests pass, sign the final enclosure
+and feed, verify both with the public key, publish immutable assets, and destroy
+temporary key material on success or failure.
+
+For planned rotation, ship the replacement public key through a release trusted
+by the current key, confirm adoption, then activate the replacement for a later
+feed. Never rotate publication credentials and application trust in one
+unreadable transaction. If the active key is lost or suspected stolen, stop
+publication, remove its protected secret, preserve evidence, assess already
+published releases, and publish remediation only through a separately reviewed
+incident plan. Users whose installed build cannot authenticate the replacement
+must update manually from the verified GitHub channel.
+
+A bad or revoked release is removed from the next signed appcast without moving
+its tag or replacing its assets. The authenticated high-water mark is retained,
+so recovery is a higher-build incident release rather than a silent downgrade.
+
+## Version and Rollback State
+
+`CFBundleVersion` is a canonical positive ASCII decimal integer of at most 18
+digits and is the monotonic update ordering value. The app persists only
+the check schedule, user automatic-check preference, deferred version, and
+highest authenticated build. It does not persist feed bodies or release notes.
+The installed build is always the minimum accepted baseline; the authenticated
+high-water mark rejects replay after a deferral.
+
+A candidate must be strictly newer than the installed build, not below the
+high-water mark, metadata-consistent, correctly signed, and within the approved
+immutable GitHub URL and 256 MiB size policy. The high-water mark advances only
+after the candidate feed and enclosure metadata authenticate.
+
+## Staging, Cancellation, and Recovery
+
+Downloaded bytes exist only in Sparkle's bounded temporary update transaction.
+Cancellation, signature or metadata rejection, download failure, timeout,
+offline state, disk exhaustion, interrupted extraction, and failed installation
+must leave the installed application untouched and remove staging. Startup
+recovery removes an abandoned transaction before a new check.
+
+The initial update panel shows version, release notes, exact declared size, and
+that CopyLasso will download, quit, install, and relaunch. The user explicitly
+chooses Download or Later. After verified extraction, a second explicit choice
+authorizes Install and Relaunch. Closing, Escape, Later, or Cancel preserves the
+current application; a deferred update may be shown again without downloading
+automatically.
+
+## 0.1.x Bootstrap and G35 Boundary
+
+CopyLasso 0.1.x contains no updater. Its users must download and install the
+first updater-enabled version from the public GitHub release page and verify it
+with the existing checksum, Developer ID, notarization, and Gatekeeper flow.
+Only that installed version can begin automatic checks.
+
+G35 does not create a production key, add an app entitlement, link Sparkle into
+the product, publish a feed, change release bytes, or perform an update. Its
+ephemeral fixture key is generated under a private temporary directory, used
+with networking denied, and removed at exit.

--- a/docs/secure-update-operations.md
+++ b/docs/secure-update-operations.md
@@ -27,10 +27,12 @@ before implementation.
 Automatic checks default on, run no more often than every 24 hours, and can be
 disabled. A user command may check immediately. Requests contain no system
 profile, hardware data, stable identifier, cookies, custom headers, screen or
-clipboard content, or delegate-provided query parameters. Sparkle's ordinary
-user agent contains only the application/display version and Sparkle version.
-The server therefore observes only normal transport metadata such as IP address
-and request time.
+clipboard content, delegate-provided query parameters, or external release-note
+fetches. Release notes are required as nonempty inline plain text inside the
+signed appcast; external/full release-note URLs, HTML notes, and missing notes
+reject the candidate before consent. Sparkle's ordinary user agent contains
+only the application/display version and Sparkle version. The server therefore
+observes only normal transport metadata such as IP address and request time.
 
 ## Signing-Key Lifecycle
 
@@ -69,6 +71,13 @@ highest authenticated build. It does not persist feed bodies or release notes.
 The installed build is always the minimum accepted baseline; the authenticated
 high-water mark rejects replay after a deferral.
 
+An absent high-water record is initialized and persisted before the first
+network check in the first updater-enabled launch, using the canonical running
+`CFBundleVersion`. A present record is never silently repaired: malformed data
+fails closed, while a valid record remains the replay authority. This lets a
+manual 0.1.x bootstrap receive the following update without weakening
+corruption detection.
+
 A candidate must be strictly newer than the installed build, not below the
 high-water mark, metadata-consistent, correctly signed, and within the approved
 immutable GitHub URL and 256 MiB size policy. The high-water mark advances only
@@ -77,6 +86,12 @@ after the candidate feed and enclosure metadata authenticate.
 ## Staging, Cancellation, and Recovery
 
 Downloaded bytes exist only in Sparkle's bounded temporary update transaction.
+The custom user driver retains Sparkle's
+`showDownloadInitiatedWithCancellation:` closure for that transaction. It
+cancels exactly once when an expected-content-length callback disagrees with
+the signed size or exceeds 256 MiB, or when the overflow-checked sum of
+`showDownloadDidReceiveDataOfLength:` deltas first exceeds either boundary.
+Extraction is never authorized until the final length equals the signed value.
 Cancellation, signature or metadata rejection, download failure, timeout,
 offline state, disk exhaustion, interrupted extraction, and failed installation
 must leave the installed application untouched and remove staging. Startup

--- a/docs/secure-update-operations.md
+++ b/docs/secure-update-operations.md
@@ -11,13 +11,18 @@ GitHub Release assets. DNS and public feed publication are later, separately
 approved work.
 
 The enclosure starts at the exact immutable `github.com` release URL recorded
-in the authenticated feed. GitHub may return the asset directly or issue one
-redirect. Only an HTTPS redirect to `release-assets.githubusercontent.com` with
-the reviewed release-asset path shape, no credentials/custom port/fragment,
-and a nonempty signed query is allowed. No second redirect is followed. A host
-change is a fail-closed incident and requires a reviewed contract update; it is
-not learned dynamically. Enclosure authentication and metadata checks remain
-mandatory after the transport handoff.
+in the authenticated feed, and CopyLasso validates that initial URL before the
+user can authorize download: with automatic downloads disabled, the custom
+`SPUUserDriver` receives the `SUAppcastItem` before its Install reply begins
+retrieval. GitHub may return the asset directly or redirect Sparkle's internal
+`NSURLSession`. Sparkle 2.9.4 exposes the initial mutable request to its updater
+delegate but no supported callback for accepting or rejecting each redirect.
+G36 therefore must not implement or advertise a redirect allowlist that it
+cannot connect to the real downloader. It treats the final response location
+and all downloaded bytes as untrusted transport until the signed length and
+Ed25519 enclosure verification succeed. A future need for redirect-level
+enforcement requires an architecture amendment or an upstream supported seam
+before implementation.
 
 Automatic checks default on, run no more often than every 24 hours, and can be
 disabled. A user command may check immediately. Requests contain no system

--- a/docs/secure-update-threat-model.md
+++ b/docs/secure-update-threat-model.md
@@ -1,0 +1,49 @@
+# Secure Update Threat Model
+
+This document defines the G35 trust boundary selected for CopyLasso 0.2. It is a
+design and local proof, not evidence that an updater or public feed ships today.
+
+## Assets and Trust Boundaries
+
+Protected assets are the installed application, the user's decision to update,
+the release-signing private key, the authenticated version history, and the
+temporary downloaded package. The trusted inputs are the public key compiled
+into CopyLasso, an Ed25519-signed appcast, an Ed25519-signed enclosure, and the
+Developer ID/notarization checks already enforced by the release workflow.
+
+The update server, GitHub hosting, DNS, TLS, caches, and network path are useful
+transport but are not trusted to authorize installation. The application must
+fail closed before replacing any installed bytes.
+
+## Threats and Controls
+
+| Threat | Required control | Failure result or residual risk |
+| --- | --- | --- |
+| Feed or CDN compromise | Require signed appcast; reject malformed XML, unknown fields that weaken policy, and unsigned or invalid data | No update; current app remains usable |
+| GitHub release compromise or artifact substitution | Verify enclosure Ed25519 signature, exact length, immutable release URL, Developer ID identity, notarization, version, and architecture | No install; compromised release account can cause denial of service but not authorize unsigned bytes |
+| DNS, TLS interception, redirect, or alternate host | Fixed HTTPS feed, strict enclosure host/path policy, no credentials, signature checks independent of transport | Network failure or rejected candidate |
+| Replay or downgrade | Compare numeric `CFBundleVersion` with installed and highest authenticated build; preserve the authenticated high-water mark | Older authenticated release is rejected; local preference deletion can remove the extra high-water defense, but never the installed-build defense |
+| Version or archive metadata mismatch | Feed build/display version must equal verified archive metadata | Candidate rejected before install |
+| Oversized, empty, truncated, or length-mismatched archive | Signed declared length, actual-length equality, 256 MiB cap, bounded temporary staging | Candidate rejected and staging removed |
+| Key theft | Protected release environment, nonsynchronized Keychain use, encrypted offline recovery copy, least-access workflow, and documented revocation | A stolen active key can authorize malicious feeds and archives; Developer ID/notarization and rapid revocation are independent defenses |
+| Key loss | Encrypted recovery copy and tested rotation procedure | Release publication pauses; installed apps continue operating |
+| Key rotation or revocation error | One active transition at a time, appcast signed by the trusted old key, release with replacement public key, explicit readback and rollback plan | 0.1.x and any build lacking the replacement key require manual bootstrap if trust continuity is broken |
+| Release workflow compromise | Protected GitHub environment, immutable tags, exact-head CI, separate Developer ID and Ed25519 secrets, artifact readback | Publication stops on mismatch; never replace bytes under an existing tag |
+| Bad or revoked release | Remove the candidate from the signed feed, preserve immutable release evidence, retain the authenticated high-water mark, and use a separately reviewed incident release | Installed copies are not silently downgraded; remediation requires a newer authenticated build |
+| Offline, timeout, server outage, malformed response | Bounded request, cancel path, user-safe error, no destructive action before verification | No update; app and clipboard remain unchanged |
+| Cancellation, interruption, crash, or disk exhaustion | Temporary transaction directory, atomic installer boundary, cleanup on failure and next launch | Installed app remains unchanged; stale temporary bytes are deleted |
+| User tricked into an update | Show authenticated version, notes, size, source, and consequences; require explicit download and install/relaunch choices | User can still approve a legitimately signed but unwanted release; transparent notes and deferral reduce this risk |
+| Privacy leakage | No system profiling, stable identifier, cookies, custom headers, content, clipboard, or screen data; fixed daily feed request only | Server sees ordinary IP/time and Sparkle's product/version user agent, as inherent in an HTTPS request |
+
+## Security Invariants
+
+No invalid, downgraded, replayed, mismatched, malformed, oversized, interrupted,
+or unconfirmed update reaches installation. Every rejected or failed path leaves
+the current application runnable and removes transient update bytes. A feed
+outage can never disable capture. Update failures never inspect, log, persist, or
+transmit screenshots, recognized text, clipboard text, or HUD previews.
+
+The app does not accept arbitrary feed overrides, enclosure domains, redirects
+to unapproved locations, or release-channel identifiers. G35 contains no
+production public key, private key, public feed, published update artifact, or
+shipping network entitlement.

--- a/docs/secure-update-threat-model.md
+++ b/docs/secure-update-threat-model.md
@@ -21,7 +21,7 @@ fail closed before replacing any installed bytes.
 | --- | --- | --- |
 | Feed or CDN compromise | Require signed appcast; reject malformed XML, unknown fields that weaken policy, and unsigned or invalid data | No update; current app remains usable |
 | GitHub release compromise or artifact substitution | Verify enclosure Ed25519 signature, exact length, immutable release URL, Developer ID identity, notarization, version, and architecture | No install; compromised release account can cause denial of service but not authorize unsigned bytes |
-| DNS, TLS interception, redirect, or alternate host | Fixed HTTPS feed, strict enclosure host/path policy, no credentials, signature checks independent of transport | Network failure or rejected candidate |
+| DNS, TLS interception, redirect, or alternate host | Fixed HTTPS feed; exact initial enclosure path; at most one HTTPS redirect to `release-assets.githubusercontent.com` with GitHub's release-asset path shape and a signed query; no credentials or follow-on redirect; signature checks independent of transport | Network failure or rejected candidate; a future GitHub CDN change requires review before allow-list expansion |
 | Replay or downgrade | Compare numeric `CFBundleVersion` with installed and highest authenticated build; preserve the authenticated high-water mark | Older authenticated release is rejected; local preference deletion can remove the extra high-water defense, but never the installed-build defense |
 | Version or archive metadata mismatch | Feed build/display version must equal verified archive metadata | Candidate rejected before install |
 | Oversized, empty, truncated, or length-mismatched archive | Signed declared length, actual-length equality, 256 MiB cap, bounded temporary staging | Candidate rejected and staging removed |
@@ -44,6 +44,7 @@ outage can never disable capture. Update failures never inspect, log, persist, o
 transmit screenshots, recognized text, clipboard text, or HUD previews.
 
 The app does not accept arbitrary feed overrides, enclosure domains, redirects
-to unapproved locations, or release-channel identifiers. G35 contains no
+outside the single bounded GitHub release-asset handoff, or release-channel
+identifiers. G35 contains no
 production public key, private key, public feed, published update artifact, or
 shipping network entitlement.

--- a/docs/secure-update-threat-model.md
+++ b/docs/secure-update-threat-model.md
@@ -21,7 +21,7 @@ fail closed before replacing any installed bytes.
 | --- | --- | --- |
 | Feed or CDN compromise | Require signed appcast; reject malformed XML, unknown fields that weaken policy, and unsigned or invalid data | No update; current app remains usable |
 | GitHub release compromise or artifact substitution | Verify enclosure Ed25519 signature, exact length, immutable release URL, Developer ID identity, notarization, version, and architecture | No install; compromised release account can cause denial of service but not authorize unsigned bytes |
-| DNS, TLS interception, redirect, or alternate host | Fixed HTTPS feed; exact initial enclosure path; at most one HTTPS redirect to `release-assets.githubusercontent.com` with GitHub's release-asset path shape and a signed query; no credentials or follow-on redirect; signature checks independent of transport | Network failure or rejected candidate; a future GitHub CDN change requires review before allow-list expansion |
+| DNS, TLS interception, redirect, or alternate host | Fixed HTTPS feed; exact initial enclosure path validated before download; no credentials or custom request data; signed length and Ed25519 checks independent of the final response URL | Network failure or rejected candidate; Sparkle follows ordinary HTTPS redirects and exposes no public redirect-policy callback, so a compromised transport may observe the request or cause denial of service but cannot authorize installation |
 | Replay or downgrade | Compare numeric `CFBundleVersion` with installed and highest authenticated build; preserve the authenticated high-water mark | Older authenticated release is rejected; local preference deletion can remove the extra high-water defense, but never the installed-build defense |
 | Version or archive metadata mismatch | Feed build/display version must equal verified archive metadata | Candidate rejected before install |
 | Oversized, empty, truncated, or length-mismatched archive | Signed declared length, actual-length equality, 256 MiB cap, bounded temporary staging | Candidate rejected and staging removed |
@@ -43,8 +43,9 @@ the current application runnable and removes transient update bytes. A feed
 outage can never disable capture. Update failures never inspect, log, persist, or
 transmit screenshots, recognized text, clipboard text, or HUD previews.
 
-The app does not accept arbitrary feed overrides, enclosure domains, redirects
-outside the single bounded GitHub release-asset handoff, or release-channel
-identifiers. G35 contains no
-production public key, private key, public feed, published update artifact, or
-shipping network entitlement.
+The app does not accept arbitrary feed overrides, initial enclosure domains, or
+release-channel identifiers. Redirect destinations remain untrusted transport;
+G35 claims no redirect guard that Sparkle's public API cannot enforce and relies
+on the independently verified enclosure signature before installation. G35
+contains no production public key, private key, public feed, published update
+artifact, or shipping network entitlement.

--- a/docs/secure-update-threat-model.md
+++ b/docs/secure-update-threat-model.md
@@ -19,12 +19,12 @@ fail closed before replacing any installed bytes.
 
 | Threat | Required control | Failure result or residual risk |
 | --- | --- | --- |
-| Feed or CDN compromise | Require signed appcast; reject malformed XML, unknown fields that weaken policy, and unsigned or invalid data | No update; current app remains usable |
+| Feed or CDN compromise | Require signed appcast; accept only nonempty inline plain-text release notes; reject remote notes, HTML, malformed XML, unknown fields that weaken policy, and unsigned or invalid data | No update; current app remains usable |
 | GitHub release compromise or artifact substitution | Verify enclosure Ed25519 signature, exact length, immutable release URL, Developer ID identity, notarization, version, and architecture | No install; compromised release account can cause denial of service but not authorize unsigned bytes |
 | DNS, TLS interception, redirect, or alternate host | Fixed HTTPS feed; exact initial enclosure path validated before download; no credentials or custom request data; signed length and Ed25519 checks independent of the final response URL | Network failure or rejected candidate; Sparkle follows ordinary HTTPS redirects and exposes no public redirect-policy callback, so a compromised transport may observe the request or cause denial of service but cannot authorize installation |
 | Replay or downgrade | Compare numeric `CFBundleVersion` with installed and highest authenticated build; preserve the authenticated high-water mark | Older authenticated release is rejected; local preference deletion can remove the extra high-water defense, but never the installed-build defense |
 | Version or archive metadata mismatch | Feed build/display version must equal verified archive metadata | Candidate rejected before install |
-| Oversized, empty, truncated, or length-mismatched archive | Signed declared length, actual-length equality, 256 MiB cap, bounded temporary staging | Candidate rejected and staging removed |
+| Oversized, empty, truncated, or length-mismatched archive | Signed declared length, actual-length equality, 256 MiB cap, and the real `SPUUserDriver` download-cancellation closure invoked on the first expected-length or received-byte callback that crosses a boundary | Candidate rejected and staging removed before extraction or installation |
 | Key theft | Protected release environment, nonsynchronized Keychain use, encrypted offline recovery copy, least-access workflow, and documented revocation | A stolen active key can authorize malicious feeds and archives; Developer ID/notarization and rapid revocation are independent defenses |
 | Key loss | Encrypted recovery copy and tested rotation procedure | Release publication pauses; installed apps continue operating |
 | Key rotation or revocation error | One active transition at a time, appcast signed by the trusted old key, release with replacement public key, explicit readback and rollback plan | 0.1.x and any build lacking the replacement key require manual bootstrap if trust continuity is broken |
@@ -33,7 +33,7 @@ fail closed before replacing any installed bytes.
 | Offline, timeout, server outage, malformed response | Bounded request, cancel path, user-safe error, no destructive action before verification | No update; app and clipboard remain unchanged |
 | Cancellation, interruption, crash, or disk exhaustion | Temporary transaction directory, atomic installer boundary, cleanup on failure and next launch | Installed app remains unchanged; stale temporary bytes are deleted |
 | User tricked into an update | Show authenticated version, notes, size, source, and consequences; require explicit download and install/relaunch choices | User can still approve a legitimately signed but unwanted release; transparent notes and deferral reduce this risk |
-| Privacy leakage | No system profiling, stable identifier, cookies, custom headers, content, clipboard, or screen data; fixed daily feed request only | Server sees ordinary IP/time and Sparkle's product/version user agent, as inherent in an HTTPS request |
+| Privacy leakage | No system profiling, stable identifier, cookies, custom headers, external release-note fetch, content, clipboard, or screen data; fixed daily feed request only | Server sees ordinary IP/time and Sparkle's product/version user agent, as inherent in an HTTPS request |
 
 ## Security Invariants
 

--- a/docs/security-and-privacy-review.md
+++ b/docs/security-and-privacy-review.md
@@ -62,17 +62,20 @@ Local Apple Development signing adds `com.apple.security.get-task-allow` to audi
 | Clipboard visibility | After a successful write, macOS and other clipboard-aware software control access. CopyLasso writes one plain-string representation and never reads prior contents. |
 | Crash or forced termination during private processing | Operation values are memory-only and no in-app crash reporter receives them. Operating-system diagnostics or a privileged memory inspector remain outside the app's trust boundary. |
 | Diagnostic leakage | The only logger emits four fixed lifecycle messages. CI rejects interpolation and content-bearing logging APIs elsewhere. |
-| Dependency compromise | The only third-party package is exact-version and exact-revision pinned, source-built, MIT licensed, covered by a full notice and justification, and has no transitive package dependency or network service. |
+| Dependency compromise | The only shipping third-party package is exact-version and exact-revision pinned, source-built, MIT licensed, covered by a full notice and justification, and has no transitive package dependency or network service. Sparkle 2.9.4 is additionally pinned and linked only into the G35 test proof; the application target and release bytes remain unchanged. |
 | Shortcut collision or spoofed event | The package validates and records the configured key combination; every event enters the same busy-rejecting command. A shortcut cannot bypass consent or selection. |
 | Malformed OCR geometry or text | Pure formatting tests retain nonempty observations conservatively, reject invalid geometry safely, and output plain text only. |
 
 ## Dependency Inventory
 
-| Dependency | Version and revision | Purpose | License | Upstream |
-| --- | --- | --- | --- | --- |
-| KeyboardShortcuts | 3.0.1, `49c3fc04ea827f816df67843bfcc57286b47ff06` | Global shortcut recording, validation, persistence, registration, replacement, and clearing | MIT | <https://github.com/sindresorhus/KeyboardShortcuts> |
+| Dependency | Scope | Version and revision | Purpose | License | Upstream |
+| --- | --- | --- | --- | --- | --- |
+| KeyboardShortcuts | Shipping application and tests | 3.0.1, `49c3fc04ea827f816df67843bfcc57286b47ff06` | Global shortcut recording, validation, persistence, registration, replacement, and clearing | MIT | <https://github.com/sindresorhus/KeyboardShortcuts> |
+| Sparkle | G35 tests only; absent from CopyLasso.app | 2.9.4, `b6496a74a087257ef5e6da1c5b29a447a60f5bd7` | Real version comparator plus offline appcast/archive signature proof | Permissive Sparkle license bundle | <https://github.com/sparkle-project/Sparkle/blob/2.9.4/LICENSE> |
 
-The package manifest declares no transitive dependency. The Release executable contains its code statically and embeds no third-party dynamic framework. Native macOS APIs provide lower-level event registration but no SwiftUI recorder plus persistence/conflict-management abstraction; the package materially reduces input and lifecycle risk. Its exact license text and attribution are in [Third-Party Notices](../THIRD_PARTY_NOTICES.md). A GitHub Advisory Database query during this audit returned no advisory for the Swift package; this time-sensitive check must be repeated for each release.
+KeyboardShortcuts declares no transitive dependency. The Release executable contains its code statically and embeds no third-party dynamic framework. Native macOS APIs provide lower-level event registration but no SwiftUI recorder plus persistence/conflict-management abstraction; the package materially reduces input and lifecycle risk. Its exact license text and attribution are in [Third-Party Notices](../THIRD_PARTY_NOTICES.md). A GitHub Advisory Database query during that release audit returned no advisory for the Swift package; this time-sensitive check must be repeated for each release.
+
+Sparkle is test-only in G35, so it is not yet a shipped dependency and is deliberately absent from Third-Party Notices and the About acknowledgements. Its exact tag, source revision, official artifact checksum, license URL, justification, and future acknowledgement gate are recorded in [ADR-004](architecture/ADR-004-secure-updates.md). G36 must add the complete shipped notice before linking Sparkle into the application.
 
 ## Reproducible Verification
 
@@ -82,7 +85,7 @@ Run the tracked source audit:
 ./scripts/audit-privacy-security.sh
 ```
 
-The canonical CI entrypoint runs it before compiling. It validates the one-key entitlement, both build-configuration references, absence of network and content-persistence APIs, logger confinement, tracked-secret and local-path scans, the exact dependency inventory/notice/justification, and absence of prebuilt dependency binaries.
+The canonical CI entrypoint runs it before compiling. It validates the one-key entitlement, both build-configuration references, absence of application networking and content-persistence APIs, logger confinement, tracked-secret and local-path scans, exact shipping and test-only dependency scope, the shipping notice/justification, and absence of prebuilt dependency binaries.
 
 The complete application unit bundle also passes when invoked directly under a process sandbox with `(deny network*)`. This exercises real Vision fixtures plus permission, selection, capture planning, formatting, clipboard, feedback, lifecycle, Settings, and end-to-end orchestration tests without disabling the workstation's network connection; the canonical verification record reports the exact current suite count.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,7 +6,7 @@ CopyLasso's canonical unsigned build and unit-test pipeline is:
 ./scripts/ci.sh
 ```
 
-The pipeline lints all Swift source, resolves the exact package dependency, builds Debug and both XCTest bundles, runs the unit suite serially with timeouts, inspects required build and privacy boundaries, builds Universal 2 Release, and verifies both executable slices. It does not launch the unsigned UI-test runner or alter macOS privacy state.
+The pipeline lints all Swift source, resolves the exact package dependencies, builds Debug and both XCTest bundles, runs the unit suite serially with timeouts, inspects required build and privacy boundaries, builds Universal 2 Release, and verifies both executable slices. It does not launch the unsigned UI-test runner or alter macOS privacy state.
 
 ## Controlled Permission And Selection UI Coverage
 
@@ -296,7 +296,7 @@ Use one stably signed Debug app, keep Screen Recording enabled, and avoid inspec
 5. Inspect Console entries for the CopyLasso process across idle, selection, cancellation, sleep/lock recovery, success, no text, failure, and termination. Only the four fixed lifecycle messages may originate from CopyLasso; no app name being captured, geometry, pixels, recognized text, clipboard text, preview, or raw error may appear.
 6. Run `scripts/test-offline.sh` against a freshly canonical-built bundle. Confirm 187/187 tests pass while the deny-network profile is active. Do not disable the workstation's network or interrupt other applications.
 7. Inspect the signed app entitlement and CodeDirectory flags. Confirm App Sandbox and Hardened Runtime, no network client/server, no device/file/group/temporary exception, and only development `get-task-allow`. G26 established the first Developer ID archive with `get-task-allow` absent; repeat that inspection for every later candidate rather than carrying the historical result forward.
-8. Inspect the built Release executable and bundle. Confirm Universal 2, only system-linked frameworks, no embedded third-party dynamic binary, one exact package resolution, and the matching MIT acknowledgement.
+8. Inspect the built Release executable and bundle. Confirm Universal 2, only system-linked frameworks, no embedded third-party dynamic binary, the exact shipping package resolution, and the matching MIT acknowledgement. Test-only packages must remain outside the application bundle.
 9. Inspect Privacy & Security after real use. Screen Recording must be the only core permission; Accessibility, Input Monitoring, Microphone, Full Disk Access, Files and Folders, and automation access must not be required.
 10. Paste the success result into TextEdit, then confirm cancellation/no-text/pre-output failures preserved the sentinel in separate runs. Remember that clipboard contents become a macOS/user trust boundary after a successful write.
 
@@ -359,6 +359,38 @@ This is a documentation and scope gate. It does not qualify an updater,
 network entitlement, new capture mode, sound asset, recognition dependency, or
 v0.2 release. Those require their later approved goals and direct behavioral
 tests.
+
+## G35 Secure-Update Architecture Proof
+
+G35 pins Sparkle 2.9.4 only to the unit-test target. The application target,
+Release bundle, entitlements, Info.plist, version/build, public feed state, and
+shipping acknowledgements remain unchanged. The focused proof uses Sparkle's
+real standard version comparator and covers current, newer, downgrade, replay,
+feed/archive signature failure, version mismatch, URL policy, empty/oversized/
+length-mismatched downloads, offline, timeout, disk exhaustion, interruption,
+cancellation, deferral, and explicit commit behavior.
+
+Canonical CI runs each of these exactly once per architecture after resolving
+the pinned artifact:
+
+```sh
+./scripts/test-secure-update-architecture.sh
+./scripts/audit-secure-update-architecture.sh
+COPYLASSO_SPARKLE_TOOLS_DIR=/path/to/Sparkle/bin \
+  ./scripts/test-secure-update-signatures.sh
+```
+
+The signature fixture runs under a process sandbox that denies networking. It
+creates two ephemeral Ed25519 keys, proves a valid archive and appcast, rejects
+in-envelope feed mutation, archive mutation, and the wrong key, checks the
+official feed tool is runnable, and removes the entire temporary directory. The
+static audit verifies the exact source revision and artifact checksum record,
+test-only target confinement, one-key product sandbox, no shipping updater
+configuration, no feed/key material, and the unchanged 0.1.1 (2) release.
+
+This evidence selects an architecture; it does not exercise an update UI,
+network request, production key, public feed, staged production package, or
+installation. Those are G36 gates.
 
 The July 13, 2026 signed run completed many functional, permission, and OCR rows
 before exposing a pre-drag sleep/wake failure. G24U subsequently passed exact

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -382,8 +382,10 @@ COPYLASSO_SPARKLE_TOOLS_DIR=/path/to/Sparkle/bin \
 
 The signature fixture runs under a process sandbox that denies networking. It
 creates two ephemeral Ed25519 keys, proves a valid archive and appcast, rejects
-in-envelope feed mutation, archive mutation, and the wrong key, checks the
-official feed tool is runnable, and removes the entire temporary directory. The
+in-envelope feed mutation, archive mutation, and the wrong key, then proves
+Sparkle's real parser rejects a signed malformed appcast. It checks the
+official feed tool is runnable, supports tool paths containing spaces, and
+removes the entire temporary directory. The
 static audit verifies the exact source revision and artifact checksum record,
 test-only target confinement, one-key product sandbox, no shipping updater
 configuration, no feed/key material, and the unchanged 0.1.1 (2) release.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -384,7 +384,8 @@ The signature fixture runs under a process sandbox that denies networking. It
 creates two ephemeral Ed25519 keys, proves a valid archive and appcast, rejects
 in-envelope feed mutation, archive mutation, and the wrong key, then proves
 Sparkle's real parser rejects a signed malformed appcast. It checks the
-official feed tool is runnable, supports tool paths containing spaces, and
+same parser first accepts a signed well-formed control, checks the official feed
+tool is runnable, supports tool paths containing spaces, and
 removes the entire temporary directory. The
 static audit verifies the exact source revision and artifact checksum record,
 test-only target confinement, one-key product sandbox, no shipping updater

--- a/scripts/audit-privacy-security.sh
+++ b/scripts/audit-privacy-security.sh
@@ -76,12 +76,17 @@ if git grep -n -I -E '/Users/[^ /]+' -- \
 fi
 
 readonly package_resolved='CopyLasso.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'
-if [[ "$(/usr/bin/grep -c '"identity"' "$package_resolved")" != 1 ]] || \
+if [[ "$(/usr/bin/grep -c '"identity"' "$package_resolved")" != 2 ]] || \
     ! /usr/bin/grep -q '"version" : "3.0.1"' "$package_resolved" || \
+    ! /usr/bin/grep -q '"revision" : "49c3fc04ea827f816df67843bfcc57286b47ff06"' "$package_resolved" || \
+    ! /usr/bin/grep -q '"version" : "2.9.4"' "$package_resolved" || \
+    ! /usr/bin/grep -q '"revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7"' "$package_resolved" || \
     ! /usr/bin/grep -q 'KeyboardShortcuts 3.0.1' THIRD_PARTY_NOTICES.md || \
     ! /usr/bin/grep -q 'License: MIT' THIRD_PARTY_NOTICES.md || \
-    ! /usr/bin/grep -q 'Justification:' THIRD_PARTY_NOTICES.md; then
-    echo "Every shipped dependency must be pinned, inventoried, licensed, and justified." >&2
+    ! /usr/bin/grep -q 'Justification:' THIRD_PARTY_NOTICES.md || \
+    ! /usr/bin/grep -Fq 'Sparkle imports must remain confined to the G35 proof test.' \
+        scripts/audit-secure-update-architecture.sh; then
+    echo "Shipped and test-only dependencies must be pinned, scoped, licensed, and justified." >&2
     exit 1
 fi
 

--- a/scripts/audit-secure-update-architecture.sh
+++ b/scripts/audit-secure-update-architecture.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && /bin/pwd -P)"
+readonly project="$repository_root/CopyLasso.xcodeproj/project.pbxproj"
+readonly package_lock="$repository_root/CopyLasso.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+readonly entitlements="$repository_root/CopyLasso/CopyLasso.entitlements"
+readonly product_info="$repository_root/Configuration/CopyLasso-Info.plist"
+readonly release_metadata="$repository_root/Configuration/ReleaseMetadata.xcconfig"
+readonly notices="$repository_root/THIRD_PARTY_NOTICES.md"
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+require_literal() {
+    local file="$1"
+    local literal="$2"
+    local message="$3"
+    /usr/bin/grep -Fq "$literal" "$file" || fail "$message"
+}
+
+for document in \
+    "$repository_root/docs/architecture/ADR-004-secure-updates.md" \
+    "$repository_root/docs/secure-update-threat-model.md" \
+    "$repository_root/docs/secure-update-operations.md"; do
+    [[ -f "$document" ]] || fail "Missing secure-update architecture document: $(basename "$document")"
+done
+
+for executable in \
+    "$repository_root/scripts/test-secure-update-architecture.sh" \
+    "$repository_root/scripts/test-secure-update-signatures.sh"; do
+    [[ -x "$executable" ]] || fail "Missing executable secure-update proof: $(basename "$executable")"
+done
+
+require_literal "$project" 'repositoryURL = "https://github.com/sparkle-project/Sparkle";' \
+    "Sparkle must come from the reviewed upstream repository."
+require_literal "$project" 'kind = exactVersion;' \
+    "Swift packages must retain exact version requirements."
+require_literal "$project" 'version = 2.9.4;' \
+    "Sparkle must remain pinned to 2.9.4."
+require_literal "$package_lock" '"identity" : "sparkle"' \
+    "Package.resolved must include Sparkle."
+require_literal "$package_lock" '"revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7"' \
+    "Package.resolved must lock the reviewed Sparkle revision."
+require_literal "$package_lock" '"version" : "2.9.4"' \
+    "Package.resolved must lock Sparkle 2.9.4."
+
+app_target="$(/usr/bin/awk '
+    /^\t\tAACED2EA30004BEB001F9909 \/\* CopyLasso \*\/ = \{$/ { capture = 1 }
+    capture { print }
+    capture && /^\t\t};$/ { exit }
+' "$project")"
+test_target="$(/usr/bin/awk '
+    /^\t\tAACED2F730004BEC001F9909 \/\* CopyLassoTests \*\/ = \{$/ { capture = 1 }
+    capture { print }
+    capture && /^\t\t};$/ { exit }
+' "$project")"
+if /usr/bin/grep -Fq 'Sparkle' <<< "$app_target"; then
+    fail "G35 must not link Sparkle into the CopyLasso application target."
+fi
+if ! /usr/bin/grep -Fq 'Sparkle' <<< "$test_target"; then
+    fail "G35 must link Sparkle into CopyLassoTests for the architecture proof."
+fi
+
+sparkle_imports="$({
+    /usr/bin/grep -R -l --include='*.swift' '^import Sparkle$' \
+        "$repository_root/CopyLasso" "$repository_root/CopyLassoTests" || true
+})"
+if [[ "$sparkle_imports" != "$repository_root/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift" ]]; then
+    fail "Sparkle imports must remain confined to the G35 proof test."
+fi
+
+if /usr/bin/grep -Eq 'com\.apple\.security\.network\.client|mach-lookup' "$entitlements"; then
+    fail "G35 must not change the shipping sandbox or networking entitlements."
+fi
+if /usr/bin/grep -Eq '<key>SU[A-Za-z]+' "$product_info"; then
+    fail "G35 must not configure a shipping updater."
+fi
+if /usr/bin/grep -Fqi 'Sparkle' "$notices"; then
+    fail "Test-only Sparkle must not be represented as a shipped dependency in G35."
+fi
+
+if [[ -n "${COPYLASSO_SECURE_UPDATE_APP:-}" ]]; then
+    application="$COPYLASSO_SECURE_UPDATE_APP"
+    [[ -d "$application" ]] || fail "The secure-update app audit requires a built application."
+    if /usr/bin/find "$application" -iname '*Sparkle*' -print -quit | \
+        /usr/bin/grep -q .; then
+        fail "The G35 application bundle must not contain Sparkle."
+    fi
+    executable="$application/Contents/MacOS/CopyLasso"
+    [[ -x "$executable" ]] || fail "The secure-update app audit cannot find CopyLasso."
+    if /usr/bin/otool -L "$executable" | /usr/bin/grep -Fqi 'Sparkle'; then
+        fail "The G35 application executable must not link Sparkle."
+    fi
+    if /usr/bin/plutil -p "$application/Contents/Info.plist" | \
+        /usr/bin/grep -Eq '"SU[A-Za-z]+'; then
+        fail "The G35 built application must not configure Sparkle."
+    fi
+fi
+
+require_literal "$release_metadata" 'COPYLASSO_RELEASE_VERSION = 0.1.1' \
+    "G35 must not change the released version."
+require_literal "$release_metadata" 'COPYLASSO_RELEASE_BUILD = 2' \
+    "G35 must not change the released build."
+
+require_literal "$repository_root/docs/architecture/ADR-004-secure-updates.md" \
+    'https://updates.copylasso.com/appcast.xml' \
+    "The ADR must lock the future feed endpoint."
+require_literal "$repository_root/docs/architecture/ADR-004-secure-updates.md" \
+    'cb6fdbdc8884f15d62a616e79face92b08322410fd2d425edc6596ccbf4ba3b0' \
+    "The ADR must record the official Sparkle artifact checksum."
+require_literal "$repository_root/docs/secure-update-threat-model.md" \
+    'highest authenticated build' \
+    "The threat model must cover authenticated rollback state."
+require_literal "$repository_root/docs/secure-update-operations.md" \
+    '0.1.x contains no updater' \
+    "Operations must explain the manual 0.1.x bootstrap."
+
+if /usr/bin/git -C "$repository_root" ls-files | \
+    /usr/bin/grep -Eq '(^|/)(appcast[^/]*\.xml|[^/]*\.(pem|p12|key))$'; then
+    fail "G35 must not track a public feed or signing-key material."
+fi
+private_key_marker='BEGIN '
+private_key_marker+='(OPENSSH|EC|RSA|PRIVATE) PRIVATE KEY'
+if /usr/bin/git -C "$repository_root" grep -nE \
+    -- "$private_key_marker|sparkle:edSignature=\"[A-Za-z0-9+/=]{20,}\"" \
+    -- ':!docs/**' ':!scripts/test-secure-update-signatures.sh'; then
+    fail "G35 must not contain production key or signature material."
+fi
+
+echo "CopyLasso secure-update architecture audit passed."

--- a/scripts/audit-secure-update-architecture.sh
+++ b/scripts/audit-secure-update-architecture.sh
@@ -50,16 +50,32 @@ require_literal "$package_lock" '"revision" : "b6496a74a087257ef5e6da1c5b29a447a
 require_literal "$package_lock" '"version" : "2.9.4"' \
     "Package.resolved must lock Sparkle 2.9.4."
 
-app_target="$(/usr/bin/awk '
-    /^\t\tAACED2EA30004BEB001F9909 \/\* CopyLasso \*\/ = \{$/ { capture = 1 }
-    capture { print }
-    capture && /^\t\t};$/ { exit }
-' "$project")"
-test_target="$(/usr/bin/awk '
-    /^\t\tAACED2F730004BEC001F9909 \/\* CopyLassoTests \*\/ = \{$/ { capture = 1 }
-    capture { print }
-    capture && /^\t\t};$/ { exit }
-' "$project")"
+target_block() {
+    local target_name="$1"
+    /usr/bin/awk -v target_name="$target_name" '
+        /\/\* Begin PBXNativeTarget section \*\// { in_section = 1; next }
+        /\/\* End PBXNativeTarget section \*\// { in_section = 0 }
+        in_section && /^\t\t[A-F0-9]+ \/\* .* \*\/ = \{$/ {
+            capture = 1
+            block = $0 ORS
+            next
+        }
+        capture { block = block $0 ORS }
+        capture && /^\t\t};$/ {
+            if (block ~ "\\n\\t\\t\\tname = " target_name ";\\n") {
+                printf "%s", block
+                exit
+            }
+            capture = 0
+            block = ""
+        }
+    ' "$project"
+}
+
+app_target="$(target_block CopyLasso)"
+test_target="$(target_block CopyLassoTests)"
+[[ -n "$app_target" ]] || fail "The secure-update audit could not resolve the CopyLasso target."
+[[ -n "$test_target" ]] || fail "The secure-update audit could not resolve the CopyLassoTests target."
 if /usr/bin/grep -Fq 'Sparkle' <<< "$app_target"; then
     fail "G35 must not link Sparkle into the CopyLasso application target."
 fi
@@ -114,6 +130,16 @@ require_literal "$repository_root/docs/architecture/ADR-004-secure-updates.md" \
 require_literal "$repository_root/docs/architecture/ADR-004-secure-updates.md" \
     'cb6fdbdc8884f15d62a616e79face92b08322410fd2d425edc6596ccbf4ba3b0' \
     "The ADR must record the official Sparkle artifact checksum."
+require_literal "$repository_root/docs/architecture/ADR-004-secure-updates.md" \
+    'SUSignedFeedFailureExpirationInterval = 0' \
+    "The ADR must retain Sparkle 2.9.4's fail-closed signed-feed expiration key."
+require_literal "$repository_root/docs/architecture/ADR-004-secure-updates.md" \
+    'no per-redirect decision hook' \
+    "The ADR must retain Sparkle's actual redirect integration boundary."
+if /usr/bin/grep -Fq 'allowsEnclosureRedirect' \
+    "$repository_root/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift"; then
+    fail "The G35 proof must not claim an unconnected redirect guard."
+fi
 require_literal "$repository_root/docs/secure-update-threat-model.md" \
     'highest authenticated build' \
     "The threat model must cover authenticated rollback state."

--- a/scripts/audit-secure-update-architecture.sh
+++ b/scripts/audit-secure-update-architecture.sh
@@ -136,6 +136,15 @@ require_literal "$repository_root/docs/architecture/ADR-004-secure-updates.md" \
 require_literal "$repository_root/docs/architecture/ADR-004-secure-updates.md" \
     'no per-redirect decision hook' \
     "The ADR must retain Sparkle's actual redirect integration boundary."
+require_literal "$repository_root/docs/architecture/ADR-004-secure-updates.md" \
+    'showDownloadDidReceiveDataOfLength:' \
+    "The ADR must bind the byte cap to Sparkle's streaming callback."
+require_literal "$repository_root/docs/architecture/ADR-004-secure-updates.md" \
+    'Release notes must be nonempty inline plain text in the signed appcast.' \
+    "The ADR must reject unauthenticated external release notes."
+require_literal "$repository_root/docs/secure-update-operations.md" \
+    'An absent high-water record is initialized and persisted' \
+    "Operations must define first-launch replay-state initialization."
 if /usr/bin/grep -Fq 'allowsEnclosureRedirect' \
     "$repository_root/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift"; then
     fail "The G35 proof must not claim an unconnected redirect guard."

--- a/scripts/audit-secure-update-architecture.sh
+++ b/scripts/audit-secure-update-architecture.sh
@@ -31,18 +31,47 @@ done
 
 for executable in \
     "$repository_root/scripts/test-secure-update-architecture.sh" \
-    "$repository_root/scripts/test-secure-update-signatures.sh"; do
+    "$repository_root/scripts/test-secure-update-signatures.sh" \
+    "$repository_root/scripts/fixtures/run-secure-update-signatures.sh"; do
     [[ -x "$executable" ]] || fail "Missing executable secure-update proof: $(basename "$executable")"
 done
 [[ -f "$repository_root/scripts/fixtures/SignedAppcastParserProbe.m" ]] || \
     fail "The signed malformed-appcast parser probe is missing."
 
-require_literal "$project" 'repositoryURL = "https://github.com/sparkle-project/Sparkle";' \
-    "Sparkle must come from the reviewed upstream repository."
-require_literal "$project" 'kind = exactVersion;' \
-    "Swift packages must retain exact version requirements."
-require_literal "$project" 'version = 2.9.4;' \
-    "Sparkle must remain pinned to 2.9.4."
+package_reference_block() {
+    local repository_url="$1"
+    /usr/bin/awk -v repository_url="$repository_url" '
+        /\/\* Begin XCRemoteSwiftPackageReference section \*\// { in_section = 1; next }
+        /\/\* End XCRemoteSwiftPackageReference section \*\// { in_section = 0 }
+        in_section && /^\t\t[A-F0-9]+ \/\* .* \*\/ = \{$/ {
+            capture = 1
+            block = $0 ORS
+            next
+        }
+        capture { block = block $0 ORS }
+        capture && /^\t\t};$/ {
+            if (index(block, "repositoryURL = \"" repository_url "\";") > 0) {
+                printf "%s", block
+                exit
+            }
+            capture = 0
+            block = ""
+        }
+    ' "$project"
+}
+
+readonly sparkle_repository='https://github.com/sparkle-project/Sparkle'
+if [[ "$(/usr/bin/grep -Fc "repositoryURL = \"$sparkle_repository\";" "$project")" != "1" ]]; then
+    fail "The project must contain exactly one reviewed Sparkle package reference."
+fi
+sparkle_package_reference="$(package_reference_block "$sparkle_repository")"
+[[ -n "$sparkle_package_reference" ]] || fail "The Sparkle package reference is missing."
+if ! /usr/bin/grep -Fq $'\t\t\t\tkind = exactVersion;' <<< "$sparkle_package_reference"; then
+    fail "Sparkle must use an exact version requirement."
+fi
+if ! /usr/bin/grep -Fq $'\t\t\t\tversion = 2.9.4;' <<< "$sparkle_package_reference"; then
+    fail "Sparkle must remain pinned to 2.9.4."
+fi
 require_literal "$package_lock" '"identity" : "sparkle"' \
     "Package.resolved must include Sparkle."
 require_literal "$package_lock" '"revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7"' \
@@ -101,8 +130,10 @@ if /usr/bin/grep -Fqi 'Sparkle' "$notices"; then
     fail "Test-only Sparkle must not be represented as a shipped dependency in G35."
 fi
 
-if [[ -n "${COPYLASSO_SECURE_UPDATE_APP:-}" ]]; then
-    application="$COPYLASSO_SECURE_UPDATE_APP"
+for application in \
+    "${COPYLASSO_SECURE_UPDATE_DEBUG_APP:-}" \
+    "${COPYLASSO_SECURE_UPDATE_RELEASE_APP:-}"; do
+    [[ -n "$application" ]] || continue
     [[ -d "$application" ]] || fail "The secure-update app audit requires a built application."
     if /usr/bin/find "$application" -iname '*Sparkle*' -print -quit | \
         /usr/bin/grep -q .; then
@@ -115,9 +146,9 @@ if [[ -n "${COPYLASSO_SECURE_UPDATE_APP:-}" ]]; then
     fi
     if /usr/bin/plutil -p "$application/Contents/Info.plist" | \
         /usr/bin/grep -Eq '"SU[A-Za-z]+'; then
-        fail "The G35 built application must not configure Sparkle."
+        fail "The G35 built application must not configure an updater."
     fi
-fi
+done
 
 require_literal "$release_metadata" 'COPYLASSO_RELEASE_VERSION = 0.1.1' \
     "G35 must not change the released version."

--- a/scripts/audit-secure-update-architecture.sh
+++ b/scripts/audit-secure-update-architecture.sh
@@ -34,6 +34,8 @@ for executable in \
     "$repository_root/scripts/test-secure-update-signatures.sh"; do
     [[ -x "$executable" ]] || fail "Missing executable secure-update proof: $(basename "$executable")"
 done
+[[ -f "$repository_root/scripts/fixtures/SignedAppcastParserProbe.m" ]] || \
+    fail "The signed malformed-appcast parser probe is missing."
 
 require_literal "$project" 'repositoryURL = "https://github.com/sparkle-project/Sparkle";' \
     "Sparkle must come from the reviewed upstream repository."

--- a/scripts/audit-secure-update-architecture.sh
+++ b/scripts/audit-secure-update-architecture.sh
@@ -72,12 +72,18 @@ fi
 if ! /usr/bin/grep -Fq $'\t\t\t\tversion = 2.9.4;' <<< "$sparkle_package_reference"; then
     fail "Sparkle must remain pinned to 2.9.4."
 fi
-require_literal "$package_lock" '"identity" : "sparkle"' \
-    "Package.resolved must include Sparkle."
-require_literal "$package_lock" '"revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7"' \
-    "Package.resolved must lock the reviewed Sparkle revision."
-require_literal "$package_lock" '"version" : "2.9.4"' \
-    "Package.resolved must lock Sparkle 2.9.4."
+sparkle_pins="$(/usr/bin/jq -c \
+    '.pins | map(select(.identity == "sparkle"))' \
+    "$package_lock")" || fail "Package.resolved must be valid JSON."
+if ! /usr/bin/jq -e '
+    length == 1 and
+    .[0].kind == "remoteSourceControl" and
+    .[0].location == "https://github.com/sparkle-project/Sparkle" and
+    .[0].state.revision == "b6496a74a087257ef5e6da1c5b29a447a60f5bd7" and
+    .[0].state.version == "2.9.4"
+    ' <<< "$sparkle_pins" >/dev/null; then
+    fail "Package.resolved must lock the reviewed Sparkle identity, source, revision, and version."
+fi
 
 target_block() {
     local target_name="$1"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -520,6 +520,11 @@ readonly release_application="$derived_data/Build/Products/Release/CopyLasso.app
         CODE_SIGNING_ALLOWED=NO
 
 readonly release_info_plist="$release_application/Contents/Info.plist"
+if /usr/bin/find "$release_application" -iname '*Sparkle*' -print -quit | \
+    /usr/bin/grep -q .; then
+    echo "The Release application must not contain Sparkle." >&2
+    exit 1
+fi
 if /usr/bin/plutil -p "$release_info_plist" | /usr/bin/grep -Eq '"SU[A-Za-z]+'; then
     echo "The Release application must not configure an updater." >&2
     exit 1

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -386,7 +386,7 @@ xcodebuild build \
     "${common_arguments[@]}" \
     -configuration Debug
 
-COPYLASSO_SECURE_UPDATE_APP="$derived_data/Build/Products/Debug/CopyLasso.app" \
+COPYLASSO_SECURE_UPDATE_DEBUG_APP="$derived_data/Build/Products/Debug/CopyLasso.app" \
     ./scripts/audit-secure-update-architecture.sh
 
 echo "Auditing final brand assets and release documentation"
@@ -520,6 +520,10 @@ readonly release_application="$derived_data/Build/Products/Release/CopyLasso.app
         CODE_SIGNING_ALLOWED=NO
 
 readonly release_info_plist="$release_application/Contents/Info.plist"
+if /usr/bin/plutil -p "$release_info_plist" | /usr/bin/grep -Eq '"SU[A-Za-z]+'; then
+    echo "The Release application must not configure an updater." >&2
+    exit 1
+fi
 if [[ "$(/usr/bin/plutil -extract LSUIElement raw -o - "$release_info_plist")" != "true" ]]; then
     echo "The Release application is not configured as a dockless agent." >&2
     exit 1

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -105,8 +105,11 @@ readonly package_resolved="CopyLasso.xcodeproj/project.xcworkspace/xcshareddata/
 if [[ ! -f "$package_resolved" ]] || \
     ! /usr/bin/grep -q '"location" : "https://github.com/sindresorhus/KeyboardShortcuts"' "$package_resolved" || \
     ! /usr/bin/grep -q '"revision" : "49c3fc04ea827f816df67843bfcc57286b47ff06"' "$package_resolved" || \
-    ! /usr/bin/grep -q '"version" : "3.0.1"' "$package_resolved"; then
-    echo "KeyboardShortcuts must remain resolved exactly to 3.0.1." >&2
+    ! /usr/bin/grep -q '"version" : "3.0.1"' "$package_resolved" || \
+    ! /usr/bin/grep -q '"location" : "https://github.com/sparkle-project/Sparkle"' "$package_resolved" || \
+    ! /usr/bin/grep -q '"revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7"' "$package_resolved" || \
+    ! /usr/bin/grep -q '"version" : "2.9.4"' "$package_resolved"; then
+    echo "KeyboardShortcuts and test-only Sparkle must remain exactly resolved." >&2
     exit 1
 fi
 
@@ -357,6 +360,17 @@ xcodebuild -resolvePackageDependencies \
     -scheme "$scheme" \
     -clonedSourcePackagesDirPath "$derived_data/SourcePackages"
 
+echo "Proving the secure-update architecture"
+./scripts/test-secure-update-architecture.sh
+sparkle_sign_update="$(/usr/bin/find "$derived_data/SourcePackages/artifacts" \
+    -type f -path '*/bin/sign_update' -print -quit)"
+if [[ -z "$sparkle_sign_update" ]]; then
+    echo "Resolved Sparkle sign_update tool is unavailable." >&2
+    exit 1
+fi
+COPYLASSO_SPARKLE_TOOLS_DIR="$(/usr/bin/dirname "$sparkle_sign_update")" \
+    ./scripts/test-secure-update-signatures.sh
+
 readonly destination="platform=macOS,arch=$requested_architecture"
 common_arguments=(
     -project "$project_path"
@@ -371,6 +385,9 @@ echo "Building Debug for $requested_architecture"
 xcodebuild build \
     "${common_arguments[@]}" \
     -configuration Debug
+
+COPYLASSO_SECURE_UPDATE_APP="$derived_data/Build/Products/Debug/CopyLasso.app" \
+    ./scripts/audit-secure-update-architecture.sh
 
 echo "Auditing final brand assets and release documentation"
 COPYLASSO_BRAND_APP="$derived_data/Build/Products/Debug/CopyLasso.app" \

--- a/scripts/fixtures/SignedAppcastParserProbe.m
+++ b/scripts/fixtures/SignedAppcastParserProbe.m
@@ -13,11 +13,17 @@
 
 int main(int argc, const char *argv[]) {
     @autoreleasepool {
-        if (argc != 2) {
+        if (argc != 3) {
             return 64;
         }
 
-        NSString *path = [NSString stringWithUTF8String:argv[1]];
+        NSString *expectation = [NSString stringWithUTF8String:argv[1]];
+        BOOL shouldParse = [expectation isEqualToString:@"accept"];
+        if (!shouldParse && ![expectation isEqualToString:@"reject"]) {
+            return 64;
+        }
+
+        NSString *path = [NSString stringWithUTF8String:argv[2]];
         NSData *data = [NSData dataWithContentsOfFile:path];
         if (data == nil) {
             return 66;
@@ -30,9 +36,9 @@ int main(int argc, const char *argv[]) {
               stateResolver:nil
     signingValidationStatus:SPUAppcastSigningValidationStatusSucceeded
                       error:&error];
-        if (appcast != nil || error == nil) {
-            return 1;
+        if (shouldParse) {
+            return appcast != nil && error == nil ? 0 : 1;
         }
-        return 0;
+        return appcast == nil && error != nil ? 0 : 1;
     }
 }

--- a/scripts/fixtures/SignedAppcastParserProbe.m
+++ b/scripts/fixtures/SignedAppcastParserProbe.m
@@ -1,0 +1,38 @@
+#import <Foundation/Foundation.h>
+#import <Sparkle/Sparkle.h>
+
+@class SPUAppcastItemStateResolver;
+
+@interface SUAppcast (CopyLassoArchitectureProof)
+- (nullable instancetype)initWithXMLData:(NSData *)xmlData
+                           relativeToURL:(nullable NSURL *)relativeURL
+                           stateResolver:(nullable SPUAppcastItemStateResolver *)stateResolver
+                 signingValidationStatus:(SPUAppcastSigningValidationStatus)signingValidationStatus
+                                   error:(NSError *_Nullable *_Nullable)error;
+@end
+
+int main(int argc, const char *argv[]) {
+    @autoreleasepool {
+        if (argc != 2) {
+            return 64;
+        }
+
+        NSString *path = [NSString stringWithUTF8String:argv[1]];
+        NSData *data = [NSData dataWithContentsOfFile:path];
+        if (data == nil) {
+            return 66;
+        }
+
+        NSError *error = nil;
+        SUAppcast *appcast = [[SUAppcast alloc]
+            initWithXMLData:data
+              relativeToURL:[NSURL fileURLWithPath:path]
+              stateResolver:nil
+    signingValidationStatus:SPUAppcastSigningValidationStatusSucceeded
+                      error:&error];
+        if (appcast != nil || error == nil) {
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/scripts/fixtures/run-secure-update-signatures.sh
+++ b/scripts/fixtures/run-secure-update-signatures.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && /bin/pwd -P)"
+readonly tools_dir="${COPYLASSO_SPARKLE_TOOLS_DIR:-}"
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+[[ "$#" == "0" ]] || fail "Unexpected sandboxed signature fixture argument."
+[[ -n "$tools_dir" ]] || fail "Set COPYLASSO_SPARKLE_TOOLS_DIR to Sparkle's bin directory."
+readonly sign_update="$tools_dir/sign_update"
+readonly generate_appcast="$tools_dir/generate_appcast"
+readonly sparkle_artifact_dir="$(cd "$tools_dir/.." && /bin/pwd)"
+readonly sparkle_frameworks="$sparkle_artifact_dir/Sparkle.xcframework/macos-arm64_x86_64"
+readonly parser_probe_source="$repository_root/scripts/fixtures/SignedAppcastParserProbe.m"
+[[ -x "$sign_update" ]] || fail "Sparkle sign_update is unavailable."
+[[ -x "$generate_appcast" ]] || fail "Sparkle generate_appcast is unavailable."
+[[ -d "$sparkle_frameworks/Sparkle.framework" ]] || fail "Sparkle framework is unavailable."
+[[ -f "$parser_probe_source" ]] || fail "Signed appcast parser probe is unavailable."
+
+readonly temporary_directory="$(/usr/bin/mktemp -d "${TMPDIR:-/private/tmp}/copylasso-g35-signatures.XXXXXX")"
+trap '/bin/rm -rf "$temporary_directory"' EXIT
+
+readonly signing_key="$temporary_directory/signing-key"
+readonly wrong_key="$temporary_directory/wrong-key"
+/usr/bin/openssl rand -base64 32 > "$signing_key"
+/usr/bin/openssl rand -base64 32 > "$wrong_key"
+/bin/chmod 600 "$signing_key" "$wrong_key"
+
+readonly archive="$temporary_directory/CopyLasso-0.2.0.dmg"
+/usr/bin/printf 'CopyLasso local secure-update fixture\n' > "$archive"
+archive_signature="$("$sign_update" --ed-key-file "$signing_key" -p "$archive" 2>/dev/null)"
+[[ -n "$archive_signature" ]] || fail "Sparkle did not produce an archive signature."
+"$sign_update" --verify --ed-key-file "$signing_key" \
+    "$archive" "$archive_signature" >/dev/null 2>&1 || \
+    fail "Sparkle rejected its signed archive fixture."
+
+readonly tampered_archive="$temporary_directory/CopyLasso-0.2.0-tampered.dmg"
+/bin/cp "$archive" "$tampered_archive"
+/usr/bin/printf 'tampered\n' >> "$tampered_archive"
+if "$sign_update" --verify --ed-key-file "$signing_key" \
+    "$tampered_archive" "$archive_signature" >/dev/null 2>&1; then
+    fail "Sparkle accepted a tampered archive fixture."
+fi
+if "$sign_update" --verify --ed-key-file "$wrong_key" \
+    "$archive" "$archive_signature" >/dev/null 2>&1; then
+    fail "Sparkle accepted an archive signed by a different key."
+fi
+
+readonly feed="$temporary_directory/appcast.xml"
+/usr/bin/printf '%s\n' \
+    '<?xml version="1.0" encoding="utf-8"?>' \
+    '<rss version="2.0"><channel><title>CopyLasso local fixture</title></channel></rss>' \
+    > "$feed"
+"$sign_update" --ed-key-file "$signing_key" "$feed" >/dev/null 2>&1 || \
+    fail "Sparkle could not sign the local appcast fixture."
+"$sign_update" --verify --ed-key-file "$signing_key" "$feed" >/dev/null 2>&1 || \
+    fail "Sparkle rejected its signed appcast fixture."
+
+readonly tampered_feed="$temporary_directory/appcast-tampered.xml"
+/bin/cp "$feed" "$tampered_feed"
+/usr/bin/sed -i '' \
+    's/CopyLasso local fixture/CopyLasso tampered fixture/' \
+    "$tampered_feed"
+if "$sign_update" --verify --ed-key-file "$signing_key" "$tampered_feed" >/dev/null 2>&1; then
+    fail "Sparkle accepted a tampered appcast fixture."
+fi
+if "$sign_update" --verify --ed-key-file "$wrong_key" "$feed" >/dev/null 2>&1; then
+    fail "Sparkle accepted an appcast signed by a different key."
+fi
+
+readonly malformed_feed="$temporary_directory/appcast-malformed.xml"
+/usr/bin/printf '<rss><channel>' > "$malformed_feed"
+"$sign_update" --ed-key-file "$signing_key" "$malformed_feed" >/dev/null 2>&1 || \
+    fail "Sparkle could not sign the malformed appcast fixture."
+"$sign_update" --verify --ed-key-file "$signing_key" "$malformed_feed" >/dev/null 2>&1 || \
+    fail "Sparkle did not authenticate the signed malformed appcast fixture."
+
+readonly parser_probe="$temporary_directory/signed-appcast-parser-probe"
+/usr/bin/xcrun clang \
+    -fobjc-arc \
+    -F "$sparkle_frameworks" \
+    -framework Foundation \
+    -framework Sparkle \
+    "$parser_probe_source" \
+    -o "$parser_probe"
+DYLD_FRAMEWORK_PATH="$sparkle_frameworks" "$parser_probe" accept "$feed" || \
+    fail "Sparkle did not parse the authenticated well-formed appcast control."
+DYLD_FRAMEWORK_PATH="$sparkle_frameworks" "$parser_probe" reject "$malformed_feed" || \
+    fail "Sparkle parsed an authenticated malformed appcast fixture."
+
+# The package must expose the reviewed feed-generation tool even though G35
+# deliberately does not generate or publish a production appcast.
+"$generate_appcast" --help >/dev/null 2>&1 || fail "Sparkle generate_appcast is unusable."
+
+echo "CopyLasso offline Sparkle signature fixtures passed."

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -221,6 +221,11 @@ if ! /usr/bin/grep -Fq \
     "$ci_script"; then
     fail "Canonical CI must audit that its Release application excludes updater configuration."
 fi
+if ! /usr/bin/grep -Fq \
+    'The Release application must not contain Sparkle.' \
+    "$ci_script"; then
+    fail "Canonical CI must audit that its Release bundle excludes embedded Sparkle."
+fi
 
 if ! /usr/bin/grep -Fq \
     'COPYLASSO_BRAND_AUDIT_OUTPUT="$derived_data/brand-release-audit" \' \

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -212,9 +212,14 @@ if ! /usr/bin/grep -Fq \
     fail "Canonical CI must run the signature proof with its resolved Sparkle tools."
 fi
 if ! /usr/bin/grep -Fq \
-    'COPYLASSO_SECURE_UPDATE_APP="$derived_data/Build/Products/Debug/CopyLasso.app" \' \
+    'COPYLASSO_SECURE_UPDATE_DEBUG_APP="$derived_data/Build/Products/Debug/CopyLasso.app" \' \
     "$ci_script"; then
-    fail "Canonical CI must audit that its built application excludes Sparkle."
+    fail "Canonical CI must audit that its Debug application excludes Sparkle."
+fi
+if ! /usr/bin/grep -Fq \
+    'The Release application must not configure an updater.' \
+    "$ci_script"; then
+    fail "Canonical CI must audit that its Release application excludes updater configuration."
 fi
 
 if ! /usr/bin/grep -Fq \

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -12,6 +12,9 @@ readonly release_workflow_audit_script="$repository_root/scripts/audit-release-w
 readonly platform_qualification_audit_script="$repository_root/scripts/audit-platform-qualification.sh"
 readonly platform_qualification_test_script="$repository_root/scripts/test-platform-qualification.sh"
 readonly v02_contract_audit_script="$repository_root/scripts/audit-v02-contract.sh"
+readonly secure_update_audit_script="$repository_root/scripts/audit-secure-update-architecture.sh"
+readonly secure_update_test_script="$repository_root/scripts/test-secure-update-architecture.sh"
+readonly secure_update_signature_script="$repository_root/scripts/test-secure-update-signatures.sh"
 readonly generated_app_cleanup_runner="$repository_root/scripts/run-with-generated-app-cleanup.sh"
 readonly ordinary_release_cleanup="$repository_root/scripts/unregister-generated-release.sh"
 readonly repeatability_script="$repository_root/scripts/test-repeatability.sh"
@@ -134,6 +137,33 @@ if [[ "$v02_contract_audit_invocations" != "1" ]]; then
     fail "Canonical CI must invoke scripts/audit-v02-contract.sh exactly once."
 fi
 
+secure_update_audit_invocations="$({
+    /usr/bin/grep -Ec \
+        '^[[:space:]]*\./scripts/audit-secure-update-architecture\.sh[[:space:]]*$' \
+        "$ci_script" || true
+})"
+if [[ "$secure_update_audit_invocations" != "1" ]]; then
+    fail "Canonical CI must invoke scripts/audit-secure-update-architecture.sh exactly once."
+fi
+
+secure_update_test_invocations="$({
+    /usr/bin/grep -Ec \
+        '^[[:space:]]*\./scripts/test-secure-update-architecture\.sh[[:space:]]*$' \
+        "$ci_script" || true
+})"
+if [[ "$secure_update_test_invocations" != "1" ]]; then
+    fail "Canonical CI must invoke scripts/test-secure-update-architecture.sh exactly once."
+fi
+
+secure_update_signature_invocations="$({
+    /usr/bin/grep -Ec \
+        '^[[:space:]]*\./scripts/test-secure-update-signatures\.sh[[:space:]]*$' \
+        "$ci_script" || true
+})"
+if [[ "$secure_update_signature_invocations" != "1" ]]; then
+    fail "Canonical CI must invoke scripts/test-secure-update-signatures.sh exactly once."
+fi
+
 if [[ ! -x "$developer_id_audit_script" ]] || \
     [[ ! -x "$repository_root/scripts/verify-developer-id-app.sh" ]] || \
     [[ ! -x "$repository_root/scripts/test-developer-id-release.sh" ]]; then
@@ -168,6 +198,23 @@ fi
 
 if [[ ! -x "$v02_contract_audit_script" ]]; then
     fail "The v0.2 product-contract audit must be executable."
+fi
+
+if [[ ! -x "$secure_update_audit_script" ]] || \
+    [[ ! -x "$secure_update_test_script" ]] || \
+    [[ ! -x "$secure_update_signature_script" ]]; then
+    fail "Secure-update architecture proof scripts must be executable."
+fi
+
+if ! /usr/bin/grep -Fq \
+    'COPYLASSO_SPARKLE_TOOLS_DIR="$(/usr/bin/dirname "$sparkle_sign_update")" \' \
+    "$ci_script"; then
+    fail "Canonical CI must run the signature proof with its resolved Sparkle tools."
+fi
+if ! /usr/bin/grep -Fq \
+    'COPYLASSO_SECURE_UPDATE_APP="$derived_data/Build/Products/Debug/CopyLasso.app" \' \
+    "$ci_script"; then
+    fail "Canonical CI must audit that its built application excludes Sparkle."
 fi
 
 if ! /usr/bin/grep -Fq \

--- a/scripts/test-secure-update-architecture.sh
+++ b/scripts/test-secure-update-architecture.sh
@@ -25,4 +25,18 @@ done
 [[ -f "$repository_root/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift" ]] || \
     fail "Secure-update behavior proof tests are missing."
 
+if ! /usr/bin/grep -Fq 'sparkle_package_reference="$(package_reference_block' \
+    "$audit_script"; then
+    fail "The audit must scope Sparkle's exact requirement to its package-reference block."
+fi
+
+ambient_marker_output="$({
+    COPYLASSO_SECURE_UPDATE_FIXTURE_INNER=1 \
+        COPYLASSO_SPARKLE_TOOLS_DIR=/private/tmp/copylasso-invalid-sparkle-tools \
+        "$fixture_script" 2>&1
+} || true)"
+if [[ "$ambient_marker_output" != *'COPYLASSO_SECURE_UPDATE_FIXTURE_INNER must not be preset.'* ]]; then
+    fail "The signature proof must reject an ambient inner-process marker."
+fi
+
 echo "CopyLasso secure-update architecture contract passed."

--- a/scripts/test-secure-update-architecture.sh
+++ b/scripts/test-secure-update-architecture.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && /bin/pwd -P)"
+readonly audit_script="$repository_root/scripts/audit-secure-update-architecture.sh"
+readonly fixture_script="$repository_root/scripts/test-secure-update-signatures.sh"
+readonly architecture_decision="$repository_root/docs/architecture/ADR-004-secure-updates.md"
+readonly threat_model="$repository_root/docs/secure-update-threat-model.md"
+readonly operations="$repository_root/docs/secure-update-operations.md"
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+for executable in "$audit_script" "$fixture_script"; do
+    [[ -x "$executable" ]] || fail "Secure-update proof executable is missing: $(basename "$executable")"
+done
+
+for document in "$architecture_decision" "$threat_model" "$operations"; do
+    [[ -f "$document" ]] || fail "Secure-update proof document is missing: $(basename "$document")"
+done
+
+[[ -f "$repository_root/CopyLassoTests/Update/SecureUpdateArchitectureProofTests.swift" ]] || \
+    fail "Secure-update behavior proof tests are missing."
+
+echo "CopyLasso secure-update architecture contract passed."

--- a/scripts/test-secure-update-architecture.sh
+++ b/scripts/test-secure-update-architecture.sh
@@ -29,6 +29,10 @@ if ! /usr/bin/grep -Fq 'sparkle_package_reference="$(package_reference_block' \
     "$audit_script"; then
     fail "The audit must scope Sparkle's exact requirement to its package-reference block."
 fi
+if ! /usr/bin/grep -Fq '.pins | map(select(.identity == "sparkle"))' \
+    "$audit_script"; then
+    fail "The audit must scope Sparkle's resolved state to its lockfile pin."
+fi
 
 ambient_marker_output="$({
     COPYLASSO_SECURE_UPDATE_FIXTURE_INNER=1 \

--- a/scripts/test-secure-update-signatures.sh
+++ b/scripts/test-secure-update-signatures.sh
@@ -4,105 +4,23 @@ set -euo pipefail
 
 readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && /bin/pwd -P)"
 readonly tools_dir="${COPYLASSO_SPARKLE_TOOLS_DIR:-}"
+readonly fixture_runner="$repository_root/scripts/fixtures/run-secure-update-signatures.sh"
 
 fail() {
     echo "$1" >&2
     exit 1
 }
 
+[[ "$#" == "0" ]] || fail "Unexpected secure-update signature proof argument."
+if [[ -n "${COPYLASSO_SECURE_UPDATE_FIXTURE_INNER:-}" ]]; then
+    fail "COPYLASSO_SECURE_UPDATE_FIXTURE_INNER must not be preset."
+fi
 [[ -n "$tools_dir" ]] || fail "Set COPYLASSO_SPARKLE_TOOLS_DIR to Sparkle's bin directory."
-readonly sign_update="$tools_dir/sign_update"
-readonly generate_appcast="$tools_dir/generate_appcast"
-readonly sparkle_artifact_dir="$(cd "$tools_dir/.." && /bin/pwd)"
-readonly sparkle_frameworks="$sparkle_artifact_dir/Sparkle.xcframework/macos-arm64_x86_64"
-readonly parser_probe_source="$repository_root/scripts/fixtures/SignedAppcastParserProbe.m"
-[[ -x "$sign_update" ]] || fail "Sparkle sign_update is unavailable."
-[[ -x "$generate_appcast" ]] || fail "Sparkle generate_appcast is unavailable."
-[[ -d "$sparkle_frameworks/Sparkle.framework" ]] || fail "Sparkle framework is unavailable."
-[[ -f "$parser_probe_source" ]] || fail "Signed appcast parser probe is unavailable."
+[[ -x "$fixture_runner" ]] || fail "The sandboxed signature fixture runner is unavailable."
 
-if [[ "${COPYLASSO_SECURE_UPDATE_FIXTURE_INNER:-0}" != "1" ]]; then
-    exec /usr/bin/sandbox-exec \
-        -p '(version 1)(allow default)(deny network*)' \
-        /usr/bin/env \
-        COPYLASSO_SECURE_UPDATE_FIXTURE_INNER=1 \
-        COPYLASSO_SPARKLE_TOOLS_DIR="$tools_dir" \
-        "$0"
-fi
-
-readonly temporary_directory="$(/usr/bin/mktemp -d "${TMPDIR:-/private/tmp}/copylasso-g35-signatures.XXXXXX")"
-trap '/bin/rm -rf "$temporary_directory"' EXIT
-
-readonly signing_key="$temporary_directory/signing-key"
-readonly wrong_key="$temporary_directory/wrong-key"
-/usr/bin/openssl rand -base64 32 > "$signing_key"
-/usr/bin/openssl rand -base64 32 > "$wrong_key"
-/bin/chmod 600 "$signing_key" "$wrong_key"
-
-readonly archive="$temporary_directory/CopyLasso-0.2.0.dmg"
-/usr/bin/printf 'CopyLasso local secure-update fixture\n' > "$archive"
-archive_signature="$("$sign_update" --ed-key-file "$signing_key" -p "$archive" 2>/dev/null)"
-[[ -n "$archive_signature" ]] || fail "Sparkle did not produce an archive signature."
-"$sign_update" --verify --ed-key-file "$signing_key" \
-    "$archive" "$archive_signature" >/dev/null 2>&1 || \
-    fail "Sparkle rejected its signed archive fixture."
-
-readonly tampered_archive="$temporary_directory/CopyLasso-0.2.0-tampered.dmg"
-/bin/cp "$archive" "$tampered_archive"
-/usr/bin/printf 'tampered\n' >> "$tampered_archive"
-if "$sign_update" --verify --ed-key-file "$signing_key" \
-    "$tampered_archive" "$archive_signature" >/dev/null 2>&1; then
-    fail "Sparkle accepted a tampered archive fixture."
-fi
-if "$sign_update" --verify --ed-key-file "$wrong_key" \
-    "$archive" "$archive_signature" >/dev/null 2>&1; then
-    fail "Sparkle accepted an archive signed by a different key."
-fi
-
-readonly feed="$temporary_directory/appcast.xml"
-/usr/bin/printf '%s\n' \
-    '<?xml version="1.0" encoding="utf-8"?>' \
-    '<rss version="2.0"><channel><title>CopyLasso local fixture</title></channel></rss>' \
-    > "$feed"
-"$sign_update" --ed-key-file "$signing_key" "$feed" >/dev/null 2>&1 || \
-    fail "Sparkle could not sign the local appcast fixture."
-"$sign_update" --verify --ed-key-file "$signing_key" "$feed" >/dev/null 2>&1 || \
-    fail "Sparkle rejected its signed appcast fixture."
-
-readonly tampered_feed="$temporary_directory/appcast-tampered.xml"
-/bin/cp "$feed" "$tampered_feed"
-/usr/bin/sed -i '' \
-    's/CopyLasso local fixture/CopyLasso tampered fixture/' \
-    "$tampered_feed"
-if "$sign_update" --verify --ed-key-file "$signing_key" "$tampered_feed" >/dev/null 2>&1; then
-    fail "Sparkle accepted a tampered appcast fixture."
-fi
-if "$sign_update" --verify --ed-key-file "$wrong_key" "$feed" >/dev/null 2>&1; then
-    fail "Sparkle accepted an appcast signed by a different key."
-fi
-
-readonly malformed_feed="$temporary_directory/appcast-malformed.xml"
-/usr/bin/printf '<rss><channel>' > "$malformed_feed"
-"$sign_update" --ed-key-file "$signing_key" "$malformed_feed" >/dev/null 2>&1 || \
-    fail "Sparkle could not sign the malformed appcast fixture."
-"$sign_update" --verify --ed-key-file "$signing_key" "$malformed_feed" >/dev/null 2>&1 || \
-    fail "Sparkle did not authenticate the signed malformed appcast fixture."
-
-readonly parser_probe="$temporary_directory/signed-appcast-parser-probe"
-/usr/bin/xcrun clang \
-    -fobjc-arc \
-    -F "$sparkle_frameworks" \
-    -framework Foundation \
-    -framework Sparkle \
-    "$parser_probe_source" \
-    -o "$parser_probe"
-DYLD_FRAMEWORK_PATH="$sparkle_frameworks" "$parser_probe" accept "$feed" || \
-    fail "Sparkle did not parse the authenticated well-formed appcast control."
-DYLD_FRAMEWORK_PATH="$sparkle_frameworks" "$parser_probe" reject "$malformed_feed" || \
-    fail "Sparkle parsed an authenticated malformed appcast fixture."
-
-# The package must expose the reviewed feed-generation tool even though G35
-# deliberately does not generate or publish a production appcast.
-"$generate_appcast" --help >/dev/null 2>&1 || fail "Sparkle generate_appcast is unusable."
-
-echo "CopyLasso offline Sparkle signature fixtures passed."
+exec /usr/bin/sandbox-exec \
+    -p '(version 1)(allow default)(deny network*)' \
+    /usr/bin/env \
+    -u COPYLASSO_SECURE_UPDATE_FIXTURE_INNER \
+    COPYLASSO_SPARKLE_TOOLS_DIR="$tools_dir" \
+    "$fixture_runner"

--- a/scripts/test-secure-update-signatures.sh
+++ b/scripts/test-secure-update-signatures.sh
@@ -13,8 +13,13 @@ fail() {
 [[ -n "$tools_dir" ]] || fail "Set COPYLASSO_SPARKLE_TOOLS_DIR to Sparkle's bin directory."
 readonly sign_update="$tools_dir/sign_update"
 readonly generate_appcast="$tools_dir/generate_appcast"
+readonly sparkle_artifact_dir="$(cd "$tools_dir/.." && /bin/pwd)"
+readonly sparkle_frameworks="$sparkle_artifact_dir/Sparkle.xcframework/macos-arm64_x86_64"
+readonly parser_probe_source="$repository_root/scripts/fixtures/SignedAppcastParserProbe.m"
 [[ -x "$sign_update" ]] || fail "Sparkle sign_update is unavailable."
 [[ -x "$generate_appcast" ]] || fail "Sparkle generate_appcast is unavailable."
+[[ -d "$sparkle_frameworks/Sparkle.framework" ]] || fail "Sparkle framework is unavailable."
+[[ -f "$parser_probe_source" ]] || fail "Signed appcast parser probe is unavailable."
 
 if [[ "${COPYLASSO_SECURE_UPDATE_FIXTURE_INNER:-0}" != "1" ]]; then
     exec /usr/bin/sandbox-exec \
@@ -36,20 +41,20 @@ readonly wrong_key="$temporary_directory/wrong-key"
 
 readonly archive="$temporary_directory/CopyLasso-0.2.0.dmg"
 /usr/bin/printf 'CopyLasso local secure-update fixture\n' > "$archive"
-archive_signature="$($sign_update --ed-key-file "$signing_key" -p "$archive" 2>/dev/null)"
+archive_signature="$("$sign_update" --ed-key-file "$signing_key" -p "$archive" 2>/dev/null)"
 [[ -n "$archive_signature" ]] || fail "Sparkle did not produce an archive signature."
-$sign_update --verify --ed-key-file "$signing_key" \
+"$sign_update" --verify --ed-key-file "$signing_key" \
     "$archive" "$archive_signature" >/dev/null 2>&1 || \
     fail "Sparkle rejected its signed archive fixture."
 
 readonly tampered_archive="$temporary_directory/CopyLasso-0.2.0-tampered.dmg"
 /bin/cp "$archive" "$tampered_archive"
 /usr/bin/printf 'tampered\n' >> "$tampered_archive"
-if $sign_update --verify --ed-key-file "$signing_key" \
+if "$sign_update" --verify --ed-key-file "$signing_key" \
     "$tampered_archive" "$archive_signature" >/dev/null 2>&1; then
     fail "Sparkle accepted a tampered archive fixture."
 fi
-if $sign_update --verify --ed-key-file "$wrong_key" \
+if "$sign_update" --verify --ed-key-file "$wrong_key" \
     "$archive" "$archive_signature" >/dev/null 2>&1; then
     fail "Sparkle accepted an archive signed by a different key."
 fi
@@ -59,9 +64,9 @@ readonly feed="$temporary_directory/appcast.xml"
     '<?xml version="1.0" encoding="utf-8"?>' \
     '<rss version="2.0"><channel><title>CopyLasso local fixture</title></channel></rss>' \
     > "$feed"
-$sign_update --ed-key-file "$signing_key" "$feed" >/dev/null 2>&1 || \
+"$sign_update" --ed-key-file "$signing_key" "$feed" >/dev/null 2>&1 || \
     fail "Sparkle could not sign the local appcast fixture."
-$sign_update --verify --ed-key-file "$signing_key" "$feed" >/dev/null 2>&1 || \
+"$sign_update" --verify --ed-key-file "$signing_key" "$feed" >/dev/null 2>&1 || \
     fail "Sparkle rejected its signed appcast fixture."
 
 readonly tampered_feed="$temporary_directory/appcast-tampered.xml"
@@ -69,21 +74,33 @@ readonly tampered_feed="$temporary_directory/appcast-tampered.xml"
 /usr/bin/sed -i '' \
     's/CopyLasso local fixture/CopyLasso tampered fixture/' \
     "$tampered_feed"
-if $sign_update --verify --ed-key-file "$signing_key" "$tampered_feed" >/dev/null 2>&1; then
+if "$sign_update" --verify --ed-key-file "$signing_key" "$tampered_feed" >/dev/null 2>&1; then
     fail "Sparkle accepted a tampered appcast fixture."
 fi
-if $sign_update --verify --ed-key-file "$wrong_key" "$feed" >/dev/null 2>&1; then
+if "$sign_update" --verify --ed-key-file "$wrong_key" "$feed" >/dev/null 2>&1; then
     fail "Sparkle accepted an appcast signed by a different key."
 fi
 
 readonly malformed_feed="$temporary_directory/appcast-malformed.xml"
 /usr/bin/printf '<rss><channel>' > "$malformed_feed"
-if $sign_update --verify --ed-key-file "$signing_key" "$malformed_feed" >/dev/null 2>&1; then
-    fail "Sparkle accepted an unsigned malformed appcast fixture."
-fi
+"$sign_update" --ed-key-file "$signing_key" "$malformed_feed" >/dev/null 2>&1 || \
+    fail "Sparkle could not sign the malformed appcast fixture."
+"$sign_update" --verify --ed-key-file "$signing_key" "$malformed_feed" >/dev/null 2>&1 || \
+    fail "Sparkle did not authenticate the signed malformed appcast fixture."
+
+readonly parser_probe="$temporary_directory/signed-appcast-parser-probe"
+/usr/bin/xcrun clang \
+    -fobjc-arc \
+    -F "$sparkle_frameworks" \
+    -framework Foundation \
+    -framework Sparkle \
+    "$parser_probe_source" \
+    -o "$parser_probe"
+DYLD_FRAMEWORK_PATH="$sparkle_frameworks" "$parser_probe" "$malformed_feed" || \
+    fail "Sparkle parsed an authenticated malformed appcast fixture."
 
 # The package must expose the reviewed feed-generation tool even though G35
 # deliberately does not generate or publish a production appcast.
-$generate_appcast --help >/dev/null 2>&1 || fail "Sparkle generate_appcast is unusable."
+"$generate_appcast" --help >/dev/null 2>&1 || fail "Sparkle generate_appcast is unusable."
 
 echo "CopyLasso offline Sparkle signature fixtures passed."

--- a/scripts/test-secure-update-signatures.sh
+++ b/scripts/test-secure-update-signatures.sh
@@ -96,7 +96,9 @@ readonly parser_probe="$temporary_directory/signed-appcast-parser-probe"
     -framework Sparkle \
     "$parser_probe_source" \
     -o "$parser_probe"
-DYLD_FRAMEWORK_PATH="$sparkle_frameworks" "$parser_probe" "$malformed_feed" || \
+DYLD_FRAMEWORK_PATH="$sparkle_frameworks" "$parser_probe" accept "$feed" || \
+    fail "Sparkle did not parse the authenticated well-formed appcast control."
+DYLD_FRAMEWORK_PATH="$sparkle_frameworks" "$parser_probe" reject "$malformed_feed" || \
     fail "Sparkle parsed an authenticated malformed appcast fixture."
 
 # The package must expose the reviewed feed-generation tool even though G35

--- a/scripts/test-secure-update-signatures.sh
+++ b/scripts/test-secure-update-signatures.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && /bin/pwd -P)"
+readonly tools_dir="${COPYLASSO_SPARKLE_TOOLS_DIR:-}"
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+[[ -n "$tools_dir" ]] || fail "Set COPYLASSO_SPARKLE_TOOLS_DIR to Sparkle's bin directory."
+readonly sign_update="$tools_dir/sign_update"
+readonly generate_appcast="$tools_dir/generate_appcast"
+[[ -x "$sign_update" ]] || fail "Sparkle sign_update is unavailable."
+[[ -x "$generate_appcast" ]] || fail "Sparkle generate_appcast is unavailable."
+
+if [[ "${COPYLASSO_SECURE_UPDATE_FIXTURE_INNER:-0}" != "1" ]]; then
+    exec /usr/bin/sandbox-exec \
+        -p '(version 1)(allow default)(deny network*)' \
+        /usr/bin/env \
+        COPYLASSO_SECURE_UPDATE_FIXTURE_INNER=1 \
+        COPYLASSO_SPARKLE_TOOLS_DIR="$tools_dir" \
+        "$0"
+fi
+
+readonly temporary_directory="$(/usr/bin/mktemp -d "${TMPDIR:-/private/tmp}/copylasso-g35-signatures.XXXXXX")"
+trap '/bin/rm -rf "$temporary_directory"' EXIT
+
+readonly signing_key="$temporary_directory/signing-key"
+readonly wrong_key="$temporary_directory/wrong-key"
+/usr/bin/openssl rand -base64 32 > "$signing_key"
+/usr/bin/openssl rand -base64 32 > "$wrong_key"
+/bin/chmod 600 "$signing_key" "$wrong_key"
+
+readonly archive="$temporary_directory/CopyLasso-0.2.0.dmg"
+/usr/bin/printf 'CopyLasso local secure-update fixture\n' > "$archive"
+archive_signature="$($sign_update --ed-key-file "$signing_key" -p "$archive" 2>/dev/null)"
+[[ -n "$archive_signature" ]] || fail "Sparkle did not produce an archive signature."
+$sign_update --verify --ed-key-file "$signing_key" \
+    "$archive" "$archive_signature" >/dev/null 2>&1 || \
+    fail "Sparkle rejected its signed archive fixture."
+
+readonly tampered_archive="$temporary_directory/CopyLasso-0.2.0-tampered.dmg"
+/bin/cp "$archive" "$tampered_archive"
+/usr/bin/printf 'tampered\n' >> "$tampered_archive"
+if $sign_update --verify --ed-key-file "$signing_key" \
+    "$tampered_archive" "$archive_signature" >/dev/null 2>&1; then
+    fail "Sparkle accepted a tampered archive fixture."
+fi
+if $sign_update --verify --ed-key-file "$wrong_key" \
+    "$archive" "$archive_signature" >/dev/null 2>&1; then
+    fail "Sparkle accepted an archive signed by a different key."
+fi
+
+readonly feed="$temporary_directory/appcast.xml"
+/usr/bin/printf '%s\n' \
+    '<?xml version="1.0" encoding="utf-8"?>' \
+    '<rss version="2.0"><channel><title>CopyLasso local fixture</title></channel></rss>' \
+    > "$feed"
+$sign_update --ed-key-file "$signing_key" "$feed" >/dev/null 2>&1 || \
+    fail "Sparkle could not sign the local appcast fixture."
+$sign_update --verify --ed-key-file "$signing_key" "$feed" >/dev/null 2>&1 || \
+    fail "Sparkle rejected its signed appcast fixture."
+
+readonly tampered_feed="$temporary_directory/appcast-tampered.xml"
+/bin/cp "$feed" "$tampered_feed"
+/usr/bin/sed -i '' \
+    's/CopyLasso local fixture/CopyLasso tampered fixture/' \
+    "$tampered_feed"
+if $sign_update --verify --ed-key-file "$signing_key" "$tampered_feed" >/dev/null 2>&1; then
+    fail "Sparkle accepted a tampered appcast fixture."
+fi
+if $sign_update --verify --ed-key-file "$wrong_key" "$feed" >/dev/null 2>&1; then
+    fail "Sparkle accepted an appcast signed by a different key."
+fi
+
+readonly malformed_feed="$temporary_directory/appcast-malformed.xml"
+/usr/bin/printf '<rss><channel>' > "$malformed_feed"
+if $sign_update --verify --ed-key-file "$signing_key" "$malformed_feed" >/dev/null 2>&1; then
+    fail "Sparkle accepted an unsigned malformed appcast fixture."
+fi
+
+# The package must expose the reviewed feed-generation tool even though G35
+# deliberately does not generate or publish a production appcast.
+$generate_appcast --help >/dev/null 2>&1 || fail "Sparkle generate_appcast is unusable."
+
+echo "CopyLasso offline Sparkle signature fixtures passed."


### PR DESCRIPTION
## What changed

- documents the accepted Sparkle 2.9.4 architecture, privacy posture, threat model, operations, key separation, and G36 handoff
- adds deterministic offline signature and appcast-tamper fixtures using Sparkle's resolved tools
- adds policy and transaction tests for versioning, replay resistance, archive constraints, cancellation, interruption, and explicit install confirmation
- adds static audits proving Sparkle remains test-only in G35 and the shipping app has no updater configuration, network entitlement, feed URL, or production update key
- integrates the focused update checks exactly once into canonical CI

## Why

G35 proves the security and privacy contracts for a future updater before any updater code ships in the product.

## Verification

- focused secure-update tests: 9 passed
- offline signature/appcast proof: passed with network denied
- secure-update, privacy/security, CI-contract, and v0.2 contract audits: passed
- canonical arm64 pipeline: passed
- canonical x86_64 pipeline: passed
- Universal 2 Release verification: passed

## Product impact

No updater UI, public feed, production update key, network entitlement, or shipping Sparkle framework is added in this goal. Version remains 0.1.1 (2).