### PR TITLE
Fix read-only DMG verification labels

### DIFF
--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -183,9 +183,9 @@ assert_release_read_only_mount() {
 
     [[ -f "$disk_record_path" ]] || \
         release_package_fail "The mounted-volume record is missing."
-    /usr/bin/grep -Eq 'Media Read-Only:[[:space:]]+Yes' "$disk_record_path" || \
+    /usr/bin/grep -Eq 'Read-Only Media:[[:space:]]+Yes' "$disk_record_path" || \
         release_package_fail "The release disk-image media is not read-only."
-    /usr/bin/grep -Eq 'Volume Read-Only:[[:space:]]+Yes' "$disk_record_path" || \
+    /usr/bin/grep -Eq 'Read-Only Volume:[[:space:]]+Yes' "$disk_record_path" || \
         release_package_fail "The mounted release volume is not read-only."
 }
 

--- a/scripts/test-release-package.sh
+++ b/scripts/test-release-package.sh
@@ -193,15 +193,15 @@ expect_failure "read-only UDZO" assert_release_dmg_imageinfo \
 
 valid_diskutil="$temporary_directory/valid-diskutil.txt"
 cat > "$valid_diskutil" <<'TEXT'
-   Media Read-Only:           Yes
-   Volume Read-Only:          Yes (read-only mount flag set)
+   Read-Only Media:           Yes
+   Read-Only Volume:          Yes (read-only mount flag set)
 TEXT
 assert_release_read_only_mount "$valid_diskutil"
-sed 's/Media Read-Only:           Yes/Media Read-Only:           No/' \
+sed 's/Read-Only Media:           Yes/Read-Only Media:           No/' \
     "$valid_diskutil" > "$temporary_directory/writable-media.txt"
 expect_failure "media is not read-only" assert_release_read_only_mount \
     "$temporary_directory/writable-media.txt"
-sed 's/Volume Read-Only:          Yes/Volume Read-Only:          No/' \
+sed 's/Read-Only Volume:          Yes/Read-Only Volume:          No/' \
     "$valid_diskutil" > "$temporary_directory/writable-volume.txt"
 expect_failure "volume is not read-only" assert_release_read_only_mount \
     "$temporary_directory/writable-volume.txt"


### PR DESCRIPTION
### Motivation
- The release verifier expected nonstandard `diskutil` field names and therefore rejected correctly mounted read-only DMG volumes, breaking the release packaging verification step.

### Description
- Update the read-only mount checks in `scripts/lib/release-package-verification.sh` to grep for `Read-Only Media:` and `Read-Only Volume:` as emitted by macOS `diskutil`.
- Update the contract fixture and negative-case strings in `scripts/test-release-package.sh` to use the real `diskutil` labels so the tests reflect actual macOS output.

### Testing
- Executed a targeted check by sourcing `scripts/lib/release-package-verification.sh` and running `assert_release_read_only_mount` against a fixture containing `Read-Only Media: Yes` and `Read-Only Volume: Yes`, and confirmed the positive fixture passed and the altered negative fixtures failed as expected.
- Attempted to run `./scripts/test-release-package.sh` in the Linux CI container but the script could not be fully exercised because it relies on macOS-specific `/usr/bin/stat -f` behavior, and `shellcheck` was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a725e347cc88327886fcef1e9aae343)