### PR TITLE
G49: prepare CopyLasso v0.2.1 publication

### DIFF
--- a/.github/workflows/prepare-publication.yml
+++ b/.github/workflows/prepare-publication.yml
@@ -1,24 +1,27 @@
-name: Prepare v0.2 Publication
+name: Prepare v0.2.1 Publication
 
 on:
-  workflow_dispatch:
+  repository_dispatch:
+    types: [copylasso_prepare_publication]
 
 permissions:
   contents: read
 
 concurrency:
-  group: copylasso-v02-publication
+  group: copylasso-v021-publication
   cancel-in-progress: false
 
 jobs:
   quality-gate:
     name: Complete publication quality gate
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'copylasso_prepare_publication' && github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
     uses: ./.github/workflows/ci.yml
 
   prepare-publication:
     name: Prepare private final release draft
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'copylasso_prepare_publication' && github.ref == 'refs/heads/main' }}
     needs: quality-gate
     runs-on: macos-26
     timeout-minutes: 45
@@ -48,34 +51,34 @@ jobs:
       - name: Initialize private publication paths
         run: |
           source ./scripts/lib/v02-publication-verification.sh
-          publication_root="$GITHUB_WORKSPACE/dist/g43/$GITHUB_SHA"
+          publication_root="$GITHUB_WORKSPACE/dist/g49/$GITHUB_SHA"
           /bin/mkdir -p "$publication_root"
-          printf 'COPYLASSO_G43_ROOT=%s\n' "$publication_root" >> "$GITHUB_ENV"
-          printf 'COPYLASSO_G43_CANDIDATE=%s\n' \
+          printf 'COPYLASSO_G49_ROOT=%s\n' "$publication_root" >> "$GITHUB_ENV"
+          printf 'COPYLASSO_G49_CANDIDATE=%s\n' \
             "$publication_root/candidate" >> "$GITHUB_ENV"
-          printf 'COPYLASSO_G43_CANDIDATE_READBACK=%s\n' \
+          printf 'COPYLASSO_G49_CANDIDATE_READBACK=%s\n' \
             "$publication_root/candidate-release.json" >> "$GITHUB_ENV"
-          printf 'COPYLASSO_G43_CANDIDATE_TAG_READBACK=%s\n' \
+          printf 'COPYLASSO_G49_CANDIDATE_TAG_READBACK=%s\n' \
             "$publication_root/candidate-tag.json" >> "$GITHUB_ENV"
-          printf 'COPYLASSO_G43_VERIFICATION=%s\n' \
+          printf 'COPYLASSO_G49_VERIFICATION=%s\n' \
             "$publication_root/verification" >> "$GITHUB_ENV"
-          printf 'COPYLASSO_G43_APPCAST=%s\n' \
+          printf 'COPYLASSO_G49_APPCAST=%s\n' \
             "$publication_root/appcast.xml" >> "$GITHUB_ENV"
-          printf 'COPYLASSO_G43_FEED=%s\n' \
+          printf 'COPYLASSO_G49_FEED=%s\n' \
             "$publication_root/feed" >> "$GITHUB_ENV"
-          printf 'COPYLASSO_G43_DRAFT_READBACK=%s\n' \
+          printf 'COPYLASSO_G49_DRAFT_READBACK=%s\n' \
             "$publication_root/final-draft.json" >> "$GITHUB_ENV"
-          printf 'COPYLASSO_G43_HANDOFF=%s\n' \
+          printf 'COPYLASSO_G49_HANDOFF=%s\n' \
             "$publication_root/publication-handoff" >> "$GITHUB_ENV"
-          printf 'COPYLASSO_G43_SOURCE_PACKAGES=%s\n' \
-            "$RUNNER_TEMP/copylasso-g43-source-packages" >> "$GITHUB_ENV"
+          printf 'COPYLASSO_G49_SOURCE_PACKAGES=%s\n' \
+            "$RUNNER_TEMP/copylasso-g49-source-packages" >> "$GITHUB_ENV"
 
       - name: Resolve pinned Sparkle publication tools
         run: |
           xcodebuild -resolvePackageDependencies \
             -project CopyLasso.xcodeproj \
             -scheme CopyLasso \
-            -clonedSourcePackagesDirPath "$COPYLASSO_G43_SOURCE_PACKAGES"
+            -clonedSourcePackagesDirPath "$COPYLASSO_G49_SOURCE_PACKAGES"
 
       - name: Download exact approved private candidate
         env:
@@ -83,17 +86,17 @@ jobs:
         run: |
           ./scripts/download-v02-candidate.sh \
             --repository "$GITHUB_REPOSITORY" \
-            --output-dir "$COPYLASSO_G43_CANDIDATE" \
-            --readback "$COPYLASSO_G43_CANDIDATE_READBACK" \
-            --tag-readback "$COPYLASSO_G43_CANDIDATE_TAG_READBACK"
+            --output-dir "$COPYLASSO_G49_CANDIDATE" \
+            --readback "$COPYLASSO_G49_CANDIDATE_READBACK" \
+            --tag-readback "$COPYLASSO_G49_CANDIDATE_TAG_READBACK"
 
       - name: Reverify approved package without rebuilding
         env:
           COPYLASSO_EXPECTED_TEAM_ID: ${{ secrets.COPYLASSO_EXPECTED_TEAM_ID }}
         run: |
           ./scripts/verify-v02-candidate-package.sh \
-            --candidate-dir "$COPYLASSO_G43_CANDIDATE" \
-            --work-dir "$COPYLASSO_G43_VERIFICATION"
+            --candidate-dir "$COPYLASSO_G49_CANDIDATE" \
+            --work-dir "$COPYLASSO_G49_VERIFICATION"
 
       - name: Generate authenticated final update metadata
         env:
@@ -101,25 +104,25 @@ jobs:
         run: |
           source ./scripts/lib/v02-publication-verification.sh
           sparkle_generate_appcast="$(
-            /usr/bin/find "$COPYLASSO_G43_SOURCE_PACKAGES/artifacts" \
+            /usr/bin/find "$COPYLASSO_G49_SOURCE_PACKAGES/artifacts" \
               -type f -path '*/bin/generate_appcast' -print -quit
           )"
           [[ -n "$sparkle_generate_appcast" ]]
           ./scripts/generate-release-appcast.sh \
             --application \
-            "$COPYLASSO_G43_VERIFICATION/extracted/payload/$COPYLASSO_V02_CANDIDATE_COMMIT/export/CopyLasso.app" \
-            --candidate-dir "$COPYLASSO_G43_CANDIDATE" \
+            "$COPYLASSO_G49_VERIFICATION/extracted/payload/$COPYLASSO_V02_CANDIDATE_COMMIT/export/CopyLasso.app" \
+            --candidate-dir "$COPYLASSO_G49_CANDIDATE" \
             --release-notes "docs/release-notes/$COPYLASSO_RELEASE_VERSION.md" \
-            --output "$COPYLASSO_G43_APPCAST" \
+            --output "$COPYLASSO_G49_APPCAST" \
             --sparkle-tools-dir "$(/usr/bin/dirname "$sparkle_generate_appcast")"
 
       - name: Prepare feed-only deployment bundle
         run: |
           source ./scripts/lib/v02-publication-verification.sh
           ./scripts/prepare-update-feed.sh \
-            --appcast "$COPYLASSO_G43_APPCAST" \
+            --appcast "$COPYLASSO_G49_APPCAST" \
             --release-notes "docs/release-notes/$COPYLASSO_RELEASE_VERSION.md" \
-            --output-dir "$COPYLASSO_G43_FEED"
+            --output-dir "$COPYLASSO_G49_FEED"
 
       - name: Create verified private final draft
         env:
@@ -127,21 +130,21 @@ jobs:
         run: |
           ./scripts/create-v02-publication-draft.sh \
             --repository "$GITHUB_REPOSITORY" \
-            --candidate-dir "$COPYLASSO_G43_CANDIDATE" \
-            --readback "$COPYLASSO_G43_DRAFT_READBACK"
+            --candidate-dir "$COPYLASSO_G49_CANDIDATE" \
+            --readback "$COPYLASSO_G49_DRAFT_READBACK"
 
       - name: Assemble private publication handoff
         run: |
           source ./scripts/lib/v02-publication-verification.sh
-          /bin/mkdir -p "$COPYLASSO_G43_HANDOFF"
-          /usr/bin/ditto "$COPYLASSO_G43_FEED" \
-            "$COPYLASSO_G43_HANDOFF/feed"
-          /bin/cp "$COPYLASSO_G43_CANDIDATE_READBACK" \
-            "$COPYLASSO_G43_HANDOFF/candidate-release.json"
-          /bin/cp "$COPYLASSO_G43_CANDIDATE_TAG_READBACK" \
-            "$COPYLASSO_G43_HANDOFF/candidate-tag.json"
-          /bin/cp "$COPYLASSO_G43_DRAFT_READBACK" \
-            "$COPYLASSO_G43_HANDOFF/final-draft.json"
+          /bin/mkdir -p "$COPYLASSO_G49_HANDOFF"
+          /usr/bin/ditto "$COPYLASSO_G49_FEED" \
+            "$COPYLASSO_G49_HANDOFF/feed"
+          /bin/cp "$COPYLASSO_G49_CANDIDATE_READBACK" \
+            "$COPYLASSO_G49_HANDOFF/candidate-release.json"
+          /bin/cp "$COPYLASSO_G49_CANDIDATE_TAG_READBACK" \
+            "$COPYLASSO_G49_HANDOFF/candidate-tag.json"
+          /bin/cp "$COPYLASSO_G49_DRAFT_READBACK" \
+            "$COPYLASSO_G49_HANDOFF/final-draft.json"
           /usr/bin/jq -n \
             --arg control_commit "$GITHUB_SHA" \
             --arg candidate_commit "$COPYLASSO_V02_CANDIDATE_COMMIT" \
@@ -149,11 +152,11 @@ jobs:
             --arg final_tag "$COPYLASSO_V02_FINAL_TAG" \
             --arg dmg_sha256 "$COPYLASSO_V02_DMG_SHA256" \
             --arg appcast_sha256 "$(
-              /usr/bin/shasum -a 256 "$COPYLASSO_G43_APPCAST" |
+              /usr/bin/shasum -a 256 "$COPYLASSO_G49_APPCAST" |
                 /usr/bin/awk '{print $1}'
             )" \
             --argjson draft_id "$(
-              /usr/bin/jq -er '.id' "$COPYLASSO_G43_DRAFT_READBACK"
+              /usr/bin/jq -er '.id' "$COPYLASSO_G49_DRAFT_READBACK"
             )" \
             '{
               control_commit: $control_commit,
@@ -163,18 +166,18 @@ jobs:
               final_draft_id: $draft_id,
               dmg_sha256: $dmg_sha256,
               appcast_sha256: $appcast_sha256
-            }' > "$COPYLASSO_G43_HANDOFF/publication-manifest.json"
+            }' > "$COPYLASSO_G49_HANDOFF/publication-manifest.json"
           ./scripts/audit-v02-publication.sh \
-            --handoff "$COPYLASSO_G43_HANDOFF" \
-            --candidate-dir "$COPYLASSO_G43_CANDIDATE" \
+            --handoff "$COPYLASSO_G49_HANDOFF" \
+            --candidate-dir "$COPYLASSO_G49_CANDIDATE" \
             --application \
-            "$COPYLASSO_G43_VERIFICATION/extracted/payload/$COPYLASSO_V02_CANDIDATE_COMMIT/export/CopyLasso.app"
+            "$COPYLASSO_G49_VERIFICATION/extracted/payload/$COPYLASSO_V02_CANDIDATE_COMMIT/export/CopyLasso.app"
 
       - name: Upload private publication handoff
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: copylasso-v0.2.0-publication
-          path: ${{ env.COPYLASSO_G43_HANDOFF }}
+          name: copylasso-v0.2.1-publication
+          path: ${{ env.COPYLASSO_G49_HANDOFF }}
           if-no-files-found: error
           retention-days: 30
           compression-level: 0

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -197,15 +197,17 @@ inferred pass; see [`v0.2-release-qualification.md`](v0.2-release-qualification.
 
 ## G48 - Qualify CopyLasso v0.2.1
 
-- [ ] Phase 1: freeze current source at `0.2.1 (4)`, add reviewed maintenance notes, reconcile public-versus-candidate documentation, and pass the focused G48 qualification audit exactly once through canonical CI.
-- [ ] Phase 1: update the protected workflow from historical G42 execution paths to G48 while retaining exact-main provenance, one positive `candidate_number`, protected credentials, derived asset names, draft-only output, and no publication path.
-- [ ] Phase 1: pass local and hosted arm64/x86_64 plus maintained macOS 15 checks, Universal 2 Release verification, exact-head review, and ready-PR readback; stop for separate merge approval without dispatching the workflow.
-- [ ] Phase 2: after the reviewed head is separately merged, dispatch from exact protected main with the first unused candidate number and create one immutable private `v0.2.1-rc.N` draft with four restricted assets.
-- [ ] Phase 2: verify signatures, notarization, Gatekeeper, package layout, checksums, GitHub digests, dSYM UUIDs, authenticated candidate metadata, browser quarantine, and the compact current-host capture matrix without rebuilding.
-- [ ] Phase 2: exercise an isolated update from exact public `0.2.0 (3)` to the byte-identical candidate, record the maintainer decision, and leave the candidate unpublished.
+- [x] Phase 1: freeze current source at `0.2.1 (4)`, add reviewed maintenance notes, reconcile public-versus-candidate documentation, and pass the focused G48 qualification audit exactly once through canonical CI.
+- [x] Phase 1: update the protected workflow from historical G42 execution paths to G48 while retaining exact-main provenance, one positive `candidate_number`, protected credentials, derived asset names, draft-only output, and no publication path.
+- [x] Phase 1: pass local and hosted arm64/x86_64 plus maintained macOS 15 checks, Universal 2 Release verification, exact-head review, and ready-PR readback; stop for separate merge approval without dispatching the workflow.
+- [x] Phase 2: after the reviewed head is separately merged, dispatch from exact protected main with the first unused candidate number and create one immutable private `v0.2.1-rc.N` draft with four restricted assets.
+- [x] Phase 2: verify signatures, notarization, Gatekeeper, package layout, checksums, GitHub digests, dSYM UUIDs, authenticated candidate metadata, browser quarantine, and the compact current-host capture matrix without rebuilding.
+- [x] Phase 2: exercise an isolated update from exact public `0.2.0 (3)` to the byte-identical candidate, record the maintainer decision, and leave the candidate unpublished.
 
 ## G49 - Publish CopyLasso v0.2.1
 
-- [ ] Begin only after the exact G48 private candidate is separately approved. Revalidate immutable candidate bytes and prepare publication controls without rebuilding or moving the RC tag.
-- [ ] Publish the final signed tag, exact public DMG and checksum, and authenticated feed only through a separately approved G49 transaction.
-- [ ] Complete public-download, updater, installation, source-archive, documentation, and release-state verification before closing the patch release.
+- [x] Begin only after the exact G48 private candidate is separately approved. Revalidate immutable candidate identity before changing publication controls.
+- [ ] Phase 1: merge the green G49 publication-control PR before dispatching the protected preparation workflow.
+- [ ] Phase 2: reverify the immutable candidate without rebuilding, create the private two-asset final draft and final-URL appcast, then publish the signed final tag, exact DMG and checksum, and authenticated feed through the approved transaction.
+- [ ] Phase 2: complete unauthenticated public-download, updater, installation, source-archive, feed, and immutable-tag verification.
+- [ ] Phase 3: date and close the public release state in a separate green ready PR without changing release bytes, tags, feed, or application code.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -335,3 +335,26 @@ post-publication documentation and issue-state changes.
 The immutable publication outcome and later G44 readback are recorded in
 [`v0.2-release-state.md`](v0.2-release-state.md). This closure record does not
 move either release tag, replace any asset, or alter the production feed.
+
+## G49 Publication Preparation
+
+G49 consumes only the approved G48 candidate. Its input-free
+`copylasso_prepare_publication` repository dispatch runs from protected
+`main`, reruns canonical CI, downloads private release `367523470`, verifies
+direct tag `v0.2.1-rc.1` at exact source commit
+`813de17c739097217aad55a5a35c04ea3c73d99f`, and reverifies all four pinned
+asset sizes and digests without rebuilding or notarizing again.
+
+Only the protected preparation job receives `contents: write`. The release
+team identifier enters only package verification, and the Sparkle seed enters
+only final-appcast generation after the candidate bytes and shipped public key
+match. The job prepares a feed-only bundle and a private, non-prerelease final
+draft containing exactly the DMG and checksum. It uploads a restricted handoff
+for maintainer readback but cannot publish the draft, create or move a tag,
+replace an asset, or deploy the feed.
+
+Publication is a later operator transaction after the protected handoff is
+verified. The annotated signed final tag and RC tag must peel to the same G48
+commit. The exact final draft is published before the authenticated appcast is
+deployed to the existing feed-only endpoint. Any ambiguous or failed readback
+stops publication without replacement or retry-by-mutation.

--- a/docs/secure-update-operations.md
+++ b/docs/secure-update-operations.md
@@ -214,3 +214,18 @@ and immutable GitHub enclosure passed signature, length, URL, version-ordering,
 browser-download, install, and public updater-path readback. The exact public
 identifiers and digests are retained in the
 [v0.2 release-state record](v0.2-release-state.md).
+
+## G49 v0.2.1 Publication Boundary
+
+G49 updates the production feed only after the signed final tag and exact
+two-asset GitHub release are public and independently verified. The protected
+preparation workflow consumes private `v0.2.1-rc.1` without rebuilding,
+generates a final-URL appcast with the existing protected Sparkle identity, and
+creates a private final draft. It has no publication or feed-deployment path.
+
+The operator transaction publishes the immutable draft and then deploys only
+the verified `appcast.xml` plus the existing `_headers` policy to the existing
+Cloudflare Pages project. It does not change the custom domain, apex DNS,
+nameservers, hosting scope, update key, or application trust settings. A failed
+GitHub or feed readback freezes the state for remediation; it never authorizes
+moving a tag, replacing an asset, or serving unsigned metadata.

--- a/docs/v0.2-publication-runbook.md
+++ b/docs/v0.2-publication-runbook.md
@@ -195,3 +195,60 @@ content-free records. G44 separately dates the changelog from GitHub's actual
 publication timestamp, updates released-state documentation, closes only
 shipped and publicly verified issues, verifies the exact public local
 installation, and reconciles protected `main`.
+
+## G49 v0.2.1 Patch Publication
+
+G49 reuses the established boundary for the separately approved maintenance
+candidate. Never rebuild the G48 candidate. The frozen identities are:
+
+- candidate commit: `813de17c739097217aad55a5a35c04ea3c73d99f`;
+- private release: `367523470`;
+- direct candidate tag: `v0.2.1-rc.1`;
+- final annotated signed tag: `v0.2.1` with message `CopyLasso 0.2.1`;
+- final release name: `CopyLasso 0.2.1`;
+- DMG SHA-256: `05180caa3600bcd282246297a9172517136e43e55c6e8fa192b55ba44af4a017`.
+
+### Phase 1 - Protected Preparation
+
+Merge the green G49 publication-control pull request to protected `main`, then
+dispatch only the input-free `copylasso_prepare_publication` event. Approve the
+existing `release` environment once. The workflow reruns canonical CI,
+downloads and reverifies the four private G48 assets, verifies the restricted
+candidate appcast, generates a final-URL authenticated appcast, prepares the
+two-file Cloudflare Pages bundle, and creates one private non-prerelease final
+draft containing only `CopyLasso-0.2.1.dmg` and its checksum.
+
+Read back the restricted handoff and prove its control commit, candidate
+identity, final draft ID, DMG digest, appcast digest, signatures, and exact
+file set. The workflow cannot publish, deploy, create a final tag, replace an
+asset, or rebuild the candidate.
+
+### Phase 2 - Signed Tag And Publication
+
+Before mutation, reconfirm public `v0.2.0` remains latest and that neither a
+`v0.2.1` tag nor release exists. Verify the private final draft, then use the
+dedicated release-tag signing identity to create and locally verify the
+annotated `v0.2.1` tag on the exact candidate commit. Push only that tag and
+require GitHub's verified signed-tag readback before publishing the prepared
+draft by release ID as public, non-prerelease, and latest.
+
+Deploy the exact feed handoff to the existing Cloudflare Pages project only
+after the immutable GitHub enclosure URL is publicly downloadable. Confirm the
+custom domain, assigned Pages hostname, and immutable deployment hostname serve
+byte-identical signed metadata with the reviewed XML, cache, and `nosniff`
+headers. The authoritative registrar remains Spaceship; G49 changes no apex
+record or nameserver.
+
+Never move either tag. Never replace a public asset. Never regenerate the
+appcast after publication. Ambiguous API or deployment responses require exact
+readback before any retry, and any mismatch stops for a remediation decision.
+
+### Public Verification And Release-State Closure
+
+Verify unauthenticated release state, both asset digests, generated source
+archives, checksum, Developer ID signature, notarization/stapling, Gatekeeper,
+package layout, metadata, architectures, entitlements, appcast and enclosure
+signatures, ordering above build `3`, and a genuine Safari-quarantined install.
+Exercise the public updater once from exact public `0.2.0 (3)` to byte-identical
+`0.2.1 (4)`. Only after those checks pass may the separate release-state
+closure PR date the changelog and describe v0.2.1 as public.

--- a/scripts/audit-g48-patch-qualification.sh
+++ b/scripts/audit-g48-patch-qualification.sh
@@ -6,7 +6,7 @@ readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && /bin/pwd -
 readonly metadata="$repository_root/Configuration/ReleaseMetadata.xcconfig"
 readonly notes="$repository_root/docs/release-notes/0.2.1.md"
 readonly workflow="$repository_root/.github/workflows/release.yml"
-readonly historical_publication_workflow="$repository_root/.github/workflows/prepare-publication.yml"
+readonly publication_workflow="$repository_root/.github/workflows/prepare-publication.yml"
 readonly entitlements="$repository_root/CopyLasso/CopyLasso.entitlements"
 readonly package_resolved="$repository_root/CopyLasso.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
 
@@ -42,7 +42,9 @@ for required_file in \
     .github/workflows/release.yml \
     .github/workflows/prepare-publication.yml \
     scripts/lib/release-package-verification.sh \
+    scripts/lib/v020-release-package-metadata.sh \
     scripts/lib/v02-publication-verification.sh \
+    scripts/audit-g49-publication.sh \
     scripts/verify-release-package.sh \
     scripts/verify-v02-candidate-package.sh; do
     [[ -s "$repository_root/$required_file" ]] || \
@@ -106,19 +108,24 @@ if /usr/bin/grep -Eiq -- \
     fail "G48 candidate tooling must remain draft-only and immutable."
 fi
 
-historical_feed_step="$(/usr/bin/sed -n \
+publication_feed_step="$(/usr/bin/sed -n \
     '/- name: Prepare feed-only deployment bundle/,/- name: Create verified private final draft/p' \
-    "$historical_publication_workflow")"
-[[ "$historical_feed_step" == *'source ./scripts/lib/v02-publication-verification.sh'* ]] || \
-    fail "The historical G43 feed step must use pinned v0.2 publication metadata."
-[[ "$historical_feed_step" != *'source ./scripts/lib/release-metadata.sh'* ]] || \
-    fail "The historical G43 feed step must not use current G48 metadata."
+    "$publication_workflow")"
+[[ "$publication_feed_step" == *'source ./scripts/lib/v02-publication-verification.sh'* ]] || \
+    fail "The G49 feed step must use pinned v0.2.1 publication metadata."
+[[ "$publication_feed_step" != *'source ./scripts/lib/release-metadata.sh'* ]] || \
+    fail "The G49 feed step must not use mutable current release metadata."
 require_text scripts/lib/v02-publication-verification.sh \
+    'COPYLASSO_RELEASE_APPCAST="CopyLasso-0.2.1-appcast.xml"'
+require_text scripts/lib/v020-release-package-metadata.sh \
     'COPYLASSO_RELEASE_APPCAST="CopyLasso-0.2.0-appcast.xml"'
 require_text scripts/lib/release-package-verification.sh \
     'COPYLASSO_RELEASE_PACKAGE_METADATA_PROFILE:-current'
 require_text scripts/verify-release-package.sh '--pinned-v02-metadata'
-require_text scripts/verify-v02-candidate-package.sh '--pinned-v02-metadata'
+if /usr/bin/grep -Fq -- '--pinned-v02-metadata' \
+    "$repository_root/scripts/verify-v02-candidate-package.sh"; then
+    fail "The G49 candidate verifier must use current v0.2.1 package metadata."
+fi
 
 entitlements_json="$(/usr/bin/plutil -convert json -o - "$entitlements")" || \
     fail "CopyLasso entitlements are invalid."
@@ -160,11 +167,11 @@ done
 
 require_text docs/v0.2-release-state.md '- Final tag: signed annotated `v0.2.0`'
 require_text docs/v0.2-release-state.md '- Release commit: `43f1d0c676b08fb24b49fc628213fede90c4ed9d`'
-require_text scripts/audit-v02-publication.sh 'COPYLASSO_V02_FINAL_TAG="v0.2.0"'
+require_text scripts/audit-g49-publication.sh 'COPYLASSO_V02_FINAL_TAG="v0.2.1"'
 require_text scripts/lib/v02-publication-verification.sh \
-    'COPYLASSO_RELEASE_VERSION="0.2.0"'
+    'COPYLASSO_RELEASE_VERSION="0.2.1"'
 require_text scripts/lib/v02-publication-verification.sh \
-    'COPYLASSO_RELEASE_DMG="CopyLasso-0.2.0.dmg"'
+    'COPYLASSO_RELEASE_DMG="CopyLasso-0.2.1.dmg"'
 require_text scripts/audit-v02-release-state.sh 'expected_release_id="361797888"'
 
 echo "CopyLasso G48 patch qualification audit passed."

--- a/scripts/audit-g49-publication.sh
+++ b/scripts/audit-g49-publication.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && /bin/pwd -P)"
+readonly metadata="$repository_root/Configuration/ReleaseMetadata.xcconfig"
+readonly notes="$repository_root/docs/release-notes/0.2.1.md"
+readonly workflow="$repository_root/.github/workflows/prepare-publication.yml"
+readonly verifier="$repository_root/scripts/lib/v02-publication-verification.sh"
+readonly publication_audit="$repository_root/scripts/audit-v02-publication.sh"
+readonly publication_test="$repository_root/scripts/test-v02-publication.sh"
+readonly candidate_workflow="$repository_root/.github/workflows/release.yml"
+readonly checklist="$repository_root/docs/release-checklist.md"
+readonly runbook="$repository_root/docs/v0.2-publication-runbook.md"
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+require_text() {
+    local file="$1"
+    local required="$2"
+
+    /usr/bin/grep -Fq -- "$required" "$file" || \
+        fail "G49 publication control is missing: $required"
+}
+
+for required_file in \
+    "$metadata" \
+    "$notes" \
+    "$workflow" \
+    "$verifier" \
+    "$publication_audit" \
+    "$publication_test" \
+    "$candidate_workflow" \
+    "$checklist" \
+    "$runbook"; do
+    [[ -s "$required_file" ]] || fail "Required G49 file is unavailable: $required_file"
+done
+
+require_text "$metadata" 'COPYLASSO_RELEASE_VERSION = 0.2.1'
+require_text "$metadata" 'COPYLASSO_RELEASE_BUILD = 4'
+require_text "$verifier" 'COPYLASSO_RELEASE_VERSION="0.2.1"'
+require_text "$verifier" 'COPYLASSO_RELEASE_BUILD="4"'
+require_text "$verifier" \
+    'COPYLASSO_V02_CANDIDATE_COMMIT="813de17c739097217aad55a5a35c04ea3c73d99f"'
+require_text "$verifier" 'COPYLASSO_V02_CANDIDATE_RELEASE_ID="367523470"'
+require_text "$verifier" 'COPYLASSO_V02_CANDIDATE_TAG="v0.2.1-rc.1"'
+require_text "$verifier" 'COPYLASSO_V02_FINAL_TAG="v0.2.1"'
+require_text "$verifier" 'COPYLASSO_V02_PREVIOUS_PUBLIC_TAG="v0.2.0"'
+require_text "$verifier" \
+    'COPYLASSO_V02_NOTES_SHA256="24dd1c6c235ba0e0d0bf433e07d6b1ddd5a8c2425fa368a4fa16926eb016b503"'
+require_text "$verifier" \
+    'COPYLASSO_V02_CANDIDATE_APPCAST_SHA256="ef48b25ed3527416ba2242cae4bf3975b3c61d21790e24e0b31669a1082bf779"'
+require_text "$verifier" \
+    'COPYLASSO_V02_DMG_SHA256="05180caa3600bcd282246297a9172517136e43e55c6e8fa192b55ba44af4a017"'
+require_text "$verifier" \
+    'COPYLASSO_V02_CHECKSUM_SHA256="b9a85f82686dce479cb41247fe9fc025ec8a0d099bbc08028c4239899359b1c9"'
+require_text "$verifier" \
+    'COPYLASSO_V02_DSYM_SHA256="0301eecaccb9fac76c1e25d2ae1db2edc99ff42febe55bfcf6f07ef4ffcbd368"'
+require_text "$verifier" \
+    'COPYLASSO_V02_VERIFICATION_SHA256="689aad0296e90b9aab83e198eaef0524da907d1742fbeab8078bddc823a1b108"'
+
+require_text "$workflow" 'types: [copylasso_prepare_publication]'
+require_text "$workflow" \
+    "github.event_name == 'repository_dispatch' && github.event.action == 'copylasso_prepare_publication' && github.ref == 'refs/heads/main'"
+require_text "$workflow" 'uses: ./.github/workflows/ci.yml'
+require_text "$workflow" 'environment:'
+require_text "$workflow" 'name: release'
+require_text "$workflow" 'cancel-in-progress: false'
+require_text "$workflow" 'persist-credentials: false'
+require_text "$workflow" './scripts/download-v02-candidate.sh'
+require_text "$workflow" './scripts/verify-v02-candidate-package.sh'
+require_text "$workflow" './scripts/generate-release-appcast.sh'
+require_text "$workflow" './scripts/prepare-update-feed.sh'
+require_text "$workflow" './scripts/create-v02-publication-draft.sh'
+require_text "$workflow" './scripts/audit-v02-publication.sh'
+require_text "$workflow" 'copylasso-v0.2.1-publication'
+
+if /usr/bin/grep -Fq '${{ github.event.client_payload.' "$workflow"; then
+    fail "G49 publication preparation must accept no dispatch payload."
+fi
+if /usr/bin/grep -Eq \
+    'build-release-candidate|xcodebuild[[:space:]]+(archive|-exportArchive)|notarytool[[:space:]]+submit|stapler[[:space:]]+staple' \
+    "$workflow"; then
+    fail "G49 must consume the immutable candidate without rebuilding or renotarizing it."
+fi
+if /usr/bin/grep -Eiq \
+    'release (publish|edit.+--draft=false)|make_latest=true|--clobber|force=true|git push|git tag|wrangler|pages deploy' \
+    "$workflow"; then
+    fail "G49 Phase 1 must not publish, tag, overwrite, or deploy."
+fi
+if /usr/bin/grep -Eq \
+    '(^|[[:space:]])(publish|make_latest|draft:[[:space:]]*false)([[:space:]]|$)' \
+    "$candidate_workflow"; then
+    fail "The approved G48 candidate workflow must remain draft-only."
+fi
+
+require_text "$checklist" '## G49 - Publish CopyLasso v0.2.1'
+require_text "$runbook" '## G49 v0.2.1 Patch Publication'
+require_text "$runbook" 'Never rebuild the G48 candidate'
+require_text "$runbook" 'Never move either tag'
+require_text "$runbook" 'Never replace a public asset'
+
+echo "CopyLasso G49 publication audit passed."

--- a/scripts/audit-v02-publication.sh
+++ b/scripts/audit-v02-publication.sh
@@ -11,7 +11,7 @@ usage() {
 Usage: audit-v02-publication.sh
        audit-v02-publication.sh \
          --handoff /path/to/private-handoff \
-         --candidate-dir /path/to/downloaded/G42/assets \
+         --candidate-dir /path/to/downloaded/G48/assets \
          --application /path/to/qualified/CopyLasso.app
 TEXT
     exit 64
@@ -59,7 +59,7 @@ readonly runbook="$repository_root/docs/v0.2-publication-runbook.md"
 readonly release_workflow_documentation="$repository_root/docs/release-workflow.md"
 readonly update_operations="$repository_root/docs/secure-update-operations.md"
 readonly release_checklist="$repository_root/docs/release-checklist.md"
-readonly notes="$repository_root/docs/release-notes/0.2.0.md"
+readonly notes="$repository_root/docs/release-notes/0.2.1.md"
 
 fail() {
     echo "$1" >&2
@@ -71,7 +71,7 @@ require_text() {
     local text="$2"
 
     /usr/bin/grep -Fq -- "$text" "$file" || \
-        fail "G43 publication contract text is missing: $text"
+        fail "G49 publication contract text is missing: $text"
 }
 
 for executable in \
@@ -82,7 +82,7 @@ for executable in \
     "$feed_preparer" \
     "$focused_tests"; do
     [[ -x "$executable" ]] || \
-        fail "G43 publication script is missing or not executable: $(/usr/bin/basename "$executable")"
+        fail "G49 publication script is missing or not executable: $(/usr/bin/basename "$executable")"
 done
 for readable in \
     "$workflow" \
@@ -96,36 +96,39 @@ for readable in \
     "$release_checklist" \
     "$notes"; do
     [[ -r "$readable" ]] || \
-        fail "G43 publication contract file is missing: $(/usr/bin/basename "$readable")"
+        fail "G49 publication contract file is missing: $(/usr/bin/basename "$readable")"
 done
 
 assert_v02_release_notes "$notes"
 require_text "$verifier_library" \
-    'COPYLASSO_V02_CANDIDATE_COMMIT="43f1d0c676b08fb24b49fc628213fede90c4ed9d"'
-require_text "$verifier_library" 'COPYLASSO_V02_CANDIDATE_RELEASE_ID="361203156"'
-require_text "$verifier_library" 'COPYLASSO_V02_CANDIDATE_TAG="v0.2.0-rc.1"'
-require_text "$verifier_library" 'COPYLASSO_V02_FINAL_TAG="v0.2.0"'
+    'COPYLASSO_V02_CANDIDATE_COMMIT="813de17c739097217aad55a5a35c04ea3c73d99f"'
+require_text "$verifier_library" 'COPYLASSO_V02_CANDIDATE_RELEASE_ID="367523470"'
+require_text "$verifier_library" 'COPYLASSO_V02_CANDIDATE_TAG="v0.2.1-rc.1"'
+require_text "$verifier_library" 'COPYLASSO_V02_FINAL_TAG="v0.2.1"'
 require_text "$verifier_library" \
-    'COPYLASSO_V02_DMG_SHA256="697cb008cf294b32500e2ad84e5777a51fe8b88916856c5a8e9f1ec4eb74ba19"'
+    'COPYLASSO_V02_DMG_SHA256="05180caa3600bcd282246297a9172517136e43e55c6e8fa192b55ba44af4a017"'
 require_text "$verifier_library" \
-    'COPYLASSO_V02_CHECKSUM_SHA256="6dfd44d92f6af1c14d765bc6c827ed3e9a0edd5ffe289c3e74ac6e1dd0c834b0"'
+    'COPYLASSO_V02_CHECKSUM_SHA256="b9a85f82686dce479cb41247fe9fc025ec8a0d099bbc08028c4239899359b1c9"'
 require_text "$verifier_library" \
-    'COPYLASSO_V02_DSYM_SHA256="b644da8776f857c1f42a95f903b315b7dde418000d173b48829c5ee346bc4754"'
+    'COPYLASSO_V02_DSYM_SHA256="0301eecaccb9fac76c1e25d2ae1db2edc99ff42febe55bfcf6f07ef4ffcbd368"'
 require_text "$verifier_library" \
-    'COPYLASSO_V02_VERIFICATION_SHA256="e4d424bdd9675b00ffa647bccdc3f3bc47b43b4d041535c0898f79cf79e3a073"'
+    'COPYLASSO_V02_VERIFICATION_SHA256="689aad0296e90b9aab83e198eaef0524da907d1742fbeab8078bddc823a1b108"'
 
-require_text "$workflow" 'workflow_dispatch:'
-if /usr/bin/grep -Fq 'inputs:' "$workflow"; then
-    fail "The G43 preparation workflow must not accept arbitrary dispatch inputs."
+require_text "$workflow" 'repository_dispatch:'
+require_text "$workflow" 'types: [copylasso_prepare_publication]'
+require_text "$workflow" \
+    "github.event_name == 'repository_dispatch' && github.event.action == 'copylasso_prepare_publication' && github.ref == 'refs/heads/main'"
+if /usr/bin/grep -Fq '${{ github.event.client_payload.' "$workflow"; then
+    fail "The G49 preparation workflow must not accept arbitrary dispatch inputs."
 fi
 for prohibited_trigger in \
     pull_request: \
     pull_request_target: \
     push: \
-    repository_dispatch: \
+    workflow_dispatch: \
     workflow_run:; do
     if /usr/bin/grep -Eq "^[[:space:]]*${prohibited_trigger}[[:space:]]*$" "$workflow"; then
-        fail "The G43 preparation workflow has a prohibited trigger: $prohibited_trigger"
+        fail "The G49 preparation workflow has a prohibited trigger: $prohibited_trigger"
     fi
 done
 require_text "$workflow" 'uses: ./.github/workflows/ci.yml'
@@ -138,28 +141,28 @@ require_text "$workflow" 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a8
 require_text "$workflow" 'persist-credentials: false'
 require_text "$workflow" 'fetch-depth: 0'
 require_text "$workflow" './scripts/download-v02-candidate.sh'
-require_text "$workflow" 'COPYLASSO_G43_CANDIDATE_TAG_READBACK'
-require_text "$workflow" '--tag-readback "$COPYLASSO_G43_CANDIDATE_TAG_READBACK"'
+require_text "$workflow" 'COPYLASSO_G49_CANDIDATE_TAG_READBACK'
+require_text "$workflow" '--tag-readback "$COPYLASSO_G49_CANDIDATE_TAG_READBACK"'
 require_text "$workflow" './scripts/verify-v02-candidate-package.sh'
 require_text "$workflow" './scripts/generate-release-appcast.sh'
 require_text "$workflow" './scripts/prepare-update-feed.sh'
 require_text "$workflow" './scripts/create-v02-publication-draft.sh'
 require_text "$workflow" './scripts/audit-v02-publication.sh'
-require_text "$workflow" 'COPYLASSO_G43_HANDOFF'
+require_text "$workflow" 'COPYLASSO_G49_HANDOFF'
 require_text "$workflow" 'retention-days: 30'
 
 contents_write_count="$(
     /usr/bin/grep -Ec '^[[:space:]]*contents: write[[:space:]]*$' "$workflow"
 )"
 [[ "$contents_write_count" == "1" ]] || \
-    fail "Only the protected G43 preparation job may receive contents write permission."
+    fail "Only the protected G49 preparation job may receive contents write permission."
 sparkle_secret_count="$(
     /usr/bin/grep -Fc \
         'COPYLASSO_SPARKLE_PRIVATE_KEY: ${{ secrets.COPYLASSO_SPARKLE_PRIVATE_KEY }}' \
         "$workflow"
 )"
 [[ "$sparkle_secret_count" == "1" ]] || \
-    fail "The Sparkle signing seed must enter exactly one narrow G43 step."
+    fail "The Sparkle signing seed must enter exactly one narrow G49 step."
 team_secret_count="$(
     /usr/bin/grep -Fc \
         'COPYLASSO_EXPECTED_TEAM_ID: ${{ secrets.COPYLASSO_EXPECTED_TEAM_ID }}' \
@@ -174,7 +177,7 @@ for prohibited_secret in \
     COPYLASSO_NOTARY_KEY_ID \
     COPYLASSO_NOTARY_ISSUER_ID; do
     if /usr/bin/grep -Fq "secrets.$prohibited_secret" "$workflow"; then
-        fail "G43 must not receive build, certificate, or notarization credentials."
+        fail "G49 must not receive build, certificate, or notarization credentials."
     fi
 done
 
@@ -182,7 +185,7 @@ while IFS= read -r action_target; do
     case "$action_target" in
         ./*) ;;
         *@????????????????????????????????????????) ;;
-        *) fail "The privileged G43 workflow contains a mutable action reference: $action_target" ;;
+        *) fail "The privileged G49 workflow contains a mutable action reference: $action_target" ;;
     esac
 done < <(/usr/bin/sed -nE \
     's/^[[:space:]]*uses:[[:space:]]*([^[:space:]]+).*$/\1/p' "$workflow")
@@ -190,7 +193,7 @@ done < <(/usr/bin/sed -nE \
 if /usr/bin/grep -Eq \
     'build-release-candidate|xcodebuild[[:space:]]+(archive|-exportArchive)|notarytool[[:space:]]+submit|stapler[[:space:]]+staple' \
     "$workflow"; then
-    fail "G43 must consume the approved candidate without rebuilding or renotarizing it."
+    fail "G49 must consume the approved candidate without rebuilding or renotarizing it."
 fi
 if /usr/bin/grep -Eiq \
     'release (publish|edit.+--draft=false)|make_latest=true|--method PATCH|--clobber|force=true|git push|git tag' \
@@ -205,7 +208,7 @@ fi
 if /usr/bin/grep -Eq \
     '(^|[[:space:]])(publish|make_latest|draft:[[:space:]]*false)([[:space:]]|$)' \
     "$candidate_workflow"; then
-    fail "The G42 candidate workflow must remain draft-only."
+    fail "The G48 candidate workflow must remain draft-only."
 fi
 
 for required_downloader_text in \
@@ -244,32 +247,33 @@ require_text "$verifier_library" 'verify-sparkle-signatures.swift'
 require_text "$signature_verifier_source" 'Curve25519.Signing.PublicKey'
 require_text "$signature_verifier_source" 'isValidSignature(feedSignature'
 require_text "$signature_verifier_source" 'isValidSignature(enclosureSignature'
-require_text "$workflow" '--candidate-dir "$COPYLASSO_G43_CANDIDATE"'
+require_text "$workflow" '--candidate-dir "$COPYLASSO_G49_CANDIDATE"'
 require_text "$workflow" '--application'
 if /usr/bin/grep -Eq \
     'git/refs|--method PATCH|--clobber|make_latest=true|draft=false' \
     "$draft_creator" "$transaction_library"; then
-    fail "The G43 draft helper must not create tags, publish, or replace public state."
+    fail "The G49 draft helper must not create tags, publish, or replace public state."
 fi
 
 for required_runbook_text in \
-    'Phase 1 - Protected Preparation' \
-    'Phase 2 - Signed Tag And Publication' \
-    'v0.2.0-rc.1' \
-    '43f1d0c676b08fb24b49fc628213fede90c4ed9d' \
+    '## G49 v0.2.1 Patch Publication' \
+    '### Phase 1 - Protected Preparation' \
+    '### Phase 2 - Signed Tag And Publication' \
+    'v0.2.1-rc.1' \
+    '813de17c739097217aad55a5a35c04ea3c73d99f' \
     'updates.copylasso.com' \
     'Cloudflare Pages' \
     'Spaceship' \
     'Never move either tag' \
     'Never replace a public asset' \
-    'G44'; do
+    'Release-State Closure'; do
     require_text "$runbook" "$required_runbook_text"
 done
-require_text "$release_workflow_documentation" '## G43 Publication Preparation'
+require_text "$release_workflow_documentation" '## G49 Publication Preparation'
 require_text "$update_operations" 'updates.copylasso.com'
-require_text "$release_checklist" '## G43 - Publish CopyLasso v0.2.0'
+require_text "$release_checklist" '## G49 - Publish CopyLasso v0.2.1'
 require_text "$release_checklist" \
-    '- [x] Merge the green G43 publication-control PR before dispatching the protected preparation workflow.'
+    '- [ ] Phase 1: merge the green G49 publication-control PR before dispatching the protected preparation workflow.'
 
 credential_marker='set -x|BEGIN '
 credential_marker+='([A-Z ]+ )?PRIVATE KEY|[a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4}'
@@ -284,12 +288,12 @@ if /usr/bin/grep -Eq \
     "$verifier_library" \
     "$transaction_library" \
     "$runbook"; then
-    fail "G43 publication controls contain unsafe tracing or credential-like material."
+    fail "G49 publication controls contain unsafe tracing or credential-like material."
 fi
 
 if [[ -n "$handoff" ]]; then
     [[ -d "$handoff" && ! -L "$handoff" ]] || \
-        fail "The private G43 publication handoff is unavailable."
+        fail "The private G49 publication handoff is unavailable."
     expected_handoff_entries="$(printf '%s\n' \
         candidate-release.json \
         candidate-tag.json \
@@ -302,7 +306,7 @@ if [[ -n "$handoff" ]]; then
             LC_ALL=C /usr/bin/sort
     })"
     [[ "$actual_handoff_entries" == "$expected_handoff_entries" ]] || \
-        fail "The private G43 handoff contains an unexpected top-level entry."
+        fail "The private G49 handoff contains an unexpected top-level entry."
     assert_v02_candidate_release_record \
         "$handoff/candidate-release.json" "$notes"
     assert_v02_candidate_tag_record "$handoff/candidate-tag.json"
@@ -346,7 +350,7 @@ if [[ -n "$handoff" ]]; then
             "final_tag"
         ]
     ' "$handoff/publication-manifest.json" >/dev/null || \
-        fail "The private G43 publication manifest differs from the reviewed contract."
+        fail "The private G49 publication manifest differs from the reviewed contract."
 fi
 
 echo "CopyLasso v0.2 publication audit passed."

--- a/scripts/audit-v02-release-qualification.sh
+++ b/scripts/audit-v02-release-qualification.sh
@@ -20,11 +20,13 @@ readonly approved_post_v02_security_patch_tree_pattern=$'\t(\\.github/workflows/
 readonly g46_product_patch_tree_pattern=$'\t(CHANGELOG\\.md|CopyLasso/App/CopyLassoApp\\.swift|CopyLasso/App/GlobalShortcutController\\.swift|CopyLasso/App/SystemGlobalShortcutEventSource\\.swift|CopyLasso/CaptureWorkflow/CaptureCommand\\.swift|CopyLasso/Models/SelectionGeometry\\.swift|CopyLasso/Services/AppKitRegionSelectionService\\.swift|CopyLasso/Services/InteractiveCaptureService\\.swift|CopyLasso/Services/RegionSelectionService\\.swift|CopyLasso/Services/ScreenCapturePermissionService\\.swift|CopyLasso/Services/SystemInteractiveCaptureService\\.swift|CopyLasso/Services/SystemScreenCapturePermissionClient\\.swift|CopyLasso/Services/SystemScreenCaptureService\\.swift|CopyLasso/SharedUI/AboutView\\.swift|CopyLasso/SharedUI/MenuBarMenuView\\.swift|CopyLasso/SharedUI/SettingsView\\.swift|CopyLassoTests/App/GlobalShortcutControllerTests\\.swift|CopyLassoTests/App/MenuBarShellTests\\.swift|CopyLassoTests/CaptureWorkflow/CaptureCommandTests\\.swift|CopyLassoTests/CaptureWorkflow/CapturePermissionFlowTests\\.swift|CopyLassoTests/CaptureWorkflow/CaptureWorkflowIntegrationTests\\.swift|CopyLassoTests/CaptureWorkflow/InteractiveCaptureWorkflowTests\\.swift|CopyLassoTests/Models/MultiDisplayBehaviorTests\\.swift|CopyLassoTests/Models/SelectionGeometryTests\\.swift|CopyLassoTests/Services/AppKitRegionSelectionServiceTests\\.swift|CopyLassoTests/Services/ScreenCapturePermissionServiceTests\\.swift|CopyLassoTests/Services/SystemInteractiveCaptureServiceTests\\.swift|CopyLassoTests/Services/SystemInteractiveSelectionTrackerTests\\.swift|CopyLassoTests/Services/SystemScreenCapturePermissionClientTests\\.swift|CopyLassoTests/Services/SystemScreenCaptureServiceTests\\.swift|CopyLassoTests/TestSupport/CaptureServiceDoubles\\.swift|CopyLassoTests/TestSupport/SettingsDoubles\\.swift|CopyLassoUITests/CopyLassoUITests\\.swift|PRIVACY\\.md|README\\.md|docs/architecture/ADR-002-screen-capture\\.md|docs/architecture/capture-workflow\\.md|docs/architecture/overview\\.md|docs/security-and-privacy-review\\.md|docs/testing\\.md|scripts/audit-g46-product-patch\\.sh|scripts/audit-privacy-security\\.sh|scripts/audit-v02-release-qualification\\.sh|scripts/ci\\.sh|scripts/test-ci-contract\\.sh)$'
 readonly g44_release_state_tree_pattern=$'\t(CHANGELOG\\.md|CONTRIBUTING\\.md|PRIVACY\\.md|README\\.md|SECURITY\\.md|docs/architecture/overview\\.md|docs/release-checklist\\.md|docs/release-workflow\\.md|docs/secure-update-operations\\.md|docs/security-and-privacy-review\\.md|docs/testing\\.md|docs/v0\\.2-product-contract\\.md|docs/v0\\.2-release-state\\.md|scripts/audit-brand-release\\.sh|scripts/audit-code-recognition\\.sh|scripts/audit-secure-update-architecture\\.sh|scripts/audit-v02-contract\\.sh|scripts/audit-v02-publication\\.sh|scripts/audit-v02-release-qualification\\.sh|scripts/audit-v02-release-state\\.sh|scripts/ci\\.sh|scripts/test-ci-contract\\.sh|scripts/test-release-metadata\\.sh)$'
 readonly g48_patch_tree_pattern=$'\t(\\.github/workflows/prepare-publication\\.yml|\\.github/workflows/release\\.yml|CHANGELOG\\.md|Configuration/ReleaseMetadata\\.xcconfig|PRIVACY\\.md|README\\.md|SECURITY\\.md|docs/architecture/build-configuration\\.md|docs/architecture/overview\\.md|docs/manual-qa-and-performance\\.md|docs/release-candidate-qualification\\.md|docs/release-checklist\\.md|docs/release-notes/0\\.2\\.1\\.md|docs/release-packaging\\.md|docs/release-workflow\\.md|docs/secure-update-operations\\.md|docs/security-and-privacy-review\\.md|docs/testing\\.md|docs/v0\\.2-product-contract\\.md|docs/v0\\.2\\.1-source-qualification\\.md|scripts/audit-brand-release\\.sh|scripts/audit-g48-patch-qualification\\.sh|scripts/audit-release-package\\.sh|scripts/audit-release-workflow\\.sh|scripts/audit-secure-update-architecture\\.sh|scripts/audit-v02-contract\\.sh|scripts/audit-v02-publication\\.sh|scripts/audit-v02-release-qualification\\.sh|scripts/audit-v02-release-state\\.sh|scripts/ci\\.sh|scripts/create-draft-release\\.sh|scripts/lib/release-package-verification\\.sh|scripts/lib/release-workflow-verification\\.sh|scripts/lib/v02-publication-verification\\.sh|scripts/test-ci-contract\\.sh|scripts/test-developer-id-release\\.sh|scripts/test-release-metadata\\.sh|scripts/test-release-package\\.sh|scripts/test-release-workflow\\.sh|scripts/test-v02-publication\\.sh|scripts/verify-release-package\\.sh|scripts/verify-v02-candidate-package\\.sh)$'
+readonly g49_publication_tree_pattern=$'\t(\\.github/workflows/prepare-publication\\.yml|docs/release-checklist\\.md|docs/release-workflow\\.md|docs/secure-update-operations\\.md|docs/v0\\.2-publication-runbook\\.md|scripts/audit-g48-patch-qualification\\.sh|scripts/audit-g49-publication\\.sh|scripts/audit-v02-publication\\.sh|scripts/audit-v02-release-qualification\\.sh|scripts/ci\\.sh|scripts/download-v02-candidate\\.sh|scripts/generate-release-appcast\\.sh|scripts/lib/release-package-verification\\.sh|scripts/lib/v020-release-package-metadata\\.sh|scripts/lib/v02-publication-transaction\\.sh|scripts/lib/v02-publication-verification\\.sh|scripts/prepare-update-feed\\.sh|scripts/test-ci-contract\\.sh|scripts/test-v02-publication\\.sh|scripts/verify-v02-candidate-package\\.sh)$'
+readonly g44_release_state_commit='295ea80bdc0d51579840ef9c2bfcad5278f87099'
 readonly expected_candidate_baseline_tree_digest='1e4844388bc872b8ac4644a13b00223af1239f431d390130346daa8e914aafa0'
 readonly expected_g48_baseline_tree_digest='e9ee74d177cbbfa5c1216f3104e231e294f593fc7f7e056937c04137ca1e7dc6'
 readonly expected_approved_post_publication_runtime_tree_digest='4269c2cc3177b938de424c53b42de94c63528f1a66ec79b97fea0de76ec095c0'
-readonly expected_g44_release_state_files_digest='1b052ac8d5c5ead190a0e9be230d4404faadb121c47688f6b1014808e08709a4'
-readonly expected_approved_post_candidate_patch_digest='773703c7aea2748341b622d0e42f5277fd43c3fe45841868a4fb60fe403d4a6d'
+readonly expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'
+readonly expected_approved_post_candidate_patch_digest='7f0497cdb8466fa6aadd7140903f39ced69d1f301ce205b3385c5ccfce5bdaef'
 
 fail() {
     echo "$1" >&2
@@ -58,7 +60,9 @@ approved_post_candidate_path() {
         printf '%s\n' "$tree_line" | \
             /usr/bin/grep -Eq "$g44_release_state_tree_pattern" || \
         printf '%s\n' "$tree_line" | \
-            /usr/bin/grep -Eq "$g48_patch_tree_pattern"
+            /usr/bin/grep -Eq "$g48_patch_tree_pattern" || \
+        printf '%s\n' "$tree_line" | \
+            /usr/bin/grep -Eq "$g49_publication_tree_pattern"
 }
 
 for required_file in \
@@ -251,6 +255,7 @@ current_baseline_tree_digest="$(
         /usr/bin/grep -Ev "$g46_product_patch_tree_pattern" |
         /usr/bin/grep -Ev "$g44_release_state_tree_pattern" |
         /usr/bin/grep -Ev "$g48_patch_tree_pattern" |
+        /usr/bin/grep -Ev "$g49_publication_tree_pattern" |
         /usr/bin/shasum -a 256 |
         /usr/bin/awk '{print $1}'
 )"
@@ -290,9 +295,11 @@ readonly g44_release_state_files=(
 )
 g44_release_state_files_digest="$(
     for relative_path in "${g44_release_state_files[@]}"; do
-        [[ -f "$repository_root/$relative_path" ]] || \
+        git -C "$repository_root" cat-file -e \
+            "$g44_release_state_commit:$relative_path" 2>/dev/null || \
             fail "The approved G44 release-state file is missing: $relative_path"
-        file_digest="$(/usr/bin/shasum -a 256 "$repository_root/$relative_path" | \
+        file_digest="$(git -C "$repository_root" show \
+            "$g44_release_state_commit:$relative_path" | /usr/bin/shasum -a 256 | \
             /usr/bin/awk '{print $1}')"
         /usr/bin/printf '%s\t%s\n' "$relative_path" "$file_digest"
     done | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -101,6 +101,9 @@ echo "Auditing the G46 product patch"
 echo "Auditing the G48 patch qualification"
 ./scripts/audit-g48-patch-qualification.sh
 
+echo "Auditing G49 publication controls"
+./scripts/audit-g49-publication.sh
+
 echo "Auditing on-screen code recognition"
 ./scripts/audit-code-recognition.sh
 

--- a/scripts/create-v02-publication-draft.sh
+++ b/scripts/create-v02-publication-draft.sh
@@ -13,7 +13,7 @@ usage() {
     cat >&2 <<'TEXT'
 Usage: create-v02-publication-draft.sh \
   --repository bennetthilberg/copylasso \
-  --candidate-dir /path/to/downloaded/G42/assets \
+  --candidate-dir /path/to/downloaded/G48/assets \
   --readback /path/to/final-draft.json
 TEXT
     exit 64
@@ -65,4 +65,4 @@ create_v02_publication_draft_transaction \
     "$gh_binary" \
     assert_v02_publication_draft_record
 
-echo "Private final v0.2 publication draft created and verified."
+echo "Private final v0.2.1 publication draft created and verified."

--- a/scripts/download-v02-candidate.sh
+++ b/scripts/download-v02-candidate.sh
@@ -90,7 +90,7 @@ trap cleanup EXIT
 if ! "$gh_binary" api \
     "repos/$repository/releases/$COPYLASSO_V02_CANDIDATE_RELEASE_ID" \
     > "$release_record"; then
-    v02_publication_fail "The approved private G42 release could not be read."
+    v02_publication_fail "The approved private G48 release could not be read."
 fi
 assert_v02_candidate_release_record \
     "$release_record" \
@@ -98,7 +98,7 @@ assert_v02_candidate_release_record \
 if ! "$gh_binary" api \
     "repos/$repository/git/ref/tags/$COPYLASSO_V02_CANDIDATE_TAG" \
     > "$tag_record"; then
-    v02_publication_fail "The approved G42 candidate tag could not be read."
+    v02_publication_fail "The approved G48 candidate tag could not be read."
 fi
 assert_v02_candidate_tag_record "$tag_record"
 
@@ -133,4 +133,4 @@ committed="true"
 cleanup
 trap - EXIT
 
-echo "Approved G42 candidate downloaded and verified."
+echo "Approved G48 candidate downloaded and verified."

--- a/scripts/generate-release-appcast.sh
+++ b/scripts/generate-release-appcast.sh
@@ -11,8 +11,8 @@ usage() {
     cat >&2 <<'TEXT'
 Usage: generate-release-appcast.sh \
   --application /path/to/CopyLasso.app \
-  --candidate-dir /path/to/downloaded/G42/assets \
-  --release-notes /path/to/0.2.0.md \
+  --candidate-dir /path/to/downloaded/G48/assets \
+  --release-notes /path/to/0.2.1.md \
   --output /path/to/appcast.xml \
   --sparkle-tools-dir /path/to/Sparkle/bin
 TEXT
@@ -115,7 +115,7 @@ readonly sign_update="$tools_directory/sign_update"
     v02_publication_fail "The reviewed Sparkle signing tools are unavailable."
 
 readonly temporary_directory="$(/usr/bin/mktemp -d \
-    "${TMPDIR:-/private/tmp}/copylasso-g43-appcast.XXXXXX")"
+    "${TMPDIR:-/private/tmp}/copylasso-g49-appcast.XXXXXX")"
 cleanup() {
     /bin/rm -rf "$temporary_directory"
 }
@@ -190,4 +190,4 @@ fi
 cleanup
 trap - EXIT
 
-echo "Authenticated public v0.2 update metadata created and verified."
+echo "Authenticated public v0.2.1 update metadata created and verified."

--- a/scripts/lib/release-package-verification.sh
+++ b/scripts/lib/release-package-verification.sh
@@ -11,8 +11,8 @@ case "${COPYLASSO_RELEASE_PACKAGE_METADATA_PROFILE:-current}" in
         source "$release_package_verification_library_root/scripts/lib/release-metadata.sh"
         ;;
     v0.2.0)
-        # shellcheck source=scripts/lib/v02-publication-verification.sh
-        source "$release_package_verification_library_root/scripts/lib/v02-publication-verification.sh"
+        # shellcheck source=scripts/lib/v020-release-package-metadata.sh
+        source "$release_package_verification_library_root/scripts/lib/v020-release-package-metadata.sh"
         ;;
     *)
         echo "The release-package metadata profile is invalid." >&2

--- a/scripts/lib/v02-publication-transaction.sh
+++ b/scripts/lib/v02-publication-transaction.sh
@@ -28,32 +28,32 @@ create_v02_publication_draft_transaction() (
     local upload_succeeded
 
     publication_transaction_directory="$(/usr/bin/mktemp -d \
-        "${TMPDIR:-/private/tmp}/copylasso-g43-draft.XXXXXX")"
+        "${TMPDIR:-/private/tmp}/copylasso-g49-draft.XXXXXX")"
     creation_record="$publication_transaction_directory/created.json"
     release_listing="$publication_transaction_directory/releases.json"
     latest_release_record="$publication_transaction_directory/latest-release.json"
     final_release_lookup="$publication_transaction_directory/final-release-lookup.txt"
     final_tag_lookup="$publication_transaction_directory/final-tag-lookup.txt"
     final_record="$publication_transaction_directory/final.json"
-    COPYLASSO_G43_TRANSACTION_REPOSITORY="$repository"
-    COPYLASSO_G43_TRANSACTION_GH_BINARY="$transaction_gh_binary"
-    COPYLASSO_G43_TRANSACTION_DIRECTORY="$publication_transaction_directory"
-    COPYLASSO_G43_TRANSACTION_RELEASE_IDENTIFIER=""
-    COPYLASSO_G43_TRANSACTION_COMMITTED="false"
-    COPYLASSO_G43_TRANSACTION_OWNS_DRAFT="false"
+    COPYLASSO_G49_TRANSACTION_REPOSITORY="$repository"
+    COPYLASSO_G49_TRANSACTION_GH_BINARY="$transaction_gh_binary"
+    COPYLASSO_G49_TRANSACTION_DIRECTORY="$publication_transaction_directory"
+    COPYLASSO_G49_TRANSACTION_RELEASE_IDENTIFIER=""
+    COPYLASSO_G49_TRANSACTION_COMMITTED="false"
+    COPYLASSO_G49_TRANSACTION_OWNS_DRAFT="false"
 
     cleanup_v02_publication_draft_transaction() {
-        if [[ -n "$COPYLASSO_G43_TRANSACTION_RELEASE_IDENTIFIER" &&
-            "$COPYLASSO_G43_TRANSACTION_COMMITTED" != "true" &&
-            "$COPYLASSO_G43_TRANSACTION_OWNS_DRAFT" == "true" ]]; then
+        if [[ -n "$COPYLASSO_G49_TRANSACTION_RELEASE_IDENTIFIER" &&
+            "$COPYLASSO_G49_TRANSACTION_COMMITTED" != "true" &&
+            "$COPYLASSO_G49_TRANSACTION_OWNS_DRAFT" == "true" ]]; then
             local release_path
-            release_path="repos/$COPYLASSO_G43_TRANSACTION_REPOSITORY/releases/$COPYLASSO_G43_TRANSACTION_RELEASE_IDENTIFIER"
-            "$COPYLASSO_G43_TRANSACTION_GH_BINARY" api \
+            release_path="repos/$COPYLASSO_G49_TRANSACTION_REPOSITORY/releases/$COPYLASSO_G49_TRANSACTION_RELEASE_IDENTIFIER"
+            "$COPYLASSO_G49_TRANSACTION_GH_BINARY" api \
                 --method DELETE \
                 "$release_path" \
                 >/dev/null 2>&1 || true
         fi
-        /bin/rm -rf "$COPYLASSO_G43_TRANSACTION_DIRECTORY"
+        /bin/rm -rf "$COPYLASSO_G49_TRANSACTION_DIRECTORY"
     }
     trap cleanup_v02_publication_draft_transaction EXIT
 
@@ -62,7 +62,7 @@ create_v02_publication_draft_transaction() (
             --paginate \
             --slurp \
             "repos/$repository/releases?per_page=100" > "$release_listing"; then
-            v02_publication_fail "Existing releases could not be checked before G43 mutation."
+            v02_publication_fail "Existing releases could not be checked before G49 mutation."
         fi
         /usr/bin/jq -e '
             type == "array" and all(.[]; type == "array")
@@ -143,14 +143,14 @@ create_v02_publication_draft_transaction() (
                 "The final v0.2 draft could not be created or identified through exact readback."
         fi
     else
-        COPYLASSO_G43_TRANSACTION_OWNS_DRAFT="true"
+        COPYLASSO_G49_TRANSACTION_OWNS_DRAFT="true"
     fi
 
     release_identifier="$(/usr/bin/jq -er '
         if (.id | type) == "number" and .id > 0 then .id else error("invalid id") end
     ' "$creation_record" 2>/dev/null)" || \
         v02_publication_fail "The final v0.2 draft has no valid identifier."
-    COPYLASSO_G43_TRANSACTION_RELEASE_IDENTIFIER="$release_identifier"
+    COPYLASSO_G49_TRANSACTION_RELEASE_IDENTIFIER="$release_identifier"
     assert_v02_publication_release_identity \
         "$creation_record" "$transaction_release_notes" true false
     [[ "$(/usr/bin/jq -er '.assets | length' \
@@ -179,7 +179,7 @@ create_v02_publication_draft_transaction() (
     /bin/cp "$final_record" "$readback"
     /bin/chmod 600 "$readback"
     draft_committed="true"
-    COPYLASSO_G43_TRANSACTION_COMMITTED="$draft_committed"
+    COPYLASSO_G49_TRANSACTION_COMMITTED="$draft_committed"
     cleanup_v02_publication_draft_transaction
     trap - EXIT
 )

--- a/scripts/lib/v02-publication-verification.sh
+++ b/scripts/lib/v02-publication-verification.sh
@@ -9,30 +9,30 @@ readonly copylasso_v02_publication_root="$(
     cd "$(dirname "${BASH_SOURCE[0]}")/../.." && /bin/pwd -P
 )"
 readonly COPYLASSO_V02_REPOSITORY="bennetthilberg/copylasso"
-readonly COPYLASSO_RELEASE_VERSION="0.2.0"
-readonly COPYLASSO_RELEASE_BUILD="3"
-readonly COPYLASSO_RELEASE_DMG="CopyLasso-0.2.0.dmg"
-readonly COPYLASSO_RELEASE_CHECKSUM="CopyLasso-0.2.0.dmg.sha256"
-readonly COPYLASSO_RELEASE_DSYM="CopyLasso-0.2.0.dSYM.zip"
-readonly COPYLASSO_RELEASE_VERIFICATION="CopyLasso-0.2.0-verification.zip"
-readonly COPYLASSO_RELEASE_APPCAST="CopyLasso-0.2.0-appcast.xml"
-readonly COPYLASSO_V02_CANDIDATE_COMMIT="43f1d0c676b08fb24b49fc628213fede90c4ed9d"
-readonly COPYLASSO_V02_CANDIDATE_RELEASE_ID="361203156"
-readonly COPYLASSO_V02_CANDIDATE_TAG="v0.2.0-rc.1"
-readonly COPYLASSO_V02_FINAL_TAG="v0.2.0"
-readonly COPYLASSO_V02_PREVIOUS_PUBLIC_TAG="v0.1.1"
-readonly COPYLASSO_V02_FINAL_TAG_MESSAGE="CopyLasso 0.2.0"
-readonly COPYLASSO_V02_RELEASE_NAME="CopyLasso 0.2.0"
-readonly COPYLASSO_V02_NOTES_SHA256="0b40f9524389b684124189ce743109429af97baf124e28bf1d12313eba26d807"
-readonly COPYLASSO_V02_CANDIDATE_APPCAST_SHA256="a80260d6cd501ffee65ec41cbe1a232b9de662a9b41b4d78a0cd9b361bfe9fe6"
-readonly COPYLASSO_V02_DMG_SIZE="3665931"
-readonly COPYLASSO_V02_DMG_SHA256="697cb008cf294b32500e2ad84e5777a51fe8b88916856c5a8e9f1ec4eb74ba19"
+readonly COPYLASSO_RELEASE_VERSION="0.2.1"
+readonly COPYLASSO_RELEASE_BUILD="4"
+readonly COPYLASSO_RELEASE_DMG="CopyLasso-0.2.1.dmg"
+readonly COPYLASSO_RELEASE_CHECKSUM="CopyLasso-0.2.1.dmg.sha256"
+readonly COPYLASSO_RELEASE_DSYM="CopyLasso-0.2.1.dSYM.zip"
+readonly COPYLASSO_RELEASE_VERIFICATION="CopyLasso-0.2.1-verification.zip"
+readonly COPYLASSO_RELEASE_APPCAST="CopyLasso-0.2.1-appcast.xml"
+readonly COPYLASSO_V02_CANDIDATE_COMMIT="813de17c739097217aad55a5a35c04ea3c73d99f"
+readonly COPYLASSO_V02_CANDIDATE_RELEASE_ID="367523470"
+readonly COPYLASSO_V02_CANDIDATE_TAG="v0.2.1-rc.1"
+readonly COPYLASSO_V02_FINAL_TAG="v0.2.1"
+readonly COPYLASSO_V02_PREVIOUS_PUBLIC_TAG="v0.2.0"
+readonly COPYLASSO_V02_FINAL_TAG_MESSAGE="CopyLasso 0.2.1"
+readonly COPYLASSO_V02_RELEASE_NAME="CopyLasso 0.2.1"
+readonly COPYLASSO_V02_NOTES_SHA256="24dd1c6c235ba0e0d0bf433e07d6b1ddd5a8c2425fa368a4fa16926eb016b503"
+readonly COPYLASSO_V02_CANDIDATE_APPCAST_SHA256="ef48b25ed3527416ba2242cae4bf3975b3c61d21790e24e0b31669a1082bf779"
+readonly COPYLASSO_V02_DMG_SIZE="3737908"
+readonly COPYLASSO_V02_DMG_SHA256="05180caa3600bcd282246297a9172517136e43e55c6e8fa192b55ba44af4a017"
 readonly COPYLASSO_V02_CHECKSUM_SIZE="86"
-readonly COPYLASSO_V02_CHECKSUM_SHA256="6dfd44d92f6af1c14d765bc6c827ed3e9a0edd5ffe289c3e74ac6e1dd0c834b0"
-readonly COPYLASSO_V02_DSYM_SIZE="6094121"
-readonly COPYLASSO_V02_DSYM_SHA256="b644da8776f857c1f42a95f903b315b7dde418000d173b48829c5ee346bc4754"
-readonly COPYLASSO_V02_VERIFICATION_SIZE="3708469"
-readonly COPYLASSO_V02_VERIFICATION_SHA256="e4d424bdd9675b00ffa647bccdc3f3bc47b43b4d041535c0898f79cf79e3a073"
+readonly COPYLASSO_V02_CHECKSUM_SHA256="b9a85f82686dce479cb41247fe9fc025ec8a0d099bbc08028c4239899359b1c9"
+readonly COPYLASSO_V02_DSYM_SIZE="6315506"
+readonly COPYLASSO_V02_DSYM_SHA256="0301eecaccb9fac76c1e25d2ae1db2edc99ff42febe55bfcf6f07ef4ffcbd368"
+readonly COPYLASSO_V02_VERIFICATION_SIZE="3771716"
+readonly COPYLASSO_V02_VERIFICATION_SHA256="689aad0296e90b9aab83e198eaef0524da907d1742fbeab8078bddc823a1b108"
 readonly COPYLASSO_V02_PUBLIC_APPCAST_NAME="appcast.xml"
 readonly COPYLASSO_V02_FEED_HOST="updates.copylasso.com"
 readonly COPYLASSO_V02_FEED_URL="https://$COPYLASSO_V02_FEED_HOST/$COPYLASSO_V02_PUBLIC_APPCAST_NAME"
@@ -47,14 +47,14 @@ assert_v02_repository() {
     local repository="$1"
 
     [[ "$repository" == "$COPYLASSO_V02_REPOSITORY" ]] || \
-        v02_publication_fail "G43 may operate only on the reviewed CopyLasso repository."
+        v02_publication_fail "G49 may operate only on the reviewed CopyLasso repository."
 }
 
 assert_v02_candidate_commit() {
     local commit="$1"
 
     [[ "$commit" == "$COPYLASSO_V02_CANDIDATE_COMMIT" ]] || \
-        v02_publication_fail "G43 may publish only the approved G42 source commit."
+        v02_publication_fail "G49 may publish only the approved G48 source commit."
 }
 
 assert_v02_final_tag() {
@@ -129,9 +129,9 @@ assert_v02_candidate_release_record() {
     local actual_body
 
     [[ -f "$record" && ! -L "$record" ]] || \
-        v02_publication_fail "The private G42 release readback is unavailable."
+        v02_publication_fail "The private G48 release readback is unavailable."
     /usr/bin/jq -e . "$record" >/dev/null 2>&1 || \
-        v02_publication_fail "The private G42 release readback is invalid."
+        v02_publication_fail "The private G48 release readback is invalid."
     assert_v02_release_notes "$v02_release_notes_file"
 
     /usr/bin/jq -e \
@@ -145,12 +145,12 @@ assert_v02_candidate_release_record() {
         and .tag_name == $tag
         and .target_commitish == $commit
     ' "$record" >/dev/null 2>&1 || \
-        v02_publication_fail "The private G42 release identity or state is invalid."
+        v02_publication_fail "The private G48 release identity or state is invalid."
 
     expected_body="$(/bin/cat "$v02_release_notes_file")"
     actual_body="$(/usr/bin/jq -er '.body' "$record" 2>/dev/null || true)"
     [[ "$actual_body" == "$expected_body" ]] || \
-        v02_publication_fail "The private G42 release notes differ from the approved source."
+        v02_publication_fail "The private G48 release notes differ from the approved source."
 
     expected_assets="$(printf '%s\n' \
         "$COPYLASSO_RELEASE_DMG" \
@@ -159,7 +159,7 @@ assert_v02_candidate_release_record() {
         "$COPYLASSO_RELEASE_VERIFICATION" | LC_ALL=C /usr/bin/sort)"
     actual_assets="$(v02_release_asset_names "$record" 2>/dev/null || true)"
     [[ "$actual_assets" == "$expected_assets" ]] || \
-        v02_publication_fail "The private G42 release has an unexpected asset set."
+        v02_publication_fail "The private G48 release has an unexpected asset set."
 
     assert_v02_asset_record \
         "$record" "$COPYLASSO_RELEASE_DMG" \
@@ -183,7 +183,7 @@ assert_v02_candidate_files() {
     local actual_checksum
 
     [[ -d "$directory" && ! -L "$directory" ]] || \
-        v02_publication_fail "The downloaded G42 candidate directory is unavailable."
+        v02_publication_fail "The downloaded G48 candidate directory is unavailable."
     expected_names="$(printf '%s\n' \
         "$COPYLASSO_RELEASE_DMG" \
         "$COPYLASSO_RELEASE_CHECKSUM" \
@@ -198,7 +198,7 @@ assert_v02_candidate_files() {
             done | LC_ALL=C /usr/bin/sort
     })"
     [[ "$actual_names" == "$expected_names" ]] || \
-        v02_publication_fail "The downloaded G42 candidate has an unexpected file set."
+        v02_publication_fail "The downloaded G48 candidate has an unexpected file set."
 
     assert_v02_exact_file \
         "$directory/$COPYLASSO_RELEASE_DMG" \
@@ -317,7 +317,7 @@ assert_v02_candidate_tag_record() {
     local record="$1"
 
     [[ -f "$record" && ! -L "$record" ]] || \
-        v02_publication_fail "The G42 candidate tag readback is unavailable."
+        v02_publication_fail "The G48 candidate tag readback is unavailable."
     /usr/bin/jq -e \
         --arg ref "refs/tags/$COPYLASSO_V02_CANDIDATE_TAG" \
         --arg commit "$COPYLASSO_V02_CANDIDATE_COMMIT" '
@@ -325,7 +325,7 @@ assert_v02_candidate_tag_record() {
         and .object.type == "commit"
         and .object.sha == $commit
     ' "$record" >/dev/null 2>&1 || \
-        v02_publication_fail "The G42 candidate tag no longer identifies the approved source commit."
+        v02_publication_fail "The G48 candidate tag no longer identifies the approved source commit."
 }
 
 assert_v02_prepublication_latest_record() {
@@ -341,7 +341,7 @@ assert_v02_prepublication_latest_record() {
         and (.published_at | type) == "string"
         and (.published_at | length) > 0
     ' "$record" >/dev/null 2>&1 || \
-        v02_publication_fail "CopyLasso v0.1.1 is no longer the latest public release."
+        v02_publication_fail "CopyLasso v0.2.0 is no longer the latest public release."
 }
 
 assert_v02_final_tag_ref_record() {
@@ -386,7 +386,7 @@ assert_v02_latest_release_record() {
     release_id="$(/usr/bin/jq -er '.id' "$release_record" 2>/dev/null || true)"
     latest_id="$(/usr/bin/jq -er '.id' "$latest_record" 2>/dev/null || true)"
     [[ "$release_id" =~ ^[1-9][0-9]*$ && "$latest_id" == "$release_id" ]] || \
-        v02_publication_fail "CopyLasso v0.2.0 is not GitHub's latest public release."
+        v02_publication_fail "CopyLasso v0.2.1 is not GitHub's latest public release."
 }
 
 assert_v02_appcast_contract() {
@@ -489,7 +489,7 @@ assert_v02_sparkle_signatures() {
         local verifier
 
         sparkle_verification_directory="$(/usr/bin/mktemp -d \
-            "${TMPDIR:-/private/tmp}/copylasso-g43-sparkle-verification.XXXXXX")"
+            "${TMPDIR:-/private/tmp}/copylasso-g49-sparkle-verification.XXXXXX")"
         trap '/bin/rm -rf "$sparkle_verification_directory"' EXIT
         verifier="$sparkle_verification_directory/verify-sparkle-signatures"
         /usr/bin/xcrun swiftc \

--- a/scripts/lib/v020-release-package-metadata.sh
+++ b/scripts/lib/v020-release-package-metadata.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ "${COPYLASSO_V020_RELEASE_PACKAGE_METADATA_LOADED:-}" == "1" ]]; then
+    return 0
+fi
+
+readonly COPYLASSO_V020_RELEASE_PACKAGE_METADATA_LOADED=1
+readonly COPYLASSO_RELEASE_VERSION="0.2.0"
+readonly COPYLASSO_RELEASE_BUILD="3"
+readonly COPYLASSO_RELEASE_DMG="CopyLasso-0.2.0.dmg"
+readonly COPYLASSO_RELEASE_CHECKSUM="CopyLasso-0.2.0.dmg.sha256"
+readonly COPYLASSO_RELEASE_DSYM="CopyLasso-0.2.0.dSYM.zip"
+readonly COPYLASSO_RELEASE_VERIFICATION="CopyLasso-0.2.0-verification.zip"
+readonly COPYLASSO_RELEASE_APPCAST="CopyLasso-0.2.0-appcast.xml"

--- a/scripts/prepare-update-feed.sh
+++ b/scripts/prepare-update-feed.sh
@@ -11,7 +11,7 @@ usage() {
     cat >&2 <<'TEXT'
 Usage: prepare-update-feed.sh \
   --appcast /path/to/appcast.xml \
-  --release-notes /path/to/0.2.0.md \
+  --release-notes /path/to/0.2.1.md \
   --output-dir /path/to/new-feed-directory
 TEXT
     exit 64

--- a/scripts/test-ci-contract.sh
+++ b/scripts/test-ci-contract.sh
@@ -18,6 +18,7 @@ readonly v02_publication_audit_script="$repository_root/scripts/audit-v02-public
 readonly v02_release_state_audit_script="$repository_root/scripts/audit-v02-release-state.sh"
 readonly g46_product_patch_audit_script="$repository_root/scripts/audit-g46-product-patch.sh"
 readonly g48_patch_qualification_audit_script="$repository_root/scripts/audit-g48-patch-qualification.sh"
+readonly g49_publication_audit_script="$repository_root/scripts/audit-g49-publication.sh"
 readonly v02_publication_test_script="$repository_root/scripts/test-v02-publication.sh"
 readonly code_recognition_audit_script="$repository_root/scripts/audit-code-recognition.sh"
 readonly latex_feasibility_audit_script="$repository_root/scripts/audit-latex-feasibility.sh"
@@ -198,8 +199,8 @@ for required_patch_guard in \
     "expected_candidate_baseline_tree_digest='1e4844388bc872b8ac4644a13b00223af1239f431d390130346daa8e914aafa0'" \
     "expected_g48_baseline_tree_digest='e9ee74d177cbbfa5c1216f3104e231e294f593fc7f7e056937c04137ca1e7dc6'" \
     "expected_approved_post_publication_runtime_tree_digest='4269c2cc3177b938de424c53b42de94c63528f1a66ec79b97fea0de76ec095c0'" \
-    "expected_g44_release_state_files_digest='1b052ac8d5c5ead190a0e9be230d4404faadb121c47688f6b1014808e08709a4'" \
-    "expected_approved_post_candidate_patch_digest='773703c7aea2748341b622d0e42f5277fd43c3fe45841868a4fb60fe403d4a6d'" \
+    "expected_g44_release_state_files_digest='8fefcac6d46e3ec19d11786ab3d5836c3c34fc476a1cad31efbfacc95d977039'" \
+    "expected_approved_post_candidate_patch_digest='7f0497cdb8466fa6aadd7140903f39ced69d1f301ce205b3385c5ccfce5bdaef'" \
     'cat-file -e "$candidate_source_commit^{tree}"' \
     'The qualified candidate commit is unavailable.' \
     '"$current_baseline_tree_digest" == "$expected_g48_baseline_tree_digest"' \
@@ -272,11 +273,29 @@ g48_patch_qualification_audit_invocations="$({
 if [[ "$g48_patch_qualification_audit_invocations" != "1" ]]; then
     fail "Canonical CI must invoke scripts/audit-g48-patch-qualification.sh exactly once."
 fi
+g49_publication_audit_invocations="$({
+    /usr/bin/grep -Ec \
+        '^[[:space:]]*\./scripts/audit-g49-publication\.sh[[:space:]]*$' \
+        "$ci_script" || true
+})"
+if [[ "$g49_publication_audit_invocations" != "1" ]]; then
+    fail "Canonical CI must invoke scripts/audit-g49-publication.sh exactly once."
+fi
+for required_g49_guard in \
+    '0.2.1' \
+    'copylasso_prepare_publication' \
+    '813de17c739097217aad55a5a35c04ea3c73d99f' \
+    'Phase 1 must not publish'; do
+    if ! /usr/bin/grep -Fq -- "$required_g49_guard" \
+        "$g49_publication_audit_script"; then
+        fail "The G49 audit is missing its publication guard: $required_g49_guard"
+    fi
+done
 for required_g48_guard in \
     '0\.2\.1' \
     'release_goal=G48' \
     'No processing indicator is included.' \
-    'COPYLASSO_V02_FINAL_TAG="v0.2.0"'; do
+    'COPYLASSO_V02_FINAL_TAG="v0.2.1"'; do
     if ! /usr/bin/grep -Fq -- "$required_g48_guard" \
         "$g48_patch_qualification_audit_script"; then
         fail "The G48 audit is missing its patch-qualification guard: $required_g48_guard"

--- a/scripts/test-v02-publication.sh
+++ b/scripts/test-v02-publication.sh
@@ -29,7 +29,7 @@ for executable in \
     "$feed_preparer" \
     "$audit_script"; do
     [[ -x "$executable" ]] || \
-        fail "G43 publication executable is missing: $(/usr/bin/basename "$executable")"
+        fail "G49 publication executable is missing: $(/usr/bin/basename "$executable")"
 done
 
 for readable in \
@@ -40,7 +40,7 @@ for readable in \
     "$generic_package_verifier" \
     "$runbook"; do
     [[ -r "$readable" ]] || \
-        fail "G43 publication contract file is missing: $(/usr/bin/basename "$readable")"
+        fail "G49 publication contract file is missing: $(/usr/bin/basename "$readable")"
 done
 
 # shellcheck source=scripts/lib/v02-publication-verification.sh
@@ -48,25 +48,24 @@ source "$verifier_library"
 # shellcheck source=scripts/lib/v02-publication-transaction.sh
 source "$transaction_library"
 
-[[ "$COPYLASSO_RELEASE_APPCAST" == "CopyLasso-0.2.0-appcast.xml" ]] || \
-    fail "The historical v0.2 verifier must pin its restricted appcast filename."
+[[ "$COPYLASSO_RELEASE_APPCAST" == "CopyLasso-0.2.1-appcast.xml" ]] || \
+    fail "The G49 verifier must pin the approved restricted appcast filename."
 
 feed_step="$(/usr/bin/sed -n \
     '/- name: Prepare feed-only deployment bundle/,/- name: Create verified private final draft/p' \
     "$workflow")"
 [[ "$feed_step" == *'source ./scripts/lib/v02-publication-verification.sh'* ]] || \
-    fail "The G43 feed step must load pinned v0.2 publication metadata."
+    fail "The G49 feed step must load pinned v0.2.1 publication metadata."
 [[ "$feed_step" != *'source ./scripts/lib/release-metadata.sh'* ]] || \
-    fail "The G43 feed step must not load current release metadata."
+    fail "The G49 feed step must not load mutable current release metadata."
 [[ "$feed_step" == *'--release-notes "docs/release-notes/$COPYLASSO_RELEASE_VERSION.md"'* ]] || \
-    fail "The G43 feed step must derive notes from the pinned v0.2 version."
+    fail "The G49 feed step must derive notes from the pinned v0.2.1 version."
 
-require_pinned_package_flag() {
-    /usr/bin/grep -Fq -- '--pinned-v02-metadata' "$1" || \
-        fail "The historical package path must request explicit pinned v0.2 metadata: $1"
-}
-require_pinned_package_flag "$package_verifier"
-require_pinned_package_flag "$generic_package_verifier"
+if /usr/bin/grep -Fq -- '--pinned-v02-metadata' "$package_verifier"; then
+    fail "G49 package verification must use current 0.2.1 release metadata."
+fi
+/usr/bin/grep -Fq -- '--pinned-v02-metadata' "$generic_package_verifier" || \
+    fail "The generic verifier must retain explicit historical v0.2.0 support."
 
 pinned_package_metadata="$(
     COPYLASSO_RELEASE_PACKAGE_METADATA_PROFILE=v0.2.0 \
@@ -97,20 +96,20 @@ expect_failure() {
     fi
 }
 
-readonly release_notes_path="$repository_root/docs/release-notes/0.2.0.md"
+readonly release_notes_path="$repository_root/docs/release-notes/0.2.1.md"
 assert_v02_repository "bennetthilberg/copylasso"
 expect_failure "only on the reviewed CopyLasso repository" \
     assert_v02_repository "other/repository"
 assert_v02_candidate_commit "$COPYLASSO_V02_CANDIDATE_COMMIT"
-expect_failure "only the approved G42 source commit" \
+expect_failure "only the approved G48 source commit" \
     assert_v02_candidate_commit "0123456789abcdef0123456789abcdef01234567"
-assert_v02_final_tag "v0.2.0"
+assert_v02_final_tag "v0.2.1"
 expect_failure "final v0.2 release tag is invalid" \
-    assert_v02_final_tag "v0.2.0-rc.1"
+    assert_v02_final_tag "v0.2.1-rc.1"
 assert_v02_release_notes "$release_notes_path"
 
 readonly temporary_directory="$(/usr/bin/mktemp -d \
-    "${TMPDIR:-/private/tmp}/copylasso-g43-tests.XXXXXX")"
+    "${TMPDIR:-/private/tmp}/copylasso-g49-tests.XXXXXX")"
 trap '/bin/rm -rf "$temporary_directory"' EXIT
 readonly candidate_record="$temporary_directory/candidate.json"
 /usr/bin/jq -n \
@@ -137,28 +136,28 @@ readonly candidate_record="$temporary_directory/candidate.json"
       assets: [
         {
           id: 1,
-          name: "CopyLasso-0.2.0.dmg",
+          name: "CopyLasso-0.2.1.dmg",
           size: $dmg_size,
           digest: $dmg_digest,
           state: "uploaded"
         },
         {
           id: 2,
-          name: "CopyLasso-0.2.0.dmg.sha256",
+          name: "CopyLasso-0.2.1.dmg.sha256",
           size: $checksum_size,
           digest: $checksum_digest,
           state: "uploaded"
         },
         {
           id: 3,
-          name: "CopyLasso-0.2.0.dSYM.zip",
+          name: "CopyLasso-0.2.1.dSYM.zip",
           size: $dsym_size,
           digest: $dsym_digest,
           state: "uploaded"
         },
         {
           id: 4,
-          name: "CopyLasso-0.2.0-verification.zip",
+          name: "CopyLasso-0.2.1-verification.zip",
           size: $verification_size,
           digest: $verification_digest,
           state: "uploaded"
@@ -174,7 +173,7 @@ expect_failure "identity or state is invalid" \
     assert_v02_candidate_release_record \
     "$temporary_directory/published-candidate.json" "$release_notes_path"
 /usr/bin/jq \
-    '(.assets[] | select(.name == "CopyLasso-0.2.0.dmg") | .digest) =
+    '(.assets[] | select(.name == "CopyLasso-0.2.1.dmg") | .digest) =
       "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' \
     "$candidate_record" > "$temporary_directory/mutated-candidate.json"
 expect_failure "differs from the approved bytes" \
@@ -208,14 +207,14 @@ readonly public_draft="$temporary_directory/public-draft.json"
       assets: [
         {
           id: 10,
-          name: "CopyLasso-0.2.0.dmg",
+          name: "CopyLasso-0.2.1.dmg",
           size: $dmg_size,
           digest: $dmg_digest,
           state: "uploaded"
         },
         {
           id: 11,
-          name: "CopyLasso-0.2.0.dmg.sha256",
+          name: "CopyLasso-0.2.1.dmg.sha256",
           size: $checksum_size,
           digest: $checksum_digest,
           state: "uploaded"
@@ -236,7 +235,7 @@ expect_failure "identity or state is invalid" \
     "$temporary_directory/prerelease-draft.json" "$release_notes_path"
 /usr/bin/jq '.assets += [{
     id: 12,
-    name: "CopyLasso-0.2.0.dSYM.zip",
+    name: "CopyLasso-0.2.1.dSYM.zip",
     size: 1,
     digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     state: "uploaded"
@@ -269,7 +268,7 @@ readonly previous_public_release="$temporary_directory/previous-public-release.j
     }
 ' > "$previous_public_release"
 assert_v02_prepublication_latest_record "$previous_public_release"
-/usr/bin/jq '.tag_name = "v0.1.0"' "$previous_public_release" > \
+/usr/bin/jq '.tag_name = "v0.1.1"' "$previous_public_release" > \
     "$temporary_directory/wrong-latest-release.json"
 expect_failure "no longer the latest public release" \
     assert_v02_prepublication_latest_record \
@@ -494,10 +493,10 @@ assert_fixture_draft_record() {
         .id == 900
         and .draft == true
         and .prerelease == false
-        and .tag_name == "v0.2.0"
+        and .tag_name == "v0.2.1"
         and (.assets | map(.name) | sort) == [
-          "CopyLasso-0.2.0.dmg",
-          "CopyLasso-0.2.0.dmg.sha256"
+          "CopyLasso-0.2.1.dmg",
+          "CopyLasso-0.2.1.dmg.sha256"
         ]
     ' "$record" >/dev/null 2>&1
 }

--- a/scripts/verify-v02-candidate-package.sh
+++ b/scripts/verify-v02-candidate-package.sh
@@ -10,7 +10,7 @@ source "$repository_root/scripts/lib/v02-publication-verification.sh"
 usage() {
     cat >&2 <<'TEXT'
 Usage: verify-v02-candidate-package.sh \
-  --candidate-dir /path/to/downloaded/G42/assets \
+  --candidate-dir /path/to/downloaded/G48/assets \
   --work-dir /path/to/new-verification-directory
 TEXT
     exit 64
@@ -37,10 +37,10 @@ done
 
 assert_v02_candidate_files "$candidate_directory"
 [[ ! -e "$work_directory" && ! -L "$work_directory" ]] || \
-    v02_publication_fail "The G43 verification work directory already exists."
+    v02_publication_fail "The G49 verification work directory already exists."
 readonly work_parent="$(/usr/bin/dirname "$work_directory")"
 [[ -d "$work_parent" && ! -L "$work_parent" ]] || \
-    v02_publication_fail "The G43 verification work parent is unavailable."
+    v02_publication_fail "The G49 verification work parent is unavailable."
 [[ "${COPYLASSO_EXPECTED_TEAM_ID:-}" =~ ^[A-Z0-9]{10}$ ]] || \
     v02_publication_fail "The approved release team is unavailable for package verification."
 
@@ -81,7 +81,7 @@ private_appcast_digest="$(
     /usr/bin/shasum -a 256 "$private_appcast" | /usr/bin/awk '{print $1}'
 )"
 [[ "$private_appcast_digest" == "$COPYLASSO_V02_CANDIDATE_APPCAST_SHA256" ]] || \
-    v02_publication_fail "The restricted candidate appcast differs from G42 evidence."
+    v02_publication_fail "The restricted candidate appcast differs from G48 evidence."
 
 for asset in \
     "$COPYLASSO_RELEASE_DMG" \
@@ -100,7 +100,6 @@ for evidence in \
 done
 
 "$repository_root/scripts/verify-release-package.sh" \
-    --pinned-v02-metadata \
     --payload-app "$application" \
     --payload-commit "$COPYLASSO_V02_CANDIDATE_COMMIT" \
     --packaging-commit "$COPYLASSO_V02_CANDIDATE_COMMIT" \
@@ -110,4 +109,4 @@ done
 committed="true"
 trap - EXIT
 
-echo "Approved G42 candidate package reverified without rebuilding."
+echo "Approved G48 candidate package reverified without rebuilding."


### PR DESCRIPTION
## Summary

- pin the approved v0.2.1 RC commit, private release, notes, and four asset digests
- add an input-free protected-main preparation event that reverifies without rebuilding and creates only a private two-asset final draft
- preserve historical v0.2.0 package verification through separate immutable metadata
- document the later signed-tag, publication, feed, verification, and release-state gates

## Verification

- canonical arm64 pipeline: passed, including 414 tests and Universal 2 Release
- canonical x86_64 pipeline: passed, including 414 tests and Universal 2 Release
- focused G48, G49, v0.2 publication, release-qualification, release-state, and CI-contract checks: passed
- shell syntax, workflow YAML parse, secret/placeholder scan, and diff checks: passed
- live readback: private v0.2.1-rc.1 remains immutable at the approved commit; public v0.2.0 remains latest

## Boundary

This PR cannot publish, deploy the feed, create or move a tag, replace an asset, rebuild, or notarize. The protected preparation event must not be dispatched until this PR is separately approved and merged.