### PR TITLE
Cancel stale input readiness on mouseDown to fix cross-display key handoff race

### DIFF
--- a/CopyLasso/Services/AppKitRegionSelectionService.swift
+++ b/CopyLasso/Services/AppKitRegionSelectionService.swift
@@ -333,6 +333,9 @@ private final class SelectionOverlayController {
 
     switch event {
     case .mouseDown(let point):
+      for surface in surfaces where surface.displayID != displayID {
+        surface.cancelInputReadiness()
+      }
       let inputSurface = surfaces.first(where: { $0.displayID == displayID })
       inputSurface?.makeInputReady { [weak self] in
         self?.inputSurfaceBecameKey(displayID)

--- a/CopyLassoTests/Services/AppKitRegionSelectionServiceTests.swift
+++ b/CopyLassoTests/Services/AppKitRegionSelectionServiceTests.swift
@@ -379,6 +379,34 @@ final class AppKitRegionSelectionServiceTests: XCTestCase {
     XCTAssertEqual(outcome, .cancelled(.applicationTerminated))
   }
 
+  func testMouseDownCancelsStalePointerReadinessBeforeCrossDisplayHandoff()
+    async throws
+  {
+    let first = try makeDisplay(id: 1, origin: CGPoint(x: 50_000, y: 50_000))
+    let second = try makeDisplay(id: 2, origin: CGPoint(x: 50_100, y: 50_000))
+    let provider = StubSelectionDisplayProvider(results: [.success([first, second])])
+    let factory = RecordingSelectionOverlaySurfaceFactory(
+      automaticallyCompletesInputReadiness: false
+    )
+    let context = makeContext(provider: provider, factory: factory)
+
+    let task = Task { try await context.service.selectRegion() }
+    await Task.yield()
+
+    factory.surfaces[1].send(.mouseDown(CGPoint(x: 50_110, y: 50_010)))
+    factory.surfaces[0].completeInputReadiness()
+    factory.surfaces[1].completeInputReadiness()
+
+    XCTAssertEqual(factory.surfaces[0].cancelInputReadinessCallCount, 1)
+    XCTAssertEqual(factory.surfaces.map(\.refreshCursorRectsCallCount), [0, 1])
+    XCTAssertEqual(context.cursor.pushCallCount, 1)
+
+    factory.surfaces[1].send(.escape)
+    await context.scheduler.runNext()
+    let outcome = try await task.value
+    XCTAssertEqual(outcome, .cancelled(.escape))
+  }
+
   func testMouseDownKeyHandoffBeforeInitialReadinessStillInstallsCrosshairOnce()
     async throws
   {


### PR DESCRIPTION
### Motivation

- Fix a race where a deferred initial key-readiness callback can cancel a clicked panel's pending readiness during cross-display drags, allowing a drag to complete without the overlay view becoming first responder so `Escape` may be ignored.

### Description

- In `SelectionOverlayController.handle(_:from:)`, cancel pending input readiness on all non-clicked surfaces before arming the clicked surface with `makeInputReady(...)` to prevent a stale pointer-surface readiness from later clearing the clicked surface's callback (`CopyLasso/Services/AppKitRegionSelectionService.swift`).
- Add a regression test `testMouseDownCancelsStalePointerReadinessBeforeCrossDisplayHandoff` to exercise the delayed-readiness/cross-display handoff ordering and assert that cursor refresh and `Escape` cancellation still occur (`CopyLassoTests/Services/AppKitRegionSelectionServiceTests.swift`).
- Preserve existing behavior for normal single-display flows and other cancellation paths; the change only clears stale readiness on other surfaces at the moment of a `mouseDown` handoff.

### Testing

- Added a unit test `testMouseDownCancelsStalePointerReadinessBeforeCrossDisplayHandoff` that reproduces the cross-display ordering and verifies `cancelInputReadiness` is invoked on the stale surface and that `Escape` still cancels the selection.  The test is included in `CopyLassoTests/Services/AppKitRegionSelectionServiceTests.swift`.
- Attempted to run `swift test` in this Linux container but it failed due to the repository root not containing `Package.swift` so automated test execution was unavailable here.  `xcodebuild` was also unavailable in this environment, so macOS/Xcode builds/tests could not be executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7263c9c86083279b7a8957a5efd26b)