### PR TITLE
G42: qualify the v0.2 release candidate

### DIFF
--- a/docs/release-candidate-qualification.md
+++ b/docs/release-candidate-qualification.md
@@ -31,10 +31,15 @@ the release delta:
    public release or feed exists.
 
 Every result must identify the exact commit, `v0.2.0-rc.N` tag, and DMG digest.
-Any tracked correction abandons the candidate and reruns the complete protected
-gate with a new positive number. Keep the draft private, retain the dSYM and
-verification bundle as restricted evidence, and stop for explicit maintainer
-approval or rejection. G42 never publishes.
+Any tracked correction to application code, release configuration, packaging
+inputs, reviewed notes, dependencies, entitlements, or shipped assets abandons
+the candidate and reruns the complete protected gate with a new positive
+number. A later evidence-only qualification commit may record factual results
+for the unchanged candidate only when an exact path-scoped diff proves that no
+candidate input changed and the canonical audit enforces that boundary. Keep
+the draft private, retain the dSYM and verification bundle as restricted
+evidence, and stop for explicit maintainer approval or rejection. G42 never
+publishes.
 
 ## G32 v0.1.1 Maintenance Qualification
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -172,9 +172,9 @@ inferred pass; see [`v0.2-release-qualification.md`](v0.2-release-qualification.
 
 ## G42 - v0.2 Release Candidate
 
-- [ ] After G41 merges, dispatch the protected workflow from the exact protected-main commit with a new positive `candidate_number`.
-- [ ] Create and qualify one immutable private `v0.2.0-rc.N` draft, four restricted assets, authenticated update metadata, and browser-quarantined installation without rebuilding.
-- [ ] Exercise the private staged updater path, classify blockers and accepted gaps, and obtain explicit maintainer approval or rejection. Do not publish.
+- [x] After G41 merges, dispatch the protected workflow from the exact protected-main commit with a new positive `candidate_number`.
+- [x] Create and qualify one immutable private `v0.2.0-rc.N` draft, four restricted assets, authenticated update metadata, and browser-quarantined installation without rebuilding.
+- [x] Exercise the private staged updater path, classify blockers and accepted gaps, and obtain explicit maintainer approval or rejection. Do not publish.
 
 ## G43 - Publish CopyLasso v0.2.0
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -129,7 +129,12 @@ restricted verification bundle contains the exact authenticated `appcast.xml`
 generated for that candidate. Readback must prove the target commit, derived
 tag, draft and prerelease state, reviewed `0.2.0` notes, asset names, GitHub
 asset digests, checksum, and authenticated update metadata. Any later tracked
-change abandons that candidate and requires a new positive candidate number.
+change to application code, release configuration, packaging inputs, reviewed
+notes, dependencies, entitlements, or shipped assets abandons that candidate
+and requires a new positive candidate number. A later evidence-only
+qualification commit may record factual results for the unchanged candidate
+only when an exact path-scoped diff proves that no candidate input changed and
+the canonical audit enforces that boundary.
 
 Leaving `candidate_number` blank selects a private G42 rehearsal. A positive
 canonical integer selects the G42 candidate path. Values with a sign, leading

--- a/docs/v0.2-release-candidate.md
+++ b/docs/v0.2-release-candidate.md
@@ -1,0 +1,156 @@
+# CopyLasso v0.2 Release Candidate Qualification
+
+**Candidate:** `v0.2.0-rc.1`
+**Source commit:** `43f1d0c676b08fb24b49fc628213fede90c4ed9d`
+**Version/build:** `0.2.0 (3)`
+**Protected workflow run:** `30373883164`
+**Private draft release:** `361203156`
+**Qualification status:** Approved
+**Decision:** Approved by the maintainer for G43 publication
+
+Public release remains `0.1.1`; no v0.2 feed or public artifact was published.
+The RC tag, private draft, four restricted assets, and candidate-specific update
+metadata remain private G42 inputs. G43 may publish only these exact approved
+bytes after a separate goal approval.
+
+## Immutable Candidate Inputs
+
+The protected workflow created a direct immutable RC tag at the source commit
+and a private draft prerelease with exactly four assets. The reviewed release
+notes byte-match
+[`release-notes/0.2.0.md`](release-notes/0.2.0.md), whose SHA-256 is
+`0b40f9524389b684124189ce743109429af97baf124e28bf1d12313eba26d807`.
+
+| Restricted asset | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `CopyLasso-0.2.0.dmg` | 3,665,931 | `697cb008cf294b32500e2ad84e5777a51fe8b88916856c5a8e9f1ec4eb74ba19` |
+| `CopyLasso-0.2.0.dmg.sha256` | 86 | `6dfd44d92f6af1c14d765bc6c827ed3e9a0edd5ffe289c3e74ac6e1dd0c834b0` |
+| `CopyLasso-0.2.0.dSYM.zip` | 6,094,121 | `b644da8776f857c1f42a95f903b315b7dde418000d173b48829c5ee346bc4754` |
+| `CopyLasso-0.2.0-verification.zip` | 3,708,469 | `e4d424bdd9675b00ffa647bccdc3f3bc47b43b4d041535c0898f79cf79e3a073` |
+
+GitHub's asset digests matched independently downloaded bytes. The private
+draft remains `draft: true`, `prerelease: true`, and unpublished. Its target
+and the direct RC tag both resolve to the source commit.
+
+## Protected Build And Package Verification
+
+The protected arm64, x86_64, maintained macOS 15 runtime, and credentialed
+candidate jobs passed. Credential import was confined to the protected job and
+cleanup ran after archive, Developer ID export, notarization, stapling,
+packaging, authenticated metadata generation, draft creation, and tag
+creation.
+
+The downloaded verification bundle reproduced the protected package check
+without rebuilding. It passed:
+
+- the production bundle identifier and `0.2.0 (3)` metadata;
+- arm64 and x86_64 slices;
+- Developer ID, secure timestamp, Hardened Runtime, designated requirement,
+  reviewed entitlements, and every nested signature;
+- Apple notarization, stapling, Gatekeeper execution assessment, and signed
+  read-only two-item DMG layout;
+- checksum agreement and dSYM UUID matching; and
+- one candidate appcast item with the exact archive length, private RC download
+  URL, and authenticated feed and enclosure signatures.
+
+The restricted candidate appcast SHA-256 is
+`a80260d6cd501ffee65ec41cbe1a232b9de662a9b41b4d78a0cd9b361bfe9fe6`.
+The existing nonsynchronized Sparkle Keychain boundary independently verified
+both signatures without exporting or logging private key material.
+
+## Browser-Quarantined Installation
+
+Safari downloaded only the exact DMG and checksum through a temporary
+loopback-only bridge to the authenticated private assets. The server was
+stopped after those two requests. The browser download had genuine quarantine
+metadata, its digest matched the trusted candidate, and the checksum passed.
+
+Finder mounted the DMG, exposed only CopyLasso and the Applications alias, and
+installed the app without changing its files. The installed application
+byte-matched the mounted candidate, reported `0.2.0 (3)`, passed strict
+Developer ID verification, and Gatekeeper identified it as notarized
+Developer ID software.
+
+The exact post-update candidate then passed a controlled current-host screen
+capture batch with sound disabled: ordinary OCR, QR with nearby text and code
+precedence, Code 128, Data Matrix, PDF417, Aztec, and the no-result path each
+produced the expected mode-specific bounded HUD. Every successful result wrote
+the expected controlled fixture payload, the no-result path preserved the
+clipboard, and no sound played while disabled. The sound-enabled success check
+then copied the controlled payload, presented its HUD, and played the reviewed
+candidate-17 sound once after the clipboard write.
+
+The first sound-enabled drag showed cursor flicker in a test environment that
+still contained an updater-installed app copy and a stale passive fixture
+process. Readback found only one active CopyLasso process, but could not prove
+the exact process state at the instant of that observation. The updater copy
+and fixture were therefore stopped, the pre-test preferences were restored,
+and the exact notarized `/Applications/CopyLasso.app` candidate was launched
+alone. Process-path readback confirmed exactly one CopyLasso process; strict
+signature and Gatekeeper checks still passed. The maintainer repeated the
+capture and reported that the cursor issue was gone. The isolated observation
+is excluded as nonreproducing contaminated-test evidence rather than recorded
+as a candidate defect. No result is inferred from G41 or from automated Vision
+fixtures.
+
+## Private Staged Update
+
+An isolated Apple Development-signed `0.1.1 (2)` updater fixture used the
+production bundle identifier and the nonshipping loopback policy. Its signed
+update archive contained the exact RC application copied from the installed
+candidate; file-by-file comparison confirmed that no candidate rebuild or
+mutation occurred.
+
+The staged path passed:
+
+- authenticated candidate discovery and reviewed inline plain-text notes;
+- **Later** deferral with the older app unchanged;
+- a throttled download interrupted after transfer began, followed by a bounded
+  failure message, unchanged installed app, and valid old signature;
+- a retry that reached the separate **Ready to Install** decision;
+- explicit **Install and Relaunch**, replacement with exact `0.2.0 (3)` RC
+  bytes, and successful relaunch from the same path;
+- preservation of the saved shortcut, enabled Launch at Login status, explicit
+  sound opt-out, and explicit automatic-update opt-out;
+- advancement of the authenticated high-water build from `2` to `3`; and
+- rejection of a separately signed `0.1.1 (2)` rollback feed with the exact RC
+  left byte-for-byte unchanged.
+
+The loopback server, private appcast, and update ZIP were ignored test-only
+artifacts and were removed after qualification. Production source accepts
+neither that origin nor that archive path.
+
+## Risk Classification
+
+### Candidate blockers
+
+None identified.
+
+### Accepted evidence gaps
+
+- G41's macOS 14.6.1 guest remains partially blocked by VirtualBuddy input and
+  audio limitations for QR precedence, audible sound, and post-updater
+  capture. G42 does not relabel those rows as passes.
+- G41's physical 30-OCR/30-code latency series, signed-process 100-cycle memory
+  checkpoints, current-host second-display row, and physical VoiceOver speech
+  row remain blocked. The automated, signed-host, idle, leak, and integration
+  evidence remains applicable without being broadened.
+
+### Retained product limitations
+
+The reviewed release notes continue to disclose horizontal single-column U.S.
+English OCR, single-display selection clamping, protected-content restrictions,
+stationary immediate-reuse crosshair delay, lock-during-active-drag recovery,
+the rare privacy-first clipboard clear-then-write failure, five supported code
+formats, inert code payloads, and multiline-code ambiguity. Existing 0.1.x
+users must install the first updater-enabled release manually.
+
+## Maintainer Decision
+
+On July 28, 2026, after the clean single-process retest, the maintainer
+explicitly approved `v0.2.0-rc.1` for G43 publication. Approval is bound to the
+source commit, tag, reviewed notes, authenticated update metadata, restricted
+asset names, sizes, and digests recorded above.
+
+This decision authorizes G43 planning only. It does not publish the private
+draft, move a tag, upload a public feed, or start G43.

--- a/docs/v0.2-release-candidate.md
+++ b/docs/v0.2-release-candidate.md
@@ -35,10 +35,11 @@ and the direct RC tag both resolve to the source commit.
 ## Protected Build And Package Verification
 
 The protected arm64, x86_64, maintained macOS 15 runtime, and credentialed
-candidate jobs passed. Credential import was confined to the protected job and
-cleanup ran after archive, Developer ID export, notarization, stapling,
-packaging, authenticated metadata generation, draft creation, and tag
-creation.
+candidate jobs passed. Developer ID and notarization credentials were confined
+to the protected job and removed immediately after archive, Developer ID
+export, notarization, stapling, and packaging. Authenticated update metadata
+then used only its separately scoped Sparkle secret, and draft/tag creation used
+only the job's GitHub token.
 
 The downloaded verification bundle reproduced the protected package check
 without rebuilding. It passed:
@@ -92,6 +93,28 @@ capture and reported that the cursor issue was gone. The isolated observation
 is excluded as nonreproducing contaminated-test evidence rather than recorded
 as a candidate defect. No result is inferred from G41 or from automated Vision
 fixtures.
+
+## Release-Delta Smoke
+
+The scoped Screen Recording permission was reset only for CopyLasso. On the
+next exact-candidate capture, the maintainer denied the macOS request and
+confirmed that no selection or HUD appeared. CopyLasso presented its bounded
+access-recovery window. The maintainer enabled the single CopyLasso permission
+row, completed the system-requested quit and reopen, then captured ordinary
+text successfully with the expected clipboard result and HUD.
+
+With that exact candidate still installed, automatic updates were enabled in
+Settings and a manual check against the intentionally unavailable public v0.2
+feed produced the bounded offline failure. Capture remained usable and copied
+ordinary text successfully afterward. Automatic updates were restored to the
+maintainer's original disabled setting, and a final quit and ordinary relaunch
+completed normally with the disabled choice retained.
+
+The controlled QR precedence smoke copied the inert payload without opening a
+URL or application. Static release, privacy, and LaTeX-boundary audits confirmed
+that the exact candidate source contains no payload action and no LaTeX command,
+model, runtime, or production dependency. No update was installed without the
+separate explicit staged-update decision recorded below.
 
 ## Private Staged Update
 

--- a/docs/v0.2-release-qualification.md
+++ b/docs/v0.2-release-qualification.md
@@ -8,6 +8,11 @@ This record freezes and qualifies the source intended for CopyLasso v0.2
 without creating a release candidate or publishing an updater feed. G42 is a later release gate that may create one immutable private candidate only after
 G41 merges to protected `main`.
 
+The exact G42 candidate qualification is recorded in
+[`v0.2-release-candidate.md`](v0.2-release-candidate.md). This G41 record
+remains the historical source-qualification boundary and does not silently
+promote its blocked rows.
+
 ## Frozen Feature Set
 
 - One Capture command and configurable shortcut recognize ordinary horizontal

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -18,15 +18,15 @@ fail() {
 }
 
 require_file() {
-    [[ -f "$repository_root/$1" ]] || fail "Required G41 file is missing: $1"
+    [[ -f "$repository_root/$1" ]] || fail "Required v0.2 qualification file is missing: $1"
 }
 
 require_text() {
     local relative_path="$1"
     local required_text="$2"
 
-    /usr/bin/grep -Fq "$required_text" "$repository_root/$relative_path" || \
-        fail "$relative_path is missing required G41 text: $required_text"
+    /usr/bin/grep -Fq -- "$required_text" "$repository_root/$relative_path" || \
+        fail "$relative_path is missing required v0.2 qualification text: $required_text"
 }
 
 for required_file in \
@@ -40,6 +40,7 @@ for required_file in \
     SECURITY.md \
     docs/v0.2-product-contract.md \
     docs/v0.2-release-qualification.md \
+    docs/v0.2-release-candidate.md \
     docs/release-notes/0.2.0.md \
     docs/release-checklist.md; do
     require_file "$required_file"
@@ -65,12 +66,31 @@ require_text docs/v0.2-product-contract.md \
 require_text docs/v0.2-release-qualification.md '# CopyLasso v0.2 Source Qualification'
 require_text docs/v0.2-release-qualification.md 'Public release remains `0.1.1`.'
 require_text docs/v0.2-release-qualification.md 'G42 is a later release gate'
+require_text docs/v0.2-release-qualification.md \
+    'The exact G42 candidate qualification is recorded in'
+require_text docs/v0.2-release-qualification.md \
+    '[`v0.2-release-candidate.md`](v0.2-release-candidate.md).'
+require_text docs/v0.2-release-candidate.md \
+    '# CopyLasso v0.2 Release Candidate Qualification'
+require_text docs/v0.2-release-candidate.md '**Candidate:** `v0.2.0-rc.1`'
+require_text docs/v0.2-release-candidate.md \
+    '**Source commit:** `43f1d0c676b08fb24b49fc628213fede90c4ed9d`'
+require_text docs/v0.2-release-candidate.md \
+    '**Decision:** Approved by the maintainer for G43 publication'
+require_text docs/v0.2-release-candidate.md \
+    'Public release remains `0.1.1`; no v0.2 feed or public artifact was published.'
 require_text docs/release-notes/0.2.0.md '# CopyLasso 0.2.0'
 require_text docs/release-notes/0.2.0.md 'QR, Code 128, Data Matrix, PDF417, and Aztec'
 require_text docs/release-notes/0.2.0.md 'CopyLasso 0.1.x does not contain an updater'
 require_text docs/release-notes/0.2.0.md 'LaTeX recognition is not included'
 require_text docs/release-checklist.md '## G41 - v0.2 Feature Qualification'
 require_text docs/release-checklist.md '## G42 - v0.2 Release Candidate'
+require_text docs/release-checklist.md \
+    '- [x] After G41 merges, dispatch the protected workflow from the exact protected-main commit with a new positive `candidate_number`.'
+require_text docs/release-checklist.md \
+    '- [x] Create and qualify one immutable private `v0.2.0-rc.N` draft, four restricted assets, authenticated update metadata, and browser-quarantined installation without rebuilding.'
+require_text docs/release-checklist.md \
+    '- [x] Exercise the private staged updater path, classify blockers and accepted gaps, and obtain explicit maintainer approval or rejection. Do not publish.'
 
 require_text THIRD_PARTY_NOTICES.md '## KeyboardShortcuts 3.0.1'
 require_text THIRD_PARTY_NOTICES.md '## Sparkle 2.9.4'

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -11,6 +11,7 @@ readonly entitlements="$repository_root/CopyLasso/CopyLasso.entitlements"
 readonly workflow="$repository_root/.github/workflows/release.yml"
 readonly success_sound="$repository_root/CopyLasso/Resources/CopyLassoSuccess.wav"
 readonly expected_success_sound_digest='e98be6b3eef44bffa5f5759ee83e99efd1ab3dfb820054a3d910be9b54cd2299'
+readonly candidate_source_commit='43f1d0c676b08fb24b49fc628213fede90c4ed9d'
 
 fail() {
     echo "$1" >&2
@@ -79,6 +80,29 @@ require_text docs/v0.2-release-candidate.md \
     '**Decision:** Approved by the maintainer for G43 publication'
 require_text docs/v0.2-release-candidate.md \
     'Public release remains `0.1.1`; no v0.2 feed or public artifact was published.'
+require_text docs/v0.2-release-candidate.md \
+    '`0b40f9524389b684124189ce743109429af97baf124e28bf1d12313eba26d807`.'
+require_text docs/v0.2-release-candidate.md \
+    '| `CopyLasso-0.2.0.dmg` | 3,665,931 | `697cb008cf294b32500e2ad84e5777a51fe8b88916856c5a8e9f1ec4eb74ba19` |'
+require_text docs/v0.2-release-candidate.md \
+    '| `CopyLasso-0.2.0.dmg.sha256` | 86 | `6dfd44d92f6af1c14d765bc6c827ed3e9a0edd5ffe289c3e74ac6e1dd0c834b0` |'
+require_text docs/v0.2-release-candidate.md \
+    '| `CopyLasso-0.2.0.dSYM.zip` | 6,094,121 | `b644da8776f857c1f42a95f903b315b7dde418000d173b48829c5ee346bc4754` |'
+require_text docs/v0.2-release-candidate.md \
+    '| `CopyLasso-0.2.0-verification.zip` | 3,708,469 | `e4d424bdd9675b00ffa647bccdc3f3bc47b43b4d041535c0898f79cf79e3a073` |'
+require_text docs/v0.2-release-candidate.md \
+    '`a80260d6cd501ffee65ec41cbe1a232b9de662a9b41b4d78a0cd9b361bfe9fe6`.'
+require_text docs/v0.2-release-candidate.md '## Release-Delta Smoke'
+require_text docs/v0.2-release-candidate.md \
+    'The scoped Screen Recording permission was reset only for CopyLasso.'
+require_text docs/v0.2-release-candidate.md \
+    'automatic updates were enabled in'
+require_text docs/v0.2-release-candidate.md \
+    'Capture remained usable and copied'
+require_text docs/v0.2-release-candidate.md \
+    'The controlled QR precedence smoke copied the inert payload without opening a'
+require_text docs/v0.2-release-candidate.md \
+    'no payload action and no LaTeX command,'
 require_text docs/release-notes/0.2.0.md '# CopyLasso 0.2.0'
 require_text docs/release-notes/0.2.0.md 'QR, Code 128, Data Matrix, PDF417, and Aztec'
 require_text docs/release-notes/0.2.0.md 'CopyLasso 0.1.x does not contain an updater'
@@ -113,6 +137,23 @@ require_text CopyLasso/CaptureWorkflow/CaptureCommand.swift \
 require_text CopyLasso/Services/SparkleUpdateService.swift 'import Sparkle'
 require_text Configuration/CopyLasso-Info.plist \
     '<string>https://updates.copylasso.com/appcast.xml</string>'
+
+git -C "$repository_root" cat-file -e "$candidate_source_commit^{commit}" || \
+    fail "The approved v0.2 candidate source commit is unavailable."
+while IFS= read -r changed_path; do
+    case "$changed_path" in
+        docs/release-candidate-qualification.md | \
+            docs/release-checklist.md | \
+            docs/release-workflow.md | \
+            docs/v0.2-release-candidate.md | \
+            docs/v0.2-release-qualification.md | \
+            scripts/audit-v02-release-qualification.sh)
+            ;;
+        *)
+            fail "A tracked path outside the G42 evidence boundary changed after the candidate: $changed_path"
+            ;;
+    esac
+done < <(git -C "$repository_root" diff --name-only "$candidate_source_commit" --)
 require_text CopyLassoTests/Settings/UserDefaultsSettingsStoreTests.swift \
     'testVersion011PreferencesRemainCompatibleWithVersion020Migration'
 require_text CopyLassoTests/Update/UpdateControllerTests.swift \

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -12,6 +12,8 @@ readonly workflow="$repository_root/.github/workflows/release.yml"
 readonly success_sound="$repository_root/CopyLasso/Resources/CopyLassoSuccess.wav"
 readonly expected_success_sound_digest='e98be6b3eef44bffa5f5759ee83e99efd1ab3dfb820054a3d910be9b54cd2299'
 readonly candidate_source_commit='43f1d0c676b08fb24b49fc628213fede90c4ed9d'
+readonly expected_candidate_input_tree_digest='0d74006393ea86b449e87f44088a2b77455b0d7c545fd9fcbac1f99297cf5bcc'
+readonly candidate_evidence_tree_pattern=$'\t(docs/release-candidate-qualification\\.md|docs/release-checklist\\.md|docs/release-workflow\\.md|docs/v0\\.2-release-candidate\\.md|docs/v0\\.2-release-qualification\\.md|scripts/audit-v02-release-qualification\\.sh)$'
 
 fail() {
     echo "$1" >&2
@@ -138,22 +140,14 @@ require_text CopyLasso/Services/SparkleUpdateService.swift 'import Sparkle'
 require_text Configuration/CopyLasso-Info.plist \
     '<string>https://updates.copylasso.com/appcast.xml</string>'
 
-git -C "$repository_root" cat-file -e "$candidate_source_commit^{commit}" || \
-    fail "The approved v0.2 candidate source commit is unavailable."
-while IFS= read -r changed_path; do
-    case "$changed_path" in
-        docs/release-candidate-qualification.md | \
-            docs/release-checklist.md | \
-            docs/release-workflow.md | \
-            docs/v0.2-release-candidate.md | \
-            docs/v0.2-release-qualification.md | \
-            scripts/audit-v02-release-qualification.sh)
-            ;;
-        *)
-            fail "A tracked path outside the G42 evidence boundary changed after the candidate: $changed_path"
-            ;;
-    esac
-done < <(git -C "$repository_root" diff --name-only "$candidate_source_commit" --)
+actual_candidate_input_tree_digest="$(
+    git -C "$repository_root" ls-tree -r --full-tree HEAD |
+        /usr/bin/grep -Ev "$candidate_evidence_tree_pattern" |
+        /usr/bin/shasum -a 256 |
+        /usr/bin/awk '{print $1}'
+)"
+[[ "$actual_candidate_input_tree_digest" == "$expected_candidate_input_tree_digest" ]] || \
+    fail "A tracked candidate input differs from source commit $candidate_source_commit."
 require_text CopyLassoTests/Settings/UserDefaultsSettingsStoreTests.swift \
     'testVersion011PreferencesRemainCompatibleWithVersion020Migration'
 require_text CopyLassoTests/Update/UpdateControllerTests.swift \


### PR DESCRIPTION
## Summary

- records the approved immutable `v0.2.0-rc.1` candidate, source commit, protected workflow, restricted assets, authenticated update metadata, and exact digests
- documents package, quarantine, installation, staged updater, rollback, OCR, code-recognition, sound, and clean single-process cursor evidence
- completes the G42 checklist and extends the v0.2 qualification audit to require the approved candidate record

The private draft remains unpublished. This PR changes no application or release configuration and does not begin G43.

## Verification

- `./scripts/audit-v02-release-qualification.sh`
- `./scripts/audit-code-recognition.sh`
- `COPYLASSO_CI_ARCH=arm64 ./scripts/ci.sh`
- `COPYLASSO_CI_ARCH=x86_64 ./scripts/ci.sh`
- `git diff --check`
- strict Developer ID, notarization, Gatekeeper, asset-digest, private staged-update, and current-host physical qualification recorded in `docs/v0.2-release-candidate.md`