### PR TITLE
Prefer OCR text over detected codes in unified Capture

### DIFF
--- a/CopyLasso/CaptureWorkflow/CaptureCommand.swift
+++ b/CopyLasso/CaptureWorkflow/CaptureCommand.swift
@@ -288,6 +288,13 @@ final class CaptureCommand: CaptureRequesting, ActiveCaptureCancelling {
     }
 
     let recognitionFailed = textAttempt.isFailure || codeAttempt.isFailure
+    if case .success(let textObservations) = textAttempt {
+      let text = textAssembler.assemble(textObservations)
+      if !text.isEmpty {
+        return .text(text)
+      }
+    }
+
     if case .success(let codeObservations) = codeAttempt {
       switch codePayloadAssembler.assemble(codeObservations) {
       case .content(let payload):
@@ -296,13 +303,6 @@ final class CaptureCommand: CaptureRequesting, ActiveCaptureCancelling {
         return .ambiguousCodes
       case .noCode:
         break
-      }
-    }
-
-    if case .success(let textObservations) = textAttempt {
-      let text = textAssembler.assemble(textObservations)
-      if !text.isEmpty {
-        return .text(text)
       }
     }
 

--- a/CopyLassoTests/CaptureWorkflow/CaptureWorkflowIntegrationTests.swift
+++ b/CopyLassoTests/CaptureWorkflow/CaptureWorkflowIntegrationTests.swift
@@ -229,7 +229,7 @@ final class CaptureWorkflowIntegrationTests: XCTestCase {
     XCTAssertEqual(context.coordinator.state, .idle)
   }
 
-  func testSupportedCodeWinsOverRecognizedTextThenPlaysSoundAndPresentsCodeFeedback()
+  func testRecognizedTextWinsOverSupportedCodeThenPlaysSoundAndPresentsTextFeedback()
     async throws
   {
     let observations = [
@@ -244,17 +244,17 @@ final class CaptureWorkflowIntegrationTests: XCTestCase {
     )
     await context.scheduler.runNext()
 
-    XCTAssertEqual(context.clipboard.writtenTexts, ["LEFT\nRIGHT"])
+    XCTAssertEqual(context.clipboard.writtenTexts, ["assembled"])
     XCTAssertEqual(context.sound.playCallCount, 1)
     XCTAssertEqual(
       context.feedback.presentedFeedback,
-      [.codeSuccess(preview: "LEFT RIGHT")]
+      [.success(preview: "assembled")]
     )
     let barcodeRecognitionCount = await context.barcode.recognitionCallCount
     let textRecognitionCount = await context.ocr.recognitionCallCount
     XCTAssertEqual(barcodeRecognitionCount, 1)
     XCTAssertEqual(textRecognitionCount, 1)
-    XCTAssertEqual(context.textAssembler.inputs, [])
+    XCTAssertEqual(context.textAssembler.inputs.count, 1)
     XCTAssertEqual(context.coordinator.state, .idle)
   }
 
@@ -282,7 +282,7 @@ final class CaptureWorkflowIntegrationTests: XCTestCase {
     XCTAssertEqual(context.sound.playCallCount, 0)
   }
 
-  func testMultilineCodeAmbiguityWinsOverTextAndPreservesClipboard() async throws {
+  func testRecognizedTextWinsOverMultilineCodeAmbiguity() async throws {
     let ambiguous = try makeContext(
       barcodeResult: .success([
         codeObservation(payload: "line one\nline two", x: 0.1),
@@ -291,10 +291,26 @@ final class CaptureWorkflowIntegrationTests: XCTestCase {
     )
     _ = ambiguous.command.perform()
     await ambiguous.scheduler.runNext()
+    XCTAssertEqual(ambiguous.feedback.presentedFeedback, [.success(preview: "assembled")])
+    XCTAssertEqual(ambiguous.clipboard.writtenTexts, ["assembled"])
+    XCTAssertEqual(ambiguous.sound.playCallCount, 1)
+    XCTAssertEqual(ambiguous.textAssembler.inputs.count, 1)
+  }
+
+  func testMultilineCodeAmbiguityWithoutTextPreservesClipboard() async throws {
+    let ambiguous = try makeContext(
+      barcodeResult: .success([
+        codeObservation(payload: "line one\nline two", x: 0.1),
+        codeObservation(payload: "another", x: 0.6),
+      ]),
+      assembledText: ""
+    )
+    _ = ambiguous.command.perform()
+    await ambiguous.scheduler.runNext()
     XCTAssertEqual(ambiguous.feedback.presentedFeedback, [.ambiguousCodes])
     XCTAssertEqual(ambiguous.clipboard.writtenTexts, [])
     XCTAssertEqual(ambiguous.sound.playCallCount, 0)
-    XCTAssertEqual(ambiguous.textAssembler.inputs, [])
+    XCTAssertEqual(ambiguous.textAssembler.inputs.count, 1)
   }
 
   func testOneRecognizerMaySucceedWhenTheOtherFails()


### PR DESCRIPTION
### Motivation
- The unified Capture flow previously resolved code payloads before OCR text, allowing nearby QR/barcode content to overwrite user-selected visible text on the clipboard.
- The change is intended to preserve clipboard integrity and user intent by preferring non-empty OCR text when present.
- Integration tests needed updates to reflect the new precedence and to preserve existing ambiguous-code behavior when no text is recognized.

### Description
- Reordered recognition resolution in `CopyLasso/CaptureWorkflow/CaptureCommand.swift` so `textAttempt` is assembled and returned first when non-empty, before considering `codeAttempt`.
- Updated `CopyLassoTests/CaptureWorkflow/CaptureWorkflowIntegrationTests.swift` to assert that recognized text wins over supported codes, renamed the affected test for clarity, and added `testMultilineCodeAmbiguityWithoutTextPreservesClipboard` to ensure ambiguous-code behavior is unchanged when OCR returns empty text.
- Preserved fallback and ambiguous-code handling so that when no text is recognized the existing code ambiguity and no-clipboard-write behavior remain intact.

### Testing
- Ran `git diff --check`, which reported no whitespace/diff issues.
- Attempted to run `xcodebuild test -scheme CopyLasso -destination 'platform=macOS'`, but `xcodebuild` is not available in this Linux environment so macOS tests could not be executed.
- Attempted `swift test` from the repository root, but no `Package.swift` is present; unit test files were updated locally but the full test suite could not be run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a725d345cfc832780ce93a69859ef26)