### PR TITLE
Reject embedded absolute paths in release evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Build and test
@@ -74,6 +75,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Download maintained-runtime artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 name: Protected Release Candidate
 
 on:
-  workflow_dispatch:
-    inputs:
-      candidate_number:
-        description: Positive release-candidate number; leave blank only for a private G42 rehearsal
-        required: false
-        type: string
+  repository_dispatch:
+    types: [copylasso_protected_release]
 
 permissions:
   contents: read
@@ -18,14 +14,14 @@ concurrency:
 jobs:
   quality-gate:
     name: Complete release quality gate
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'copylasso_protected_release' && github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
     uses: ./.github/workflows/ci.yml
 
   protected-release:
     name: Build protected draft release
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'copylasso_protected_release' && github.ref == 'refs/heads/main' }}
     needs: quality-gate
     runs-on: macos-26
     timeout-minutes: 90
@@ -35,7 +31,8 @@ jobs:
       contents: write
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
-      COPYLASSO_CANDIDATE_NUMBER: ${{ inputs.candidate_number }}
+      # Omit candidate_number only for a private G42 rehearsal.
+      COPYLASSO_CANDIDATE_NUMBER: ${{ github.event.client_payload.candidate_number }}
     steps:
       - name: Check out exact protected commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,14 @@ concurrency:
 jobs:
   quality-gate:
     name: Complete release quality gate
+    if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
     uses: ./.github/workflows/ci.yml
 
   protected-release:
     name: Build protected draft release
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: quality-gate
     runs-on: macos-26
     timeout-minutes: 90

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -142,8 +142,12 @@ the canonical audit enforces that boundary.
 Leaving `candidate_number` blank selects a private G42 rehearsal. A positive
 canonical integer selects the G42 candidate path. Values with a sign, leading
 zero, decimal, whitespace, or tag text are rejected before they influence a tag
-or path. No arbitrary tag, ref, or mode input exists. The tag is created last,
-and the helper never replaces, patches, moves, or force-updates a ref or release.
+or path. No arbitrary tag, ref, or mode input exists. The candidate tag is
+created atomically before draft creation and is rollback-eligible only after
+that exact ref creation succeeds. An ambiguous release-creation response retains
+the tag for manual inspection because another actor may already have attached a
+release to it. The helper never replaces, patches, moves, or force-updates a ref
+or release.
 
 The reviewed candidate body is
 [`release-notes/0.2.0.md`](release-notes/0.2.0.md). Follow

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,6 +1,6 @@
 # Protected Release Workflow
 
-The manually dispatched workflow builds one signed, notarized, and verified
+The maintainer-dispatched workflow builds one signed, notarized, and verified
 CopyLasso release from the exact protected `main` commit. It creates a private
 draft prerelease and never publishes it. G41 updates this source-only trust
 boundary for G42 and version `0.2.0`; it does not dispatch the workflow. A final
@@ -10,11 +10,12 @@ have been independently read back.
 
 ## Trust Boundary
 
-The workflow file must exist on the default branch before GitHub accepts its `workflow_dispatch`
-event. Run it only by choosing `main` in the Actions interface or by dispatching the workflow with
-`--ref main`.
-The workflow itself rejects every ref except `refs/heads/main`, requires the checked-out `HEAD` to
-equal the dispatched full commit, and requires that commit to equal `origin/main`.
+The workflow accepts only the `copylasso_protected_release` `repository_dispatch`
+event. GitHub runs that event from the repository's default branch, so the
+caller cannot select an unreviewed branch copy of the privileged workflow. The
+workflow also rejects every ref except `refs/heads/main`, requires the checked-out
+`HEAD` to equal the dispatched full commit, and requires that commit to equal
+`origin/main`.
 
 The ordinary pull-request workflow has no release trigger and receives no release credential. The
 protected workflow runs the complete reusable arm64, x86_64, and minimum-macOS gate before it asks
@@ -84,7 +85,8 @@ contract remains separate.
 Only after the G41 source pull request is reviewed, green, and separately
 merged, and G42 is explicitly approved:
 
-1. Open **Actions > Protected Release Candidate > Run workflow** and select `main`.
+1. Dispatch `copylasso_protected_release` through GitHub's repository dispatch API without a
+   `candidate_number` payload field.
 2. Confirm the run's commit is the intended protected `main` commit.
 3. Wait for the complete reusable CI gate.
 4. Approve the `release` environment when GitHub requests deployment review.
@@ -116,8 +118,9 @@ altering either historical record.
 G42 has two ordered phases.
 
 1. Merge the reviewed G41 source-enablement pull request to protected `main`.
-   Because `workflow_dispatch` uses the workflow on the default branch, no
-   rehearsal or candidate can be created from the unmerged G41 branch.
+   Because `repository_dispatch` runs the workflow from the default branch, no
+   rehearsal or candidate can be created from the unmerged G41 branch or an
+   attacker-selected branch copy of the workflow.
 2. In a separately approved post-merge protected run, supply only a validated
    positive `candidate_number`. The workflow derives `v0.2.0-rc.N`, refuses an
    existing tag or release, and builds the exact protected `main` commit through
@@ -154,9 +157,9 @@ The completed G32 maintenance handoff is historical evidence for public
 `0.1.1`. It had two ordered phases.
 
 1. Land a reviewed source-enablement pull request that adds a distinct RC mode to the protected
-   workflow, draft helper, static audit, and regression tests. Because `workflow_dispatch` uses the
-   workflow on the default branch, this phase requires a separately approved merge to protected
-   `main` before candidate creation can begin.
+   workflow, draft helper, static audit, and regression tests. The historical G32 operator selected
+   `main`, and the source verifier rejected every other ref. G45 later replaced that branch-selectable
+   trigger with a default-branch-only repository dispatch boundary.
 2. In the post-merge protected run, supply only a validated positive `candidate_number`; derive
    `v0.1.1-rc.N` inside the workflow, refuse an existing tag or release, and build the exact merged
    `main` commit through the complete quality gate and `release` environment. The job must sign,

--- a/scripts/audit-release-workflow.sh
+++ b/scripts/audit-release-workflow.sh
@@ -81,19 +81,22 @@ for prohibited_key in teamID provisioningProfiles installerSigningCertificate; d
     fi
 done
 
-require_text "$workflow" 'workflow_dispatch:'
-require_text "$workflow" 'candidate_number:'
-require_text "$workflow" 'COPYLASSO_CANDIDATE_NUMBER: ${{ inputs.candidate_number }}'
+require_text "$workflow" 'repository_dispatch:'
+require_text "$workflow" 'types: [copylasso_protected_release]'
+require_text "$workflow" \
+    'COPYLASSO_CANDIDATE_NUMBER: ${{ github.event.client_payload.candidate_number }}'
 require_text "$workflow" 'assert_release_candidate_number "$COPYLASSO_CANDIDATE_NUMBER"'
 require_text "$workflow" 'release_candidate_tag "$COPYLASSO_CANDIDATE_NUMBER"'
 require_text "$workflow" 'release_tag="v${COPYLASSO_G28_VERSION}-g42.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}"'
-if [[ "$(/usr/bin/grep -Fc '${{ inputs.' "$workflow")" != "1" ]]; then
-    fail "candidate_number must be the protected workflow's sole dispatch input."
+if [[ "$(/usr/bin/grep -Fc '${{ github.event.client_payload.' "$workflow")" != "1" ]]; then
+    fail "candidate_number must be the protected workflow's sole dispatch payload field."
 fi
-if /usr/bin/grep -Eq '\$\{\{[[:space:]]*inputs\.(tag|ref|mode)' "$workflow"; then
-    fail "The protected workflow must not accept an arbitrary tag, ref, or mode input."
+if /usr/bin/grep -Eq \
+    '\$\{\{[[:space:]]*github\.event\.client_payload\.(tag|ref|mode)' \
+    "$workflow"; then
+    fail "The protected workflow must not accept an arbitrary tag, ref, or mode payload."
 fi
-for prohibited_trigger in pull_request: pull_request_target: push: repository_dispatch: workflow_run:; do
+for prohibited_trigger in pull_request: pull_request_target: push: workflow_dispatch: workflow_run:; do
     if /usr/bin/grep -Eq "^[[:space:]]*${prohibited_trigger}[[:space:]]*$" "$workflow"; then
         fail "The protected release workflow has a prohibited trigger: $prohibited_trigger"
     fi
@@ -110,6 +113,7 @@ contents_write_count="$(/usr/bin/grep -Ec '^[[:space:]]*contents: write[[:space:
     fail "Only the protected draft job may receive contents write permission."
 require_text "$workflow" 'permissions:'
 require_text "$workflow" 'contents: read'
+assert_release_workflow_trusted_dispatch "$workflow"
 assert_release_workflow_job_guard "$workflow" "quality-gate"
 assert_release_workflow_job_guard "$workflow" "protected-release"
 
@@ -260,7 +264,7 @@ for required_documentation_text in \
     'self-review allowed' \
     'Team API key' \
     'password-protected PKCS#12' \
-    'workflow_dispatch' \
+    'repository_dispatch' \
     'refs/heads/main' \
     'pull-request workflow has no release trigger' \
     'credential cleanup' \

--- a/scripts/audit-release-workflow.sh
+++ b/scripts/audit-release-workflow.sh
@@ -107,6 +107,10 @@ contents_write_count="$(/usr/bin/grep -Ec '^[[:space:]]*contents: write[[:space:
     fail "Only the protected draft job may receive contents write permission."
 require_text "$workflow" 'permissions:'
 require_text "$workflow" 'contents: read'
+require_text "$workflow" 'if: ${{ github.ref == '"'"'refs/heads/main'"'"' }}'
+[[ "$(/usr/bin/grep -Fc 'if: ${{ github.ref == '"'"'refs/heads/main'"'"' }}' "$workflow")" == "2" ]] || \
+    fail "Both release jobs must enforce the trusted main-branch dispatch guard."
+
 
 require_text "$workflow" 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0'
 require_text "$workflow" 'ref: ${{ github.sha }}'

--- a/scripts/audit-release-workflow.sh
+++ b/scripts/audit-release-workflow.sh
@@ -62,6 +62,9 @@ for readable in \
         fail "Protected-release contract file is missing: $(basename "$readable")"
 done
 
+# shellcheck source=scripts/lib/release-workflow-verification.sh
+source "$verification_library"
+
 /usr/bin/plutil -lint "$ci_export_options" >/dev/null
 [[ "$(/usr/bin/plutil -extract method raw -o - "$ci_export_options")" == "developer-id" ]] || \
     fail "The hosted release export method must be developer-id."
@@ -107,10 +110,8 @@ contents_write_count="$(/usr/bin/grep -Ec '^[[:space:]]*contents: write[[:space:
     fail "Only the protected draft job may receive contents write permission."
 require_text "$workflow" 'permissions:'
 require_text "$workflow" 'contents: read'
-require_text "$workflow" 'if: ${{ github.ref == '"'"'refs/heads/main'"'"' }}'
-[[ "$(/usr/bin/grep -Fc 'if: ${{ github.ref == '"'"'refs/heads/main'"'"' }}' "$workflow")" == "2" ]] || \
-    fail "Both release jobs must enforce the trusted main-branch dispatch guard."
-
+assert_release_workflow_job_guard "$workflow" "quality-gate"
+assert_release_workflow_job_guard "$workflow" "protected-release"
 
 require_text "$workflow" 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0'
 require_text "$workflow" 'ref: ${{ github.sha }}'

--- a/scripts/audit-release-workflow.sh
+++ b/scripts/audit-release-workflow.sh
@@ -273,7 +273,9 @@ for required_documentation_text in \
     'v0.2.0-rc.N' \
     'candidate_number' \
     'asset digests' \
-    'tag is created last' \
+    'candidate tag is' \
+    'created atomically before draft creation' \
+    'ambiguous release-creation response retains' \
     'G32' \
     'G42' \
     'COPYLASSO_SPARKLE_PRIVATE_KEY' \

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -15,11 +15,12 @@ readonly candidate_source_commit='43f1d0c676b08fb24b49fc628213fede90c4ed9d'
 readonly expected_candidate_input_tree_digest='baf122b35c5132f31e1df07d1ff0402713f9cabe7ef7b48355289bc29682f39e'
 readonly candidate_evidence_tree_pattern=$'\t(\\.github/workflows/prepare-publication\\.yml|docs/release-candidate-qualification\\.md|docs/release-checklist\\.md|docs/release-workflow\\.md|docs/secure-update-operations\\.md|docs/v0\\.2-publication-runbook\\.md|docs/v0\\.2-release-candidate\\.md|docs/v0\\.2-release-qualification\\.md|scripts/audit-v02-publication\\.sh|scripts/audit-v02-release-qualification\\.sh|scripts/ci\\.sh|scripts/create-v02-publication-draft\\.sh|scripts/download-v02-candidate\\.sh|scripts/generate-release-appcast\\.sh|scripts/lib/release-package-verification\\.sh|scripts/lib/v02-publication-transaction\\.sh|scripts/lib/v02-publication-verification\\.sh|scripts/lib/verify-sparkle-signatures\\.swift|scripts/prepare-update-feed\\.sh|scripts/test-ci-contract\\.sh|scripts/test-release-package\\.sh|scripts/test-v02-publication\\.sh|scripts/verify-release-package\\.sh|scripts/verify-v02-candidate-package\\.sh)$'
 readonly approved_post_publication_patch_tree_pattern=$'\t(CHANGELOG\\.md|CopyLasso/App/CopyLassoApp\\.swift|CopyLasso/Models/SecureUpdateReleaseNotesPresentation\\.swift|CopyLasso/SharedUI/SecureUpdatePresentation\\.swift|CopyLassoTests/Update/SecureUpdateReleaseNotesPresentationTests\\.swift|CopyLassoUITests/CopyLassoUITests\\.swift|docs/architecture/overview\\.md|docs/manual-qa-and-performance\\.md|docs/secure-update-operations\\.md|docs/testing\\.md)$'
-readonly approved_post_publication_runtime_tree_pattern=$'\t(CopyLasso/App/CopyLassoApp\\.swift|CopyLasso/Models/SecureUpdateReleaseNotesPresentation\\.swift|CopyLasso/SharedUI/SecureUpdatePresentation\\.swift|CopyLassoTests/Update/SecureUpdateReleaseNotesPresentationTests\\.swift|CopyLassoUITests/CopyLassoUITests\\.swift|docs/manual-qa-and-performance\\.md)$'
+readonly approved_post_publication_runtime_tree_pattern=$'\t(CopyLasso/App/CopyLassoApp\\.swift|CopyLasso/Models/SecureUpdateReleaseNotesPresentation\\.swift|CopyLasso/SharedUI/SecureUpdatePresentation\\.swift)$'
+readonly approved_post_v02_security_patch_tree_pattern=$'\t(\\.github/workflows/release\\.yml|CopyLasso/Services/VisionOCRService\\.swift|CopyLassoTests/Services/VisionOCRServiceTests\\.swift|CopyLassoUITests/CopyLassoUITests\\.swift|scripts/audit-privacy-security\\.sh|scripts/audit-release-workflow\\.sh|scripts/audit-v02-release-qualification\\.sh|scripts/ci\\.sh|scripts/create-draft-release\\.sh|scripts/lib/release-package-verification\\.sh|scripts/lib/release-workflow-verification\\.sh|scripts/test-release-package\\.sh|scripts/test-release-workflow\\.sh)$'
 readonly g44_release_state_tree_pattern=$'\t(CHANGELOG\\.md|CONTRIBUTING\\.md|PRIVACY\\.md|README\\.md|SECURITY\\.md|docs/architecture/overview\\.md|docs/release-checklist\\.md|docs/release-workflow\\.md|docs/secure-update-operations\\.md|docs/security-and-privacy-review\\.md|docs/testing\\.md|docs/v0\\.2-product-contract\\.md|docs/v0\\.2-release-state\\.md|scripts/audit-brand-release\\.sh|scripts/audit-code-recognition\\.sh|scripts/audit-secure-update-architecture\\.sh|scripts/audit-v02-contract\\.sh|scripts/audit-v02-publication\\.sh|scripts/audit-v02-release-qualification\\.sh|scripts/audit-v02-release-state\\.sh|scripts/ci\\.sh|scripts/test-ci-contract\\.sh|scripts/test-release-metadata\\.sh)$'
-readonly expected_candidate_baseline_tree_digest='e6358aa654914c17146018f5bb5bfdd7eb3f52d79d88358bf2b16a814ba21c7b'
-readonly expected_approved_post_publication_runtime_tree_digest='6aa226944fafb8a45887db345b70afa94c2a2d2bc49b348350b153ce50095b7f'
-readonly expected_g44_release_state_files_digest='2223f222a24e2c970d7123cc973c54eb1a91ead66373ef9da481e452c1c8e30e'
+readonly expected_candidate_baseline_tree_digest='d7ffab8e04dee244d3dd0edb9f9b65402181f73f09a2255b4a2d3a153b833dfc'
+readonly expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'
+readonly expected_g44_release_state_files_digest='2a2f33d546587b081b1571a5beabe1772125ccf3550eab67c96279455856acb9'
 
 fail() {
     echo "$1" >&2
@@ -160,6 +161,7 @@ if git -C "$repository_root" cat-file -e "$candidate_source_commit^{tree}" 2>/de
         git -C "$repository_root" ls-tree -r --full-tree "$candidate_source_commit" |
             /usr/bin/grep -Ev "$candidate_evidence_tree_pattern" |
             /usr/bin/grep -Ev "$approved_post_publication_patch_tree_pattern" |
+            /usr/bin/grep -Ev "$approved_post_v02_security_patch_tree_pattern" |
             /usr/bin/grep -Ev "$g44_release_state_tree_pattern" |
             /usr/bin/shasum -a 256 |
             /usr/bin/awk '{print $1}'
@@ -172,6 +174,7 @@ current_baseline_tree_digest="$(
     git -C "$repository_root" ls-tree -r --full-tree HEAD |
         /usr/bin/grep -Ev "$candidate_evidence_tree_pattern" |
         /usr/bin/grep -Ev "$approved_post_publication_patch_tree_pattern" |
+        /usr/bin/grep -Ev "$approved_post_v02_security_patch_tree_pattern" |
         /usr/bin/grep -Ev "$g44_release_state_tree_pattern" |
         /usr/bin/shasum -a 256 |
         /usr/bin/awk '{print $1}'
@@ -209,7 +212,6 @@ readonly g44_release_state_files=(
     scripts/audit-v02-contract.sh
     scripts/audit-v02-publication.sh
     scripts/audit-v02-release-state.sh
-    scripts/ci.sh
     scripts/test-release-metadata.sh
 )
 g44_release_state_files_digest="$(

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -21,7 +21,7 @@ readonly g44_release_state_tree_pattern=$'\t(CHANGELOG\\.md|CONTRIBUTING\\.md|PR
 readonly expected_candidate_baseline_tree_digest='ecbcf39d0cac2b1525e46dc154123eb5418db3a9e790770a36a281b5160775bf'
 readonly expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'
 readonly expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'
-readonly expected_approved_post_candidate_patch_digest='3d69bb84129948dcabfd3783d05e4e967abdd8c65dbe8665dfdfdc5eddbf664a'
+readonly expected_approved_post_candidate_patch_digest='724128130010f3012c1b2466337b35c01f8d3ddd220b7e883a7bc4d61dcc2b22'
 
 fail() {
     echo "$1" >&2

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -21,7 +21,7 @@ readonly g44_release_state_tree_pattern=$'\t(CHANGELOG\\.md|CONTRIBUTING\\.md|PR
 readonly expected_candidate_baseline_tree_digest='d7ffab8e04dee244d3dd0edb9f9b65402181f73f09a2255b4a2d3a153b833dfc'
 readonly expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'
 readonly expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'
-readonly expected_approved_post_candidate_patch_digest='19d862803b654bf53fa663faa492232cf5f0ed3e12577430ce71c347f846f713'
+readonly expected_approved_post_candidate_patch_digest='73d0f5c39d90862e6b0bbfd57ff265846d1babcb93abb3106cc7c046a1e5ac13'
 
 fail() {
     echo "$1" >&2

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -21,7 +21,7 @@ readonly g44_release_state_tree_pattern=$'\t(CHANGELOG\\.md|CONTRIBUTING\\.md|PR
 readonly expected_candidate_baseline_tree_digest='ecbcf39d0cac2b1525e46dc154123eb5418db3a9e790770a36a281b5160775bf'
 readonly expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'
 readonly expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'
-readonly expected_approved_post_candidate_patch_digest='724128130010f3012c1b2466337b35c01f8d3ddd220b7e883a7bc4d61dcc2b22'
+readonly expected_approved_post_candidate_patch_digest='e019c0ba95e76220632aa04efa6af8d335ff37a56e7c561b36c734e6e08646ea'
 
 fail() {
     echo "$1" >&2

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -16,12 +16,12 @@ readonly expected_candidate_input_tree_digest='baf122b35c5132f31e1df07d1ff040271
 readonly candidate_evidence_tree_pattern=$'\t(\\.github/workflows/prepare-publication\\.yml|docs/release-candidate-qualification\\.md|docs/release-checklist\\.md|docs/release-workflow\\.md|docs/secure-update-operations\\.md|docs/v0\\.2-publication-runbook\\.md|docs/v0\\.2-release-candidate\\.md|docs/v0\\.2-release-qualification\\.md|scripts/audit-v02-publication\\.sh|scripts/audit-v02-release-qualification\\.sh|scripts/ci\\.sh|scripts/create-v02-publication-draft\\.sh|scripts/download-v02-candidate\\.sh|scripts/generate-release-appcast\\.sh|scripts/lib/release-package-verification\\.sh|scripts/lib/v02-publication-transaction\\.sh|scripts/lib/v02-publication-verification\\.sh|scripts/lib/verify-sparkle-signatures\\.swift|scripts/prepare-update-feed\\.sh|scripts/test-ci-contract\\.sh|scripts/test-release-package\\.sh|scripts/test-v02-publication\\.sh|scripts/verify-release-package\\.sh|scripts/verify-v02-candidate-package\\.sh)$'
 readonly approved_post_publication_patch_tree_pattern=$'\t(CHANGELOG\\.md|CopyLasso/App/CopyLassoApp\\.swift|CopyLasso/Models/SecureUpdateReleaseNotesPresentation\\.swift|CopyLasso/SharedUI/SecureUpdatePresentation\\.swift|CopyLassoTests/Update/SecureUpdateReleaseNotesPresentationTests\\.swift|CopyLassoUITests/CopyLassoUITests\\.swift|docs/architecture/overview\\.md|docs/manual-qa-and-performance\\.md|docs/secure-update-operations\\.md|docs/testing\\.md)$'
 readonly approved_post_publication_runtime_tree_pattern=$'\t(CopyLasso/App/CopyLassoApp\\.swift|CopyLasso/Models/SecureUpdateReleaseNotesPresentation\\.swift|CopyLasso/SharedUI/SecureUpdatePresentation\\.swift)$'
-readonly approved_post_v02_security_patch_tree_pattern=$'\t(\\.github/workflows/release\\.yml|CopyLasso/Services/VisionOCRService\\.swift|CopyLassoTests/Services/VisionOCRServiceTests\\.swift|CopyLassoUITests/CopyLassoUITests\\.swift|scripts/audit-privacy-security\\.sh|scripts/audit-release-workflow\\.sh|scripts/audit-v02-release-qualification\\.sh|scripts/ci\\.sh|scripts/create-draft-release\\.sh|scripts/lib/release-package-verification\\.sh|scripts/lib/release-workflow-verification\\.sh|scripts/test-release-package\\.sh|scripts/test-release-workflow\\.sh)$'
+readonly approved_post_v02_security_patch_tree_pattern=$'\t(\\.github/workflows/ci\\.yml|\\.github/workflows/release\\.yml|CopyLasso/Services/VisionOCRService\\.swift|CopyLassoTests/Services/VisionOCRServiceTests\\.swift|CopyLassoUITests/CopyLassoUITests\\.swift|scripts/audit-privacy-security\\.sh|scripts/audit-release-workflow\\.sh|scripts/audit-v02-release-qualification\\.sh|scripts/ci\\.sh|scripts/create-draft-release\\.sh|scripts/lib/release-package-verification\\.sh|scripts/lib/release-workflow-verification\\.sh|scripts/test-release-package\\.sh|scripts/test-release-workflow\\.sh)$'
 readonly g44_release_state_tree_pattern=$'\t(CHANGELOG\\.md|CONTRIBUTING\\.md|PRIVACY\\.md|README\\.md|SECURITY\\.md|docs/architecture/overview\\.md|docs/release-checklist\\.md|docs/release-workflow\\.md|docs/secure-update-operations\\.md|docs/security-and-privacy-review\\.md|docs/testing\\.md|docs/v0\\.2-product-contract\\.md|docs/v0\\.2-release-state\\.md|scripts/audit-brand-release\\.sh|scripts/audit-code-recognition\\.sh|scripts/audit-secure-update-architecture\\.sh|scripts/audit-v02-contract\\.sh|scripts/audit-v02-publication\\.sh|scripts/audit-v02-release-qualification\\.sh|scripts/audit-v02-release-state\\.sh|scripts/ci\\.sh|scripts/test-ci-contract\\.sh|scripts/test-release-metadata\\.sh)$'
-readonly expected_candidate_baseline_tree_digest='d7ffab8e04dee244d3dd0edb9f9b65402181f73f09a2255b4a2d3a153b833dfc'
+readonly expected_candidate_baseline_tree_digest='ecbcf39d0cac2b1525e46dc154123eb5418db3a9e790770a36a281b5160775bf'
 readonly expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'
 readonly expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'
-readonly expected_approved_post_candidate_patch_digest='bfa22b32e8a1a1ebe5f9dba00ffbf54d176d7e1db6074114844aacc078fd52c9'
+readonly expected_approved_post_candidate_patch_digest='1511b020ef05d49db5ae9e3ae6fcb11bb2e6a6f8f6a8090d76e2c7a41addd54b'
 
 fail() {
     echo "$1" >&2
@@ -162,51 +162,52 @@ require_text CopyLasso/Services/SparkleUpdateService.swift 'import Sparkle'
 require_text Configuration/CopyLasso-Info.plist \
     '<string>https://updates.copylasso.com/appcast.xml</string>'
 
-if git -C "$repository_root" cat-file -e "$candidate_source_commit^{tree}" 2>/dev/null; then
-    while IFS= read -r approved_path; do
-        approved_post_candidate_path "$approved_path" || \
-            fail "An unapproved path differs from the qualified v0.2 candidate: $approved_path"
-    done < <(git -C "$repository_root" diff --name-only \
-        "$candidate_source_commit")
+git -C "$repository_root" cat-file -e "$candidate_source_commit^{tree}" 2>/dev/null || \
+    fail "The qualified candidate commit is unavailable. Fetch full history before qualification."
 
-    approved_post_candidate_patch_digest="$(
-        git -C "$repository_root" diff \
-            --binary \
-            --full-index \
-            --no-ext-diff \
-            --no-textconv \
-            "$candidate_source_commit" \
-            -- . \
-            ':(exclude)scripts/audit-v02-release-qualification.sh' \
-            ':(exclude)scripts/test-ci-contract.sh' | \
-            /usr/bin/shasum -a 256 | \
-            /usr/bin/awk '{print $1}'
-    )"
-    [[ "$approved_post_candidate_patch_digest" == \
-        "$expected_approved_post_candidate_patch_digest" ]] || \
-        fail "The approved post-candidate patch differs from its reviewed digest."
+while IFS= read -r approved_path; do
+    approved_post_candidate_path "$approved_path" || \
+        fail "An unapproved path differs from the qualified v0.2 candidate: $approved_path"
+done < <(git -C "$repository_root" diff --name-only \
+    "$candidate_source_commit")
 
-    qualified_candidate_input_tree_digest="$(
-        git -C "$repository_root" ls-tree -r --full-tree "$candidate_source_commit" |
-            /usr/bin/grep -Ev "$candidate_evidence_tree_pattern" |
-            /usr/bin/shasum -a 256 |
-            /usr/bin/awk '{print $1}'
-    )"
-    [[ "$qualified_candidate_input_tree_digest" == "$expected_candidate_input_tree_digest" ]] || \
-        fail "The qualified candidate input tree no longer matches its reviewed digest."
+approved_post_candidate_patch_digest="$(
+    git -C "$repository_root" diff \
+        --binary \
+        --full-index \
+        --no-ext-diff \
+        --no-textconv \
+        "$candidate_source_commit" \
+        -- . \
+        ':(exclude)scripts/audit-v02-release-qualification.sh' \
+        ':(exclude)scripts/test-ci-contract.sh' | \
+        /usr/bin/shasum -a 256 | \
+        /usr/bin/awk '{print $1}'
+)"
+[[ "$approved_post_candidate_patch_digest" == \
+    "$expected_approved_post_candidate_patch_digest" ]] || \
+    fail "The approved post-candidate patch differs from its reviewed digest."
 
-    candidate_baseline_tree_digest="$(
-        git -C "$repository_root" ls-tree -r --full-tree "$candidate_source_commit" |
-            /usr/bin/grep -Ev "$candidate_evidence_tree_pattern" |
-            /usr/bin/grep -Ev "$approved_post_publication_patch_tree_pattern" |
-            /usr/bin/grep -Ev "$approved_post_v02_security_patch_tree_pattern" |
-            /usr/bin/grep -Ev "$g44_release_state_tree_pattern" |
-            /usr/bin/shasum -a 256 |
-            /usr/bin/awk '{print $1}'
-    )"
-    [[ "$candidate_baseline_tree_digest" == "$expected_candidate_baseline_tree_digest" ]] || \
-        fail "The frozen candidate baseline no longer matches its reviewed digest."
-fi
+qualified_candidate_input_tree_digest="$(
+    git -C "$repository_root" ls-tree -r --full-tree "$candidate_source_commit" |
+        /usr/bin/grep -Ev "$candidate_evidence_tree_pattern" |
+        /usr/bin/shasum -a 256 |
+        /usr/bin/awk '{print $1}'
+)"
+[[ "$qualified_candidate_input_tree_digest" == "$expected_candidate_input_tree_digest" ]] || \
+    fail "The qualified candidate input tree no longer matches its reviewed digest."
+
+candidate_baseline_tree_digest="$(
+    git -C "$repository_root" ls-tree -r --full-tree "$candidate_source_commit" |
+        /usr/bin/grep -Ev "$candidate_evidence_tree_pattern" |
+        /usr/bin/grep -Ev "$approved_post_publication_patch_tree_pattern" |
+        /usr/bin/grep -Ev "$approved_post_v02_security_patch_tree_pattern" |
+        /usr/bin/grep -Ev "$g44_release_state_tree_pattern" |
+        /usr/bin/shasum -a 256 |
+        /usr/bin/awk '{print $1}'
+)"
+[[ "$candidate_baseline_tree_digest" == "$expected_candidate_baseline_tree_digest" ]] || \
+    fail "The frozen candidate baseline no longer matches its reviewed digest."
 
 current_baseline_tree_digest="$(
     git -C "$repository_root" ls-tree -r --full-tree HEAD |

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -21,7 +21,7 @@ readonly g44_release_state_tree_pattern=$'\t(CHANGELOG\\.md|CONTRIBUTING\\.md|PR
 readonly expected_candidate_baseline_tree_digest='d7ffab8e04dee244d3dd0edb9f9b65402181f73f09a2255b4a2d3a153b833dfc'
 readonly expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'
 readonly expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'
-readonly expected_approved_post_candidate_patch_digest='bfa22b32e8a1a1ebe5f9dba00ffbf54d176d7e1db6074114844aacc078fd52c9'
+readonly expected_approved_post_candidate_patch_digest='c992b7a313a540069c272c30d2bc49952692dcabd1e67fd3730bd363e2deb4c8'
 
 fail() {
     echo "$1" >&2

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -20,7 +20,8 @@ readonly approved_post_v02_security_patch_tree_pattern=$'\t(\\.github/workflows/
 readonly g44_release_state_tree_pattern=$'\t(CHANGELOG\\.md|CONTRIBUTING\\.md|PRIVACY\\.md|README\\.md|SECURITY\\.md|docs/architecture/overview\\.md|docs/release-checklist\\.md|docs/release-workflow\\.md|docs/secure-update-operations\\.md|docs/security-and-privacy-review\\.md|docs/testing\\.md|docs/v0\\.2-product-contract\\.md|docs/v0\\.2-release-state\\.md|scripts/audit-brand-release\\.sh|scripts/audit-code-recognition\\.sh|scripts/audit-secure-update-architecture\\.sh|scripts/audit-v02-contract\\.sh|scripts/audit-v02-publication\\.sh|scripts/audit-v02-release-qualification\\.sh|scripts/audit-v02-release-state\\.sh|scripts/ci\\.sh|scripts/test-ci-contract\\.sh|scripts/test-release-metadata\\.sh)$'
 readonly expected_candidate_baseline_tree_digest='d7ffab8e04dee244d3dd0edb9f9b65402181f73f09a2255b4a2d3a153b833dfc'
 readonly expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'
-readonly expected_g44_release_state_files_digest='2a2f33d546587b081b1571a5beabe1772125ccf3550eab67c96279455856acb9'
+readonly expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'
+readonly expected_approved_post_candidate_patch_digest='bfa22b32e8a1a1ebe5f9dba00ffbf54d176d7e1db6074114844aacc078fd52c9'
 
 fail() {
     echo "$1" >&2
@@ -37,6 +38,20 @@ require_text() {
 
     /usr/bin/grep -Fq -- "$required_text" "$repository_root/$relative_path" || \
         fail "$relative_path is missing required v0.2 qualification text: $required_text"
+}
+
+approved_post_candidate_path() {
+    local relative_path="$1"
+    local tree_line=$'\t'"$relative_path"
+
+    printf '%s\n' "$tree_line" | \
+        /usr/bin/grep -Eq "$candidate_evidence_tree_pattern" || \
+        printf '%s\n' "$tree_line" | \
+            /usr/bin/grep -Eq "$approved_post_publication_patch_tree_pattern" || \
+        printf '%s\n' "$tree_line" | \
+            /usr/bin/grep -Eq "$approved_post_v02_security_patch_tree_pattern" || \
+        printf '%s\n' "$tree_line" | \
+            /usr/bin/grep -Eq "$g44_release_state_tree_pattern"
 }
 
 for required_file in \
@@ -148,6 +163,29 @@ require_text Configuration/CopyLasso-Info.plist \
     '<string>https://updates.copylasso.com/appcast.xml</string>'
 
 if git -C "$repository_root" cat-file -e "$candidate_source_commit^{tree}" 2>/dev/null; then
+    while IFS= read -r approved_path; do
+        approved_post_candidate_path "$approved_path" || \
+            fail "An unapproved path differs from the qualified v0.2 candidate: $approved_path"
+    done < <(git -C "$repository_root" diff --name-only \
+        "$candidate_source_commit")
+
+    approved_post_candidate_patch_digest="$(
+        git -C "$repository_root" diff \
+            --binary \
+            --full-index \
+            --no-ext-diff \
+            --no-textconv \
+            "$candidate_source_commit" \
+            -- . \
+            ':(exclude)scripts/audit-v02-release-qualification.sh' \
+            ':(exclude)scripts/test-ci-contract.sh' | \
+            /usr/bin/shasum -a 256 | \
+            /usr/bin/awk '{print $1}'
+    )"
+    [[ "$approved_post_candidate_patch_digest" == \
+        "$expected_approved_post_candidate_patch_digest" ]] || \
+        fail "The approved post-candidate patch differs from its reviewed digest."
+
     qualified_candidate_input_tree_digest="$(
         git -C "$repository_root" ls-tree -r --full-tree "$candidate_source_commit" |
             /usr/bin/grep -Ev "$candidate_evidence_tree_pattern" |
@@ -200,7 +238,6 @@ readonly g44_release_state_files=(
     SECURITY.md
     docs/architecture/overview.md
     docs/release-checklist.md
-    docs/release-workflow.md
     docs/secure-update-operations.md
     docs/security-and-privacy-review.md
     docs/testing.md
@@ -291,7 +328,7 @@ for prohibited_pattern in \
 done
 
 require_text .github/workflows/release.yml \
-    'leave blank only for a private G42 rehearsal'
+    'Omit candidate_number only for a private G42 rehearsal.'
 require_text .github/workflows/release.yml 'release_goal=G42'
 require_text .github/workflows/release.yml 'release_subdirectory=g42'
 require_text .github/workflows/release.yml \

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -21,7 +21,7 @@ readonly g44_release_state_tree_pattern=$'\t(CHANGELOG\\.md|CONTRIBUTING\\.md|PR
 readonly expected_candidate_baseline_tree_digest='ecbcf39d0cac2b1525e46dc154123eb5418db3a9e790770a36a281b5160775bf'
 readonly expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'
 readonly expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'
-readonly expected_approved_post_candidate_patch_digest='1511b020ef05d49db5ae9e3ae6fcb11bb2e6a6f8f6a8090d76e2c7a41addd54b'
+readonly expected_approved_post_candidate_patch_digest='6a7930d0b4b5205e81ad4c61e444dd13238a07e4d91dcfde26b66cefd50e60c6'
 
 fail() {
     echo "$1" >&2
@@ -172,15 +172,37 @@ done < <(git -C "$repository_root" diff --name-only \
     "$candidate_source_commit")
 
 approved_post_candidate_patch_digest="$(
-    git -C "$repository_root" diff \
-        --binary \
-        --full-index \
-        --no-ext-diff \
-        --no-textconv \
-        "$candidate_source_commit" \
-        -- . \
-        ':(exclude)scripts/audit-v02-release-qualification.sh' \
-        ':(exclude)scripts/test-ci-contract.sh' | \
+    while IFS= read -r approved_path; do
+        if [[ ! -e "$repository_root/$approved_path" && \
+            ! -L "$repository_root/$approved_path" ]]; then
+            printf 'deleted\t%s\n' "$approved_path"
+            continue
+        fi
+        approved_mode="$(
+            git -C "$repository_root" ls-files -s -- "$approved_path" | \
+                /usr/bin/awk 'NR == 1 {print $1}'
+        )"
+        if [[ "$approved_path" == \
+            "scripts/audit-v02-release-qualification.sh" || \
+            "$approved_path" == "scripts/test-ci-contract.sh" ]]; then
+            approved_digest="$(
+                /usr/bin/sed -E \
+                    's/(expected_approved_post_candidate_patch_digest[^0-9a-f]*)[0-9a-f]{64}/\1<self-normalized>/g' \
+                    "$repository_root/$approved_path" | \
+                    /usr/bin/shasum -a 256 | \
+                    /usr/bin/awk '{print $1}'
+            )"
+        else
+            approved_digest="$(
+                git -C "$repository_root" hash-object -- "$approved_path"
+            )"
+        fi
+        printf '%s\t%s\t%s\n' \
+            "$approved_mode" "$approved_digest" "$approved_path"
+    done < <(
+        git -C "$repository_root" diff --name-only "$candidate_source_commit" | \
+            LC_ALL=C /usr/bin/sort
+    ) | \
         /usr/bin/shasum -a 256 | \
         /usr/bin/awk '{print $1}'
 )"

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -21,7 +21,7 @@ readonly g44_release_state_tree_pattern=$'\t(CHANGELOG\\.md|CONTRIBUTING\\.md|PR
 readonly expected_candidate_baseline_tree_digest='d7ffab8e04dee244d3dd0edb9f9b65402181f73f09a2255b4a2d3a153b833dfc'
 readonly expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'
 readonly expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'
-readonly expected_approved_post_candidate_patch_digest='c992b7a313a540069c272c30d2bc49952692dcabd1e67fd3730bd363e2deb4c8'
+readonly expected_approved_post_candidate_patch_digest='19d862803b654bf53fa663faa492232cf5f0ed3e12577430ce71c347f846f713'
 
 fail() {
     echo "$1" >&2

--- a/scripts/create-draft-release.sh
+++ b/scripts/create-draft-release.sh
@@ -170,6 +170,12 @@ fi
 release_identifier="$(/usr/bin/plutil -extract id raw -o - "$creation_record" 2>/dev/null || true)"
 [[ "$release_identifier" =~ ^[0-9]+$ ]] || \
     protected_release_fail "The protected draft release has no valid identifier."
+if [[ "$release_mode" == "candidate" ]]; then
+    # GitHub creates a missing tag_name at release creation time using
+    # target_commitish. Treat that tag as part of the candidate transaction so
+    # rollback removes an unqualified RC tag if later verification fails.
+    candidate_tag_created="true"
+fi
 
 if ! "$gh_binary" release upload "$tag" \
     "$run_directory/$COPYLASSO_G28_DMG" \

--- a/scripts/create-draft-release.sh
+++ b/scripts/create-draft-release.sh
@@ -96,16 +96,16 @@ candidate_tag_created="false"
 draft_committed="false"
 
 rollback_draft() {
-    if [[ "$candidate_tag_created" == "true" && "$draft_committed" != "true" ]]; then
-        "$gh_binary" api \
-            --method DELETE \
-            "repos/$repository/git/refs/tags/$tag" \
-            >/dev/null 2>&1 || true
-    fi
     if [[ -n "$release_identifier" && "$draft_committed" != "true" ]]; then
         "$gh_binary" api \
             --method DELETE \
             "repos/$repository/releases/$release_identifier" \
+            >/dev/null 2>&1 || true
+    fi
+    if [[ "$candidate_tag_created" == "true" && "$draft_committed" != "true" ]]; then
+        "$gh_binary" api \
+            --method DELETE \
+            "repos/$repository/git/refs/tags/$tag" \
             >/dev/null 2>&1 || true
     fi
     /bin/rm -rf "$temporary_directory"
@@ -154,6 +154,26 @@ else
 fi
 readonly release_name
 
+if [[ "$release_mode" == "candidate" ]]; then
+    if "$gh_binary" api \
+        --method POST \
+        "repos/$repository/git/refs" \
+        -f "ref=refs/tags/$tag" \
+        -f "sha=$commit" \
+        > "$candidate_tag_record"; then
+        candidate_tag_created="true"
+        assert_release_candidate_tag_record "$candidate_tag_record" "$commit" "$tag"
+    else
+        if "$gh_binary" api \
+            "repos/$repository/git/ref/tags/$tag" > "$candidate_tag_record"; then
+            protected_release_fail \
+                "The release-candidate tag creation outcome is ambiguous; the existing tag was retained for manual inspection."
+        fi
+        protected_release_fail \
+            "The release-candidate transaction could not create its immutable tag."
+    fi
+fi
+
 if ! "$gh_binary" api \
     --method POST \
     "repos/$repository/releases" \
@@ -170,12 +190,6 @@ fi
 release_identifier="$(/usr/bin/plutil -extract id raw -o - "$creation_record" 2>/dev/null || true)"
 [[ "$release_identifier" =~ ^[0-9]+$ ]] || \
     protected_release_fail "The protected draft release has no valid identifier."
-if [[ "$release_mode" == "candidate" ]]; then
-    # GitHub creates a missing tag_name at release creation time using
-    # target_commitish. Treat that tag as part of the candidate transaction so
-    # rollback removes an unqualified RC tag if later verification fails.
-    candidate_tag_created="true"
-fi
 
 if ! "$gh_binary" release upload "$tag" \
     "$run_directory/$COPYLASSO_G28_DMG" \
@@ -199,20 +213,6 @@ if [[ "$release_mode" == "candidate" ]]; then
         "$candidate_number" \
         "$run_directory" \
         "$reviewed_candidate_notes"
-    if ! "$gh_binary" api \
-        --method POST \
-        "repos/$repository/git/refs" \
-        -f "ref=refs/tags/$tag" \
-        -f "sha=$commit" \
-        >/dev/null; then
-        if ! "$gh_binary" api \
-            "repos/$repository/git/ref/tags/$tag" > "$candidate_tag_record"; then
-            protected_release_fail \
-                "The release-candidate transaction could not create its immutable tag."
-        fi
-        assert_release_candidate_tag_record "$candidate_tag_record" "$commit" "$tag"
-    fi
-    candidate_tag_created="true"
     if ! "$gh_binary" api \
         "repos/$repository/git/ref/tags/$tag" > "$candidate_tag_record"; then
         protected_release_fail "The release-candidate transaction could not read back its tag."

--- a/scripts/create-draft-release.sh
+++ b/scripts/create-draft-release.sh
@@ -185,6 +185,11 @@ if ! "$gh_binary" api \
     -f make_latest=false \
     -F "body=@$notes" \
     > "$creation_record"; then
+    if [[ "$release_mode" == "candidate" ]]; then
+        candidate_tag_created="false"
+        protected_release_fail \
+            "The release-candidate release creation outcome is ambiguous; its tag was retained for manual inspection."
+    fi
     protected_release_fail "The protected draft release could not be created."
 fi
 release_identifier="$(/usr/bin/plutil -extract id raw -o - "$creation_record" 2>/dev/null || true)"

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -259,7 +259,7 @@ assert_release_evidence_is_portable() {
     [[ -f "$evidence_record_path" ]] || \
         release_package_fail "The release evidence record is missing."
     if /usr/bin/grep -Eq \
-        '(^|[=[:space:]"])/|:/[^/]|[Ff][Ii][Ll][Ee]:/+' \
+        "(^|[=[:space:]\"'])/|:/[^/]|[Ff][Ii][Ll][Ee]:/+" \
         "$evidence_record_path"; then
         release_package_fail "The release evidence must not contain local absolute paths."
     fi

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -255,7 +255,7 @@ assert_release_evidence_is_portable() {
 
     [[ -f "$evidence_record_path" ]] || \
         release_package_fail "The release evidence record is missing."
-    if /usr/bin/grep -Eq '^[^=]+=/.*$' "$evidence_record_path"; then
+    if /usr/bin/grep -Eq '=/' "$evidence_record_path"; then
         release_package_fail "The release evidence must not contain local absolute paths."
     fi
 }

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -196,7 +196,6 @@ assert_release_notary_records() {
     local log_status
     local observed_submission_identifier
     local log_identifier
-    local issues
 
     [[ -f "$submission_record_path" && -f "$diagnostic_log_path" ]] || \
         release_package_fail "The notarization submission record or diagnostic log is missing."
@@ -211,8 +210,14 @@ assert_release_notary_records() {
         [[ "$observed_submission_identifier" != "$log_identifier" ]]; then
         release_package_fail "The notarization submission and diagnostic log do not match."
     fi
-    issues="$(/usr/bin/plutil -extract issues json -o - "$diagnostic_log_path" 2>/dev/null || true)"
-    if [[ "$issues" != "[]" ]] && [[ "$issues" != "null" ]]; then
+    if ! /usr/bin/jq -e '
+        type == "object" and
+        has("issues") and
+        (
+            .issues == null or
+            ((.issues | type) == "array" and (.issues | length) == 0)
+        )
+    ' "$diagnostic_log_path" >/dev/null 2>&1; then
         release_package_fail "The accepted notarization diagnostic log contains issues."
     fi
 }

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -259,7 +259,7 @@ assert_release_evidence_is_portable() {
     [[ -f "$evidence_record_path" ]] || \
         release_package_fail "The release evidence record is missing."
     if /usr/bin/grep -Eq \
-        "(^|[=[:space:]\"'])/|:/[^/]|[Ff][Ii][Ll][Ee]:/+" \
+        "(^|[=,;|[:space:]\"'(){}<>])/|\[/|\]/|:/[^/]|[Ff][Ii][Ll][Ee]:/+" \
         "$evidence_record_path"; then
         release_package_fail "The release evidence must not contain local absolute paths."
     fi

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -258,7 +258,7 @@ assert_release_evidence_is_portable() {
 
     [[ -f "$evidence_record_path" ]] || \
         release_package_fail "The release evidence record is missing."
-    if /usr/bin/grep -Eq '=/' "$evidence_record_path"; then
+    if /usr/bin/grep -Eq '(^|[=[:space:]"])/' "$evidence_record_path"; then
         release_package_fail "The release evidence must not contain local absolute paths."
     fi
 }

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -212,9 +212,7 @@ assert_release_notary_records() {
         release_package_fail "The notarization submission and diagnostic log do not match."
     fi
     issues="$(/usr/bin/plutil -extract issues json -o - "$diagnostic_log_path" 2>/dev/null || true)"
-    if [[ "$issues" != "[]" ]] && \
-        ! /usr/bin/grep -Eq '"issues"[[:space:]]*:[[:space:]]*null([[:space:]]*[,}]|[[:space:]]*$)' \
-            "$diagnostic_log_path"; then
+    if [[ "$issues" != "[]" ]] && [[ "$issues" != "null" ]]; then
         release_package_fail "The accepted notarization diagnostic log contains issues."
     fi
 }

--- a/scripts/lib/release-workflow-verification.sh
+++ b/scripts/lib/release-workflow-verification.sh
@@ -61,10 +61,73 @@ release_workflow_job_if_values() {
     ' "$workflow_file"
 }
 
+release_workflow_trigger_names() {
+    local workflow_file="$1"
+
+    /usr/bin/awk '
+        /^on:[[:space:]]*$/ {
+            in_triggers = 1
+            next
+        }
+        in_triggers && /^[^[:space:]#]/ {
+            in_triggers = 0
+        }
+        in_triggers && /^  [A-Za-z0-9_-]+:[[:space:]]*/ {
+            trigger = $0
+            sub(/^  /, "", trigger)
+            sub(/:.*/, "", trigger)
+            print trigger
+        }
+    ' "$workflow_file"
+}
+
+release_workflow_repository_dispatch_types() {
+    local workflow_file="$1"
+
+    /usr/bin/awk '
+        /^on:[[:space:]]*$/ {
+            in_triggers = 1
+            next
+        }
+        in_triggers && /^[^[:space:]#]/ {
+            in_triggers = 0
+            in_repository_dispatch = 0
+        }
+        in_triggers && /^  [A-Za-z0-9_-]+:[[:space:]]*/ {
+            trigger = $0
+            sub(/^  /, "", trigger)
+            sub(/:.*/, "", trigger)
+            in_repository_dispatch = trigger == "repository_dispatch"
+            next
+        }
+        in_repository_dispatch && /^    types:[[:space:]]*/ {
+            value = $0
+            sub(/^    types:[[:space:]]*/, "", value)
+            sub(/[[:space:]]*$/, "", value)
+            print value
+        }
+    ' "$workflow_file"
+}
+
+assert_release_workflow_trusted_dispatch() {
+    local workflow_file="$1"
+    local trigger_names
+    local dispatch_types
+
+    [[ -f "$workflow_file" ]] || \
+        protected_release_fail "The protected release workflow is missing."
+    trigger_names="$(release_workflow_trigger_names "$workflow_file")"
+    dispatch_types="$(release_workflow_repository_dispatch_types "$workflow_file")"
+    [[ "$trigger_names" == "repository_dispatch" && \
+        "$dispatch_types" == "[copylasso_protected_release]" ]] || \
+        protected_release_fail \
+            "The protected release workflow must use only the trusted default-branch repository dispatch event."
+}
+
 assert_release_workflow_job_guard() {
     local workflow_file="$1"
     local target_job="$2"
-    local expected_guard="\${{ github.ref == 'refs/heads/main' }}"
+    local expected_guard="\${{ github.event_name == 'repository_dispatch' && github.event.action == 'copylasso_protected_release' && github.ref == 'refs/heads/main' }}"
     local actual_guards
     local guard_count
 

--- a/scripts/lib/release-workflow-verification.sh
+++ b/scripts/lib/release-workflow-verification.sh
@@ -32,6 +32,52 @@ assert_protected_release_ref() {
         protected_release_fail "Protected releases may be dispatched only from protected main."
 }
 
+release_workflow_job_if_values() {
+    local workflow_file="$1"
+    local target_job="$2"
+
+    /usr/bin/awk -v target_job="$target_job" '
+        /^jobs:[[:space:]]*$/ {
+            in_jobs = 1
+            current_job = ""
+            next
+        }
+        in_jobs && /^[^[:space:]#]/ {
+            in_jobs = 0
+            current_job = ""
+        }
+        in_jobs && /^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$/ {
+            current_job = $0
+            sub(/^  /, "", current_job)
+            sub(/:.*/, "", current_job)
+            next
+        }
+        in_jobs && current_job == target_job && /^    if:[[:space:]]*/ {
+            value = $0
+            sub(/^    if:[[:space:]]*/, "", value)
+            sub(/[[:space:]]*$/, "", value)
+            print value
+        }
+    ' "$workflow_file"
+}
+
+assert_release_workflow_job_guard() {
+    local workflow_file="$1"
+    local target_job="$2"
+    local expected_guard="\${{ github.ref == 'refs/heads/main' }}"
+    local actual_guards
+    local guard_count
+
+    [[ -f "$workflow_file" ]] || \
+        protected_release_fail "The protected release workflow is missing."
+    actual_guards="$(release_workflow_job_if_values "$workflow_file" "$target_job")"
+    guard_count="$(printf '%s\n' "$actual_guards" | \
+        /usr/bin/awk 'NF { count += 1 } END { print count + 0 }')"
+    [[ "$guard_count" == "1" && "$actual_guards" == "$expected_guard" ]] || \
+        protected_release_fail \
+            "Release job $target_job must run only for refs/heads/main."
+}
+
 assert_release_source_state() {
     local g28_repository="$1"
     local g28_git_ref="$2"

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -157,12 +157,14 @@ fi
 for required_patch_guard in \
     "approved_post_publication_patch_tree_pattern" \
     "approved_post_publication_runtime_tree_pattern" \
+    "approved_post_v02_security_patch_tree_pattern" \
     "g44_release_state_tree_pattern" \
-    "expected_candidate_baseline_tree_digest='e6358aa654914c17146018f5bb5bfdd7eb3f52d79d88358bf2b16a814ba21c7b'" \
-    "expected_approved_post_publication_runtime_tree_digest='6aa226944fafb8a45887db345b70afa94c2a2d2bc49b348350b153ce50095b7f'" \
-    "expected_g44_release_state_files_digest='2223f222a24e2c970d7123cc973c54eb1a91ead66373ef9da481e452c1c8e30e'" \
+    "expected_candidate_baseline_tree_digest='d7ffab8e04dee244d3dd0edb9f9b65402181f73f09a2255b4a2d3a153b833dfc'" \
+    "expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'" \
+    "expected_g44_release_state_files_digest='2a2f33d546587b081b1571a5beabe1772125ccf3550eab67c96279455856acb9'" \
     'cat-file -e "$candidate_source_commit^{tree}"' \
     '"$current_baseline_tree_digest" == "$expected_candidate_baseline_tree_digest"' \
+    '/usr/bin/grep -Ev "$approved_post_v02_security_patch_tree_pattern"' \
     '/usr/bin/grep -Ev "$g44_release_state_tree_pattern"' \
     'The approved G43A runtime patch differs from its reviewed tree digest.'; do
     if ! /usr/bin/grep -Fq "$required_patch_guard" \

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -172,7 +172,7 @@ for required_patch_guard in \
     "expected_candidate_baseline_tree_digest='d7ffab8e04dee244d3dd0edb9f9b65402181f73f09a2255b4a2d3a153b833dfc'" \
     "expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'" \
     "expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'" \
-    "expected_approved_post_candidate_patch_digest='bfa22b32e8a1a1ebe5f9dba00ffbf54d176d7e1db6074114844aacc078fd52c9'" \
+    "expected_approved_post_candidate_patch_digest='c992b7a313a540069c272c30d2bc49952692dcabd1e67fd3730bd363e2deb4c8'" \
     'cat-file -e "$candidate_source_commit^{tree}"' \
     '"$current_baseline_tree_digest" == "$expected_candidate_baseline_tree_digest"' \
     'approved_post_candidate_path "$approved_path"' \

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -34,6 +34,18 @@ fail() {
     exit 1
 }
 
+checkout_count="$({
+    /usr/bin/grep -Ec \
+        '^[[:space:]]*uses:[[:space:]]+actions/checkout@' "$workflow" || true
+})"
+full_history_count="$({
+    /usr/bin/grep -Ec \
+        '^[[:space:]]*fetch-depth:[[:space:]]+0[[:space:]]*$' "$workflow" || true
+})"
+if [[ "$checkout_count" == "0" || "$full_history_count" != "$checkout_count" ]]; then
+    fail "Every canonical CI checkout must fetch full history for release qualification."
+fi
+
 for qualification_pin in \
     'approved_post_candidate_path' \
     'expected_approved_post_candidate_patch_digest' \
@@ -169,11 +181,12 @@ for required_patch_guard in \
     "approved_post_publication_runtime_tree_pattern" \
     "approved_post_v02_security_patch_tree_pattern" \
     "g44_release_state_tree_pattern" \
-    "expected_candidate_baseline_tree_digest='d7ffab8e04dee244d3dd0edb9f9b65402181f73f09a2255b4a2d3a153b833dfc'" \
+    "expected_candidate_baseline_tree_digest='ecbcf39d0cac2b1525e46dc154123eb5418db3a9e790770a36a281b5160775bf'" \
     "expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'" \
     "expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'" \
-    "expected_approved_post_candidate_patch_digest='bfa22b32e8a1a1ebe5f9dba00ffbf54d176d7e1db6074114844aacc078fd52c9'" \
+    "expected_approved_post_candidate_patch_digest='1511b020ef05d49db5ae9e3ae6fcb11bb2e6a6f8f6a8090d76e2c7a41addd54b'" \
     'cat-file -e "$candidate_source_commit^{tree}"' \
+    'The qualified candidate commit is unavailable.' \
     '"$current_baseline_tree_digest" == "$expected_candidate_baseline_tree_digest"' \
     'approved_post_candidate_path "$approved_path"' \
     'The approved post-candidate patch differs from its reviewed digest.' \

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -184,7 +184,7 @@ for required_patch_guard in \
     "expected_candidate_baseline_tree_digest='ecbcf39d0cac2b1525e46dc154123eb5418db3a9e790770a36a281b5160775bf'" \
     "expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'" \
     "expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'" \
-    "expected_approved_post_candidate_patch_digest='3d69bb84129948dcabfd3783d05e4e967abdd8c65dbe8665dfdfdc5eddbf664a'" \
+    "expected_approved_post_candidate_patch_digest='724128130010f3012c1b2466337b35c01f8d3ddd220b7e883a7bc4d61dcc2b22'" \
     'cat-file -e "$candidate_source_commit^{tree}"' \
     'The qualified candidate commit is unavailable.' \
     '"$current_baseline_tree_digest" == "$expected_candidate_baseline_tree_digest"' \

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -184,7 +184,7 @@ for required_patch_guard in \
     "expected_candidate_baseline_tree_digest='ecbcf39d0cac2b1525e46dc154123eb5418db3a9e790770a36a281b5160775bf'" \
     "expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'" \
     "expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'" \
-    "expected_approved_post_candidate_patch_digest='724128130010f3012c1b2466337b35c01f8d3ddd220b7e883a7bc4d61dcc2b22'" \
+    "expected_approved_post_candidate_patch_digest='e019c0ba95e76220632aa04efa6af8d335ff37a56e7c561b36c734e6e08646ea'" \
     'cat-file -e "$candidate_source_commit^{tree}"' \
     'The qualified candidate commit is unavailable.' \
     '"$current_baseline_tree_digest" == "$expected_candidate_baseline_tree_digest"' \

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -172,7 +172,7 @@ for required_patch_guard in \
     "expected_candidate_baseline_tree_digest='d7ffab8e04dee244d3dd0edb9f9b65402181f73f09a2255b4a2d3a153b833dfc'" \
     "expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'" \
     "expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'" \
-    "expected_approved_post_candidate_patch_digest='c992b7a313a540069c272c30d2bc49952692dcabd1e67fd3730bd363e2deb4c8'" \
+    "expected_approved_post_candidate_patch_digest='19d862803b654bf53fa663faa492232cf5f0ed3e12577430ce71c347f846f713'" \
     'cat-file -e "$candidate_source_commit^{tree}"' \
     '"$current_baseline_tree_digest" == "$expected_candidate_baseline_tree_digest"' \
     'approved_post_candidate_path "$approved_path"' \

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -184,11 +184,14 @@ for required_patch_guard in \
     "expected_candidate_baseline_tree_digest='ecbcf39d0cac2b1525e46dc154123eb5418db3a9e790770a36a281b5160775bf'" \
     "expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'" \
     "expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'" \
-    "expected_approved_post_candidate_patch_digest='1511b020ef05d49db5ae9e3ae6fcb11bb2e6a6f8f6a8090d76e2c7a41addd54b'" \
+    "expected_approved_post_candidate_patch_digest='6a7930d0b4b5205e81ad4c61e444dd13238a07e4d91dcfde26b66cefd50e60c6'" \
     'cat-file -e "$candidate_source_commit^{tree}"' \
     'The qualified candidate commit is unavailable.' \
     '"$current_baseline_tree_digest" == "$expected_candidate_baseline_tree_digest"' \
     'approved_post_candidate_path "$approved_path"' \
+    'hash-object -- "$approved_path"' \
+    'expected_approved_post_candidate_patch_digest[^0-9a-f]*' \
+    '<self-normalized>' \
     'The approved post-candidate patch differs from its reviewed digest.' \
     '/usr/bin/grep -Ev "$approved_post_v02_security_patch_tree_pattern"' \
     '/usr/bin/grep -Ev "$g44_release_state_tree_pattern"' \
@@ -198,6 +201,15 @@ for required_patch_guard in \
         fail "The v0.2 qualification audit must pin the exact approved G43A patch."
     fi
 done
+
+if /usr/bin/grep -Fq \
+    ':(exclude)scripts/audit-v02-release-qualification.sh' \
+    "$v02_release_qualification_audit_script" || \
+    /usr/bin/grep -Fq \
+        ':(exclude)scripts/test-ci-contract.sh' \
+        "$v02_release_qualification_audit_script"; then
+    fail "The post-candidate digest must pin its own audit and contract scripts."
+fi
 
 v02_publication_test_invocations="$({
     /usr/bin/grep -Ec \

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -172,7 +172,7 @@ for required_patch_guard in \
     "expected_candidate_baseline_tree_digest='d7ffab8e04dee244d3dd0edb9f9b65402181f73f09a2255b4a2d3a153b833dfc'" \
     "expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'" \
     "expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'" \
-    "expected_approved_post_candidate_patch_digest='19d862803b654bf53fa663faa492232cf5f0ed3e12577430ce71c347f846f713'" \
+    "expected_approved_post_candidate_patch_digest='73d0f5c39d90862e6b0bbfd57ff265846d1babcb93abb3106cc7c046a1e5ac13'" \
     'cat-file -e "$candidate_source_commit^{tree}"' \
     '"$current_baseline_tree_digest" == "$expected_candidate_baseline_tree_digest"' \
     'approved_post_candidate_path "$approved_path"' \

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -34,6 +34,16 @@ fail() {
     exit 1
 }
 
+for qualification_pin in \
+    'approved_post_candidate_path' \
+    'expected_approved_post_candidate_patch_digest' \
+    'approved_post_candidate_patch_digest'; do
+    if ! /usr/bin/grep -Fq "$qualification_pin" \
+        "$v02_release_qualification_audit_script"; then
+        fail "The v0.2 qualification audit is missing post-candidate patch pinning: $qualification_pin"
+    fi
+done
+
 repeatability_invocations="$({
     /usr/bin/grep -Ec '^[[:space:]]*\./scripts/test-repeatability\.sh[[:space:]]*$' \
         "$ci_script" || true
@@ -161,9 +171,12 @@ for required_patch_guard in \
     "g44_release_state_tree_pattern" \
     "expected_candidate_baseline_tree_digest='d7ffab8e04dee244d3dd0edb9f9b65402181f73f09a2255b4a2d3a153b833dfc'" \
     "expected_approved_post_publication_runtime_tree_digest='388191bdbca550efa34ca64d9f8ebba3f127457313e4f0739d4601919fa9de7d'" \
-    "expected_g44_release_state_files_digest='2a2f33d546587b081b1571a5beabe1772125ccf3550eab67c96279455856acb9'" \
+    "expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'" \
+    "expected_approved_post_candidate_patch_digest='bfa22b32e8a1a1ebe5f9dba00ffbf54d176d7e1db6074114844aacc078fd52c9'" \
     'cat-file -e "$candidate_source_commit^{tree}"' \
     '"$current_baseline_tree_digest" == "$expected_candidate_baseline_tree_digest"' \
+    'approved_post_candidate_path "$approved_path"' \
+    'The approved post-candidate patch differs from its reviewed digest.' \
     '/usr/bin/grep -Ev "$approved_post_v02_security_patch_tree_pattern"' \
     '/usr/bin/grep -Ev "$g44_release_state_tree_pattern"' \
     'The approved G43A runtime patch differs from its reviewed tree digest.'; do

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -309,7 +309,7 @@ expect_failure "must not contain local absolute paths" \
 embedded_absolute_path_evidence="$temporary_directory/embedded-absolute-path-evidence.txt"
 cat > "$embedded_absolute_path_evidence" <<'TEXT'
 version=0.2.0
-build_log=output=/Users/alice/project
+build_log=output=/opt/copylasso/project
 TEXT
 expect_failure "must not contain local absolute paths" \
     assert_release_evidence_is_portable "$embedded_absolute_path_evidence"

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -244,6 +244,18 @@ JSON
 expect_failure "contains issues" assert_release_notary_records \
     "$valid_submission" "$temporary_directory/warning-log.json"
 
+nested_null_issues_log="$temporary_directory/nested-null-issues-log.json"
+cat > "$nested_null_issues_log" <<'JSON'
+{
+  "jobId": "00000000-0000-0000-0000-000000000000",
+  "status": "Accepted",
+  "issues": [{"severity":"warning"}],
+  "metadata": {"issues": null}
+}
+JSON
+expect_failure "contains issues" assert_release_notary_records \
+    "$valid_submission" "$nested_null_issues_log"
+
 valid_app_uuids="$temporary_directory/app-uuids.txt"
 valid_dsym_uuids="$temporary_directory/dsym-uuids.txt"
 cat > "$valid_app_uuids" <<'TEXT'

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -341,6 +341,20 @@ build_log=output:'/private/tmp/copylasso.log'
 TEXT
 expect_failure "must not contain local absolute paths" \
     assert_release_evidence_is_portable "$single_quoted_path_evidence"
+list_delimited_path_evidence="$temporary_directory/list-delimited-path-evidence.txt"
+cat > "$list_delimited_path_evidence" <<'TEXT'
+version=0.2.0
+build_logs=ci.log,/private/tmp/copylasso.log
+TEXT
+expect_failure "must not contain local absolute paths" \
+    assert_release_evidence_is_portable "$list_delimited_path_evidence"
+bracket_delimited_path_evidence="$temporary_directory/bracket-delimited-path-evidence.txt"
+cat > "$bracket_delimited_path_evidence" <<'TEXT'
+version=0.2.0
+outputs=[/private/tmp/CopyLasso.app]
+TEXT
+expect_failure "must not contain local absolute paths" \
+    assert_release_evidence_is_portable "$bracket_delimited_path_evidence"
 
 assert_release_commit_matches \
     "payload" \

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -256,6 +256,26 @@ JSON
 expect_failure "contains issues" assert_release_notary_records \
     "$valid_submission" "$nested_null_issues_log"
 
+cat > "$temporary_directory/missing-top-level-issues.json" <<'JSON'
+{
+  "jobId": "00000000-0000-0000-0000-000000000000",
+  "status": "Accepted",
+  "metadata": {"issues": null}
+}
+JSON
+expect_failure "contains issues" assert_release_notary_records \
+    "$valid_submission" "$temporary_directory/missing-top-level-issues.json"
+
+cat > "$temporary_directory/scalar-issues.json" <<'JSON'
+{
+  "jobId": "00000000-0000-0000-0000-000000000000",
+  "status": "Accepted",
+  "issues": "none"
+}
+JSON
+expect_failure "contains issues" assert_release_notary_records \
+    "$valid_submission" "$temporary_directory/scalar-issues.json"
+
 valid_app_uuids="$temporary_directory/app-uuids.txt"
 valid_dsym_uuids="$temporary_directory/dsym-uuids.txt"
 cat > "$valid_app_uuids" <<'TEXT'

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -334,6 +334,13 @@ source=file:///opt/copylasso/project
 TEXT
 expect_failure "must not contain local absolute paths" \
     assert_release_evidence_is_portable "$file_url_evidence"
+single_quoted_path_evidence="$temporary_directory/single-quoted-path-evidence.txt"
+cat > "$single_quoted_path_evidence" <<'TEXT'
+version=0.2.0
+build_log=output:'/private/tmp/copylasso.log'
+TEXT
+expect_failure "must not contain local absolute paths" \
+    assert_release_evidence_is_portable "$single_quoted_path_evidence"
 
 assert_release_commit_matches \
     "payload" \

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -273,6 +273,13 @@ local_artifact=/local/build/output
 TEXT
 expect_failure "must not contain local absolute paths" \
     assert_release_evidence_is_portable "$absolute_path_evidence"
+embedded_absolute_path_evidence="$temporary_directory/embedded-absolute-path-evidence.txt"
+cat > "$embedded_absolute_path_evidence" <<'TEXT'
+version=0.2.0
+build_log=output=/Users/alice/project
+TEXT
+expect_failure "must not contain local absolute paths" \
+    assert_release_evidence_is_portable "$embedded_absolute_path_evidence"
 
 assert_release_commit_matches \
     "payload" \

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -296,6 +296,7 @@ portable_evidence="$temporary_directory/portable-evidence.txt"
 cat > "$portable_evidence" <<'TEXT'
 version=0.2.0
 build=3
+source_url=https://github.com/bennetthilberg/copylasso
 TEXT
 assert_release_evidence_is_portable "$portable_evidence"
 absolute_path_evidence="$temporary_directory/absolute-path-evidence.txt"
@@ -312,6 +313,13 @@ build_log=output=/Users/alice/project
 TEXT
 expect_failure "must not contain local absolute paths" \
     assert_release_evidence_is_portable "$embedded_absolute_path_evidence"
+spaced_absolute_path_evidence="$temporary_directory/spaced-absolute-path-evidence.txt"
+cat > "$spaced_absolute_path_evidence" <<'TEXT'
+version=0.2.0
+build_log=output: /private/tmp/copylasso.log
+TEXT
+expect_failure "must not contain local absolute paths" \
+    assert_release_evidence_is_portable "$spaced_absolute_path_evidence"
 
 assert_release_commit_matches \
     "payload" \

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -67,6 +67,35 @@ expect_failure "only from protected main" \
     assert_protected_release_ref "refs/heads/feature"
 expect_failure "only from protected main" \
     assert_protected_release_ref "refs/tags/v0.2.0-rc.1"
+
+readonly guarded_workflow="$temporary_directory/guarded-release.yml"
+/bin/cp "$workflow" "$guarded_workflow"
+assert_release_workflow_job_guard "$guarded_workflow" "quality-gate"
+assert_release_workflow_job_guard "$guarded_workflow" "protected-release"
+
+/usr/bin/awk '
+    !removed && /^    if:.*refs\/heads\/main/ { removed = 1; next }
+    { print }
+' "$workflow" > "$temporary_directory/missing-quality-guard.yml"
+printf '%s\n' \
+    'decoy:' \
+    '    if: ${{ github.ref == '\''refs/heads/main'\'' }}' \
+    >> "$temporary_directory/missing-quality-guard.yml"
+expect_failure "quality-gate must run only for refs/heads/main" \
+    assert_release_workflow_job_guard \
+    "$temporary_directory/missing-quality-guard.yml" \
+    "quality-gate"
+
+/usr/bin/awk '
+    /^  protected-release:/ { protected_job = 1 }
+    protected_job && /^    if:.*refs\/heads\/main/ { next }
+    { print }
+' "$workflow" > "$temporary_directory/missing-protected-guard.yml"
+expect_failure "protected-release must run only for refs/heads/main" \
+    assert_release_workflow_job_guard \
+    "$temporary_directory/missing-protected-guard.yml" \
+    "protected-release"
+
 assert_full_release_commit "0123456789abcdef0123456789abcdef01234567"
 expect_failure "full lowercase Git object identifier" \
     assert_full_release_commit "0123456789abcdef"

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -400,9 +400,7 @@ if [[ "$1" == "api" && "$*" == *"--method POST"* && "$*" == *"git/refs"* ]]; the
     exit 0
 fi
 if [[ "$1" == "api" && "$*" == *"--method POST"* && "$*" == *"/releases"* ]]; then
-    if [[ "$*" == *"tag_name=v0.2.0-rc."* ]]; then
-        : > "$FAKE_GH_TAG_STATE"
-    fi
+    [[ "${FAKE_GH_MODE:-success}" != "release-create-fail" ]] || exit 1
     printf '{"id":123}\n'
     exit 0
 fi
@@ -472,9 +470,17 @@ assert_release_candidate_record \
     "$release_notes"
 [[ -f "$fake_gh_tag_state" ]] || fail "The verified RC transaction must create its tag."
 /usr/bin/grep -Fq -- '--method POST repos/owner/repository/git/refs' "$fake_gh_log" || \
-    fail "The verified RC transaction must prove its tag through the Git ref API."
+    fail "The verified RC transaction must create its tag through the Git ref API."
 /usr/bin/grep -Fq -- 'api repos/owner/repository/git/ref/tags/v0.2.0-rc.1' "$fake_gh_log" || \
-    fail "The verified RC transaction must accept GitHub's release-created exact tag."
+    fail "The verified RC transaction must read back its owned exact tag."
+tag_create_line="$(/usr/bin/grep -n -- '--method POST repos/owner/repository/git/refs' \
+    "$fake_gh_log" | /usr/bin/head -n 1 | /usr/bin/cut -d: -f1)"
+release_create_line="$(/usr/bin/grep -n -- '--method POST repos/owner/repository/releases' \
+    "$fake_gh_log" | /usr/bin/head -n 1 | /usr/bin/cut -d: -f1)"
+if [[ -z "$tag_create_line" || -z "$release_create_line" ]] || \
+    ((tag_create_line >= release_create_line)); then
+    fail "The RC transaction must prove tag ownership before creating its draft release."
+fi
 /usr/bin/grep -Fq -- \
     '--paginate --slurp repos/owner/repository/releases?per_page=100' \
     "$fake_gh_log" || fail "The verified RC transaction must inspect every existing release."
@@ -485,17 +491,52 @@ fi
 : > "$fake_gh_log"
 /bin/rm -f "$fake_gh_tag_state"
 export FAKE_GH_MODE="tag-create-uncertain"
-"$draft_creator" \
+expect_failure "tag creation outcome is ambiguous" \
+    "$draft_creator" \
     --repository owner/repository \
     --commit 0123456789abcdef0123456789abcdef01234567 \
     --candidate-number 1 \
     --run-dir "$release_run" \
     --readback "$temporary_directory/uncertain-tag-readback.json"
 [[ -f "$fake_gh_tag_state" ]] || \
-    fail "An ambiguously created exact tag must be retained after successful readback."
+    fail "An ambiguously created exact tag must be retained for manual inspection."
 if /usr/bin/grep -Fq -- '--method DELETE' "$fake_gh_log"; then
-    fail "An ambiguously created exact tag must complete without rollback."
+    fail "An ambiguously created tag must never be deleted without proof of ownership."
 fi
+if /usr/bin/grep -Fq -- '--method POST repos/owner/repository/releases' "$fake_gh_log"; then
+    fail "An ambiguous tag outcome must prevent draft-release creation."
+fi
+
+: > "$fake_gh_log"
+/bin/rm -f "$fake_gh_tag_state"
+export FAKE_GH_MODE="tag-create-fail"
+expect_failure "could not create its immutable tag" \
+    "$draft_creator" \
+    --repository owner/repository \
+    --commit 0123456789abcdef0123456789abcdef01234567 \
+    --candidate-number 1 \
+    --run-dir "$release_run" \
+    --readback "$temporary_directory/tag-create-fail.json"
+if /usr/bin/grep -Eq -- '--method (DELETE|POST) repos/owner/repository/releases' \
+    "$fake_gh_log"; then
+    fail "A failed tag creation must not mutate release state."
+fi
+
+: > "$fake_gh_log"
+/bin/rm -f "$fake_gh_tag_state"
+export FAKE_GH_MODE="release-create-fail"
+expect_failure "draft release could not be created" \
+    "$draft_creator" \
+    --repository owner/repository \
+    --commit 0123456789abcdef0123456789abcdef01234567 \
+    --candidate-number 1 \
+    --run-dir "$release_run" \
+    --readback "$temporary_directory/release-create-fail.json"
+/usr/bin/grep -Fq -- \
+    '--method DELETE repos/owner/repository/git/refs/tags/v0.2.0-rc.1' \
+    "$fake_gh_log" || fail "A failed release creation must delete its owned tag."
+[[ ! -f "$fake_gh_tag_state" ]] || \
+    fail "A failed release creation must not retain its owned candidate tag."
 
 : > "$fake_gh_log"
 /bin/rm -f "$fake_gh_tag_state"
@@ -570,7 +611,7 @@ for failure_mode in upload-fail tag-readback-fail; do
         "$fake_gh_log" || fail "A failed RC transaction must delete its incomplete draft."
     /usr/bin/grep -Fq -- \
         '--method DELETE repos/owner/repository/git/refs/tags/v0.2.0-rc.1' \
-        "$fake_gh_log" || fail "A failed RC transaction must delete its release-created tag."
+        "$fake_gh_log" || fail "A failed RC transaction must delete its owned tag."
     [[ ! -f "$fake_gh_tag_state" ]] || \
         fail "A failed RC transaction must not retain a tag created by that invocation."
 done

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -364,12 +364,16 @@ if [[ "$1" == "api" && "$*" == *"git/ref/tags/"* ]]; then
 fi
 if [[ "$1" == "api" && "$*" == *"--method POST"* && "$*" == *"git/refs"* ]]; then
     [[ "${FAKE_GH_MODE:-success}" != "tag-create-fail" ]] || exit 1
+    [[ ! -f "$FAKE_GH_TAG_STATE" ]] || exit 1
     : > "$FAKE_GH_TAG_STATE"
     [[ "${FAKE_GH_MODE:-success}" != "tag-create-uncertain" ]] || exit 1
     /bin/cat "$FAKE_GH_TAG_RECORD"
     exit 0
 fi
 if [[ "$1" == "api" && "$*" == *"--method POST"* && "$*" == *"/releases"* ]]; then
+    if [[ "$*" == *"tag_name=v0.2.0-rc."* ]]; then
+        : > "$FAKE_GH_TAG_STATE"
+    fi
     printf '{"id":123}\n'
     exit 0
 fi
@@ -439,7 +443,9 @@ assert_release_candidate_record \
     "$release_notes"
 [[ -f "$fake_gh_tag_state" ]] || fail "The verified RC transaction must create its tag."
 /usr/bin/grep -Fq -- '--method POST repos/owner/repository/git/refs' "$fake_gh_log" || \
-    fail "The verified RC transaction must create its tag through the Git ref API."
+    fail "The verified RC transaction must prove its tag through the Git ref API."
+/usr/bin/grep -Fq -- 'api repos/owner/repository/git/ref/tags/v0.2.0-rc.1' "$fake_gh_log" || \
+    fail "The verified RC transaction must accept GitHub's release-created exact tag."
 /usr/bin/grep -Fq -- \
     '--paginate --slurp repos/owner/repository/releases?per_page=100' \
     "$fake_gh_log" || fail "The verified RC transaction must inspect every existing release."
@@ -520,7 +526,7 @@ if /usr/bin/grep -Fq -- '--method POST' "$fake_gh_log"; then
     fail "A pre-existing tag must prevent every RC mutation."
 fi
 
-for failure_mode in upload-fail tag-create-fail tag-readback-fail; do
+for failure_mode in upload-fail tag-readback-fail; do
     : > "$fake_gh_log"
     /bin/rm -f "$fake_gh_tag_state"
     export FAKE_GH_MODE="$failure_mode"
@@ -533,11 +539,9 @@ for failure_mode in upload-fail tag-create-fail tag-readback-fail; do
         --readback "$temporary_directory/$failure_mode.json"
     /usr/bin/grep -Fq -- '--method DELETE repos/owner/repository/releases/123' \
         "$fake_gh_log" || fail "A failed RC transaction must delete its incomplete draft."
-    if [[ "$failure_mode" == "tag-readback-fail" ]]; then
-        /usr/bin/grep -Fq -- \
-            '--method DELETE repos/owner/repository/git/refs/tags/v0.2.0-rc.1' \
-            "$fake_gh_log" || fail "A failed RC tag readback must delete its newly created tag."
-    fi
+    /usr/bin/grep -Fq -- \
+        '--method DELETE repos/owner/repository/git/refs/tags/v0.2.0-rc.1' \
+        "$fake_gh_log" || fail "A failed RC transaction must delete its release-created tag."
     [[ ! -f "$fake_gh_tag_state" ]] || \
         fail "A failed RC transaction must not retain a tag created by that invocation."
 done

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -68,6 +68,22 @@ expect_failure "only from protected main" \
 expect_failure "only from protected main" \
     assert_protected_release_ref "refs/tags/v0.2.0-rc.1"
 
+assert_release_workflow_trusted_dispatch "$workflow"
+
+/usr/bin/sed \
+    's/^  repository_dispatch:/  workflow_dispatch:/' \
+    "$workflow" > "$temporary_directory/branch-selectable-dispatch.yml"
+expect_failure "trusted default-branch repository dispatch event" \
+    assert_release_workflow_trusted_dispatch \
+    "$temporary_directory/branch-selectable-dispatch.yml"
+
+/usr/bin/sed \
+    's/\[copylasso_protected_release\]/[unreviewed_release_event]/' \
+    "$workflow" > "$temporary_directory/wrong-dispatch-type.yml"
+expect_failure "trusted default-branch repository dispatch event" \
+    assert_release_workflow_trusted_dispatch \
+    "$temporary_directory/wrong-dispatch-type.yml"
+
 readonly guarded_workflow="$temporary_directory/guarded-release.yml"
 /bin/cp "$workflow" "$guarded_workflow"
 assert_release_workflow_job_guard "$guarded_workflow" "quality-gate"

--- a/scripts/test-release-workflow.sh
+++ b/scripts/test-release-workflow.sh
@@ -541,18 +541,20 @@ fi
 : > "$fake_gh_log"
 /bin/rm -f "$fake_gh_tag_state"
 export FAKE_GH_MODE="release-create-fail"
-expect_failure "draft release could not be created" \
+expect_failure "release creation outcome is ambiguous" \
     "$draft_creator" \
     --repository owner/repository \
     --commit 0123456789abcdef0123456789abcdef01234567 \
     --candidate-number 1 \
     --run-dir "$release_run" \
     --readback "$temporary_directory/release-create-fail.json"
-/usr/bin/grep -Fq -- \
+if /usr/bin/grep -Fq -- \
     '--method DELETE repos/owner/repository/git/refs/tags/v0.2.0-rc.1' \
-    "$fake_gh_log" || fail "A failed release creation must delete its owned tag."
-[[ ! -f "$fake_gh_tag_state" ]] || \
-    fail "A failed release creation must not retain its owned candidate tag."
+    "$fake_gh_log"; then
+    fail "An ambiguous release response must not delete a tag that a raced release may use."
+fi
+[[ -f "$fake_gh_tag_state" ]] || \
+    fail "An ambiguous release response must retain the candidate tag for inspection."
 
 : > "$fake_gh_log"
 /bin/rm -f "$fake_gh_tag_state"


### PR DESCRIPTION
## Motivation

Release evidence must not leak machine-local absolute paths hidden inside compound values.

## Changes

- Reject direct, assignment-embedded, space-delimited, colon-delimited, quoted, and file-URL absolute paths.
- Preserve valid HTTPS release URLs.
- Add regression fixtures for compact tool output and file URLs.
- Include the complete upstream #64, #66, and #67 security layers.

## Verification

Focused release-package, protected-release, CI-contract, qualification-audit, formatting, and canonical pipeline checks pass. Exact-head review and required hosted CI are the final merge gates.

## Merge order

4 of 6. Merge #64, #66, and #67 first, then this PR, followed by #70 and #73.